### PR TITLE
Single TCP connection for TCK driver client

### DIFF
--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaClientDriver.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaClientDriver.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -52,7 +53,7 @@ public class JavaClientDriver {
     private final Map<String, MySubscriber<Payload>> payloadSubscribers;
     private final Map<String, MySubscriber<Void>> fnfSubscribers;
     private final Map<String, String> idToType;
-    private final RSocket client;
+    private final Supplier<RSocket> rsocketClient;
     private final List<String> testList;
     private final String AGENT = "[CLIENT]";
     private ConsoleUtils consoleUtils = new ConsoleUtils(AGENT);
@@ -63,7 +64,7 @@ public class JavaClientDriver {
         this.payloadSubscribers = new HashMap<>();
         this.fnfSubscribers = new HashMap<>();
         this.idToType = new HashMap<>();
-        this.client = client;
+        this.rsocketClient = ()->client;
         this.testList = tests;
     }
 
@@ -214,24 +215,27 @@ public class JavaClientDriver {
                 MySubscriber<Payload> rrsub = new MySubscriber<>(0L, AGENT);
                 payloadSubscribers.put(args[2], rrsub);
                 idToType.put(args[2], args[1]);
+                RSocket rrclient = rsocketClient.get();
                 consoleUtils.info("Sending RR with " + args[3] + " " + args[4]);
-                Publisher<Payload> rrpub = client.requestResponse(new PayloadImpl(args[3], args[4]));
+                Publisher<Payload> rrpub = rrclient.requestResponse(new PayloadImpl(args[3], args[4]));
                 rrpub.subscribe(rrsub);
                 break;
             case "rs":
                 MySubscriber<Payload> rssub = new MySubscriber<>(0L, AGENT);
                 payloadSubscribers.put(args[2], rssub);
                 idToType.put(args[2], args[1]);
+                RSocket rsclient = rsocketClient.get();
                 consoleUtils.info("Sending RS with " + args[3] + " " + args[4]);
-                Publisher<Payload> rspub = client.requestStream(new PayloadImpl(args[3], args[4]));
+                Publisher<Payload> rspub = rsclient.requestStream(new PayloadImpl(args[3], args[4]));
                 rspub.subscribe(rssub);
                 break;
             case "fnf":
                 MySubscriber<Void> fnfsub = new MySubscriber<>(0L, AGENT);
                 fnfSubscribers.put(args[2], fnfsub);
                 idToType.put(args[2], args[1]);
+                RSocket fnfclient = rsocketClient.get();
                 consoleUtils.info("Sending fnf with " + args[3] + " " + args[4]);
-                Publisher<Void> fnfpub = client.fireAndForget(new PayloadImpl(args[3], args[4]));
+                Publisher<Void> fnfpub = fnfclient.fireAndForget(new PayloadImpl(args[3], args[4]));
                 fnfpub.subscribe(fnfsub);
                 break;
             default:break;
@@ -263,6 +267,7 @@ public class JavaClientDriver {
 
         // we now create the publisher that the server will subscribe to with its own subscriber
         // we want to give that subscriber a subscription that the client will use to send data to the server
+        RSocket client = rsocketClient.get();
         AtomicReference<ParseChannelThread> mypct = new AtomicReference<>();
         Publisher<Payload> pub = client.requestChannel(new Publisher<Payload>() {
             @Override
@@ -294,6 +299,7 @@ public class JavaClientDriver {
     private void handleEchoChannel(String[] args) {
         Payload initPayload = new PayloadImpl(args[1], args[2]);
         MySubscriber<Payload> testsub = new MySubscriber<>(1L, AGENT);
+        RSocket client = rsocketClient.get();
         Publisher<Payload> pub = client.requestChannel(new Publisher<Payload>() {
             @Override
             public void subscribe(Subscriber<? super Payload> s) {
@@ -513,7 +519,8 @@ public class JavaClientDriver {
 
     private void handleEOF() {
         MySubscriber<Void> fnfsub = new MySubscriber<>(0L, AGENT);
-        Publisher<Void> fnfpub = client.fireAndForget(new PayloadImpl("shutdown", "shutdown"));
+        RSocket fnfclient = rsocketClient.get();
+        Publisher<Void> fnfpub = fnfclient.fireAndForget(new PayloadImpl("shutdown", "shutdown"));
         fnfpub.subscribe(fnfsub);
         fnfsub.request(1);
     }

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaClientDriver.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaClientDriver.java
@@ -53,12 +53,12 @@ public class JavaClientDriver {
     private final Map<String, MySubscriber<Payload>> payloadSubscribers;
     private final Map<String, MySubscriber<Void>> fnfSubscribers;
     private final Map<String, String> idToType;
-    private final Supplier<RSocket> createClient;
+    private final RSocket createClient;
     private final List<String> testList;
     private final String AGENT = "[CLIENT]";
     private ConsoleUtils consoleUtils = new ConsoleUtils(AGENT);
 
-    public JavaClientDriver(String path, Supplier<RSocket> createClient, List<String> tests)
+    public JavaClientDriver(String path, RSocket createClient, List<String> tests)
             throws FileNotFoundException {
         this.reader = new BufferedReader(new FileReader(path));
         this.payloadSubscribers = new HashMap<>();
@@ -215,7 +215,7 @@ public class JavaClientDriver {
                 MySubscriber<Payload> rrsub = new MySubscriber<>(0L, AGENT);
                 payloadSubscribers.put(args[2], rrsub);
                 idToType.put(args[2], args[1]);
-                RSocket rrclient = createClient.get();
+                RSocket rrclient = createClient;
                 consoleUtils.info("Sending RR with " + args[3] + " " + args[4]);
                 Publisher<Payload> rrpub = rrclient.requestResponse(new PayloadImpl(args[3], args[4]));
                 rrpub.subscribe(rrsub);
@@ -224,7 +224,7 @@ public class JavaClientDriver {
                 MySubscriber<Payload> rssub = new MySubscriber<>(0L, AGENT);
                 payloadSubscribers.put(args[2], rssub);
                 idToType.put(args[2], args[1]);
-                RSocket rsclient = createClient.get();
+                RSocket rsclient = createClient;
                 consoleUtils.info("Sending RS with " + args[3] + " " + args[4]);
                 Publisher<Payload> rspub = rsclient.requestStream(new PayloadImpl(args[3], args[4]));
                 rspub.subscribe(rssub);
@@ -233,7 +233,7 @@ public class JavaClientDriver {
                 MySubscriber<Void> fnfsub = new MySubscriber<>(0L, AGENT);
                 fnfSubscribers.put(args[2], fnfsub);
                 idToType.put(args[2], args[1]);
-                RSocket fnfclient = createClient.get();
+                RSocket fnfclient = createClient;
                 consoleUtils.info("Sending fnf with " + args[3] + " " + args[4]);
                 Publisher<Void> fnfpub = fnfclient.fireAndForget(new PayloadImpl(args[3], args[4]));
                 fnfpub.subscribe(fnfsub);
@@ -267,7 +267,7 @@ public class JavaClientDriver {
 
         // we now create the publisher that the server will subscribe to with its own subscriber
         // we want to give that subscriber a subscription that the client will use to send data to the server
-        RSocket client = createClient.get();
+        RSocket client = createClient;
         AtomicReference<ParseChannelThread> mypct = new AtomicReference<>();
         Publisher<Payload> pub = client.requestChannel(new Publisher<Payload>() {
             @Override
@@ -299,7 +299,7 @@ public class JavaClientDriver {
     private void handleEchoChannel(String[] args) {
         Payload initPayload = new PayloadImpl(args[1], args[2]);
         MySubscriber<Payload> testsub = new MySubscriber<>(1L, AGENT);
-        RSocket client = createClient.get();
+        RSocket client = createClient;
         Publisher<Payload> pub = client.requestChannel(new Publisher<Payload>() {
             @Override
             public void subscribe(Subscriber<? super Payload> s) {
@@ -519,7 +519,7 @@ public class JavaClientDriver {
 
     private void handleEOF() {
         MySubscriber<Void> fnfsub = new MySubscriber<>(0L, AGENT);
-        RSocket fnfclient = createClient.get();
+        RSocket fnfclient = createClient;
         Publisher<Void> fnfpub = fnfclient.fireAndForget(new PayloadImpl("shutdown", "shutdown"));
         fnfpub.subscribe(fnfsub);
         fnfsub.request(1);

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaTCPClient.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaTCPClient.java
@@ -37,7 +37,8 @@ public class JavaTCPClient {
         if (realfile != null) file = realfile;
         try {
             setURI(new URI("tcp://" + host + ":" + port + "/rs"));
-            JavaClientDriver jd = new JavaClientDriver(file, createClient(), tests);
+            RSocket client = createClient();
+            JavaClientDriver jd = new JavaClientDriver(file, ()->client, tests);
             return jd.runTests();
         } catch (Exception e) {
             e.printStackTrace();

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaTCPClient.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaTCPClient.java
@@ -37,7 +37,7 @@ public class JavaTCPClient {
         if (realfile != null) file = realfile;
         try {
             setURI(new URI("tcp://" + host + ":" + port + "/rs"));
-            JavaClientDriver jd = new JavaClientDriver(file, JavaTCPClient::createClient, tests);
+            JavaClientDriver jd = new JavaClientDriver(file, createClient(), tests);
             return jd.runTests();
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Modified the javaClientDriver to open a single TCP connection, instead of opening a new TCP connection for every new request/stream.