### PR TITLE
Refactor transport specific tests 

### DIFF
--- a/rsocket-core/src/test/java/io/rsocket/RSocketFactoryTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketFactoryTest.java
@@ -1,23 +1,23 @@
 package io.rsocket;
 
+import static org.junit.Assert.fail;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
-
 public class RSocketFactoryTest {
 
-    @Test
-    @Ignore
-    public void testPluginsAppliedToClient() {
-        // TODO implement test
-        fail();
-    }
+  @Test
+  @Ignore
+  public void testPluginsAppliedToClient() {
+    // TODO implement test
+    fail();
+  }
 
-    @Test
-    @Ignore
-    public void testPluginsAppliedToServer() {
-        // TODO implement test
-        fail();
-    }
+  @Test
+  @Ignore
+  public void testPluginsAppliedToServer() {
+    // TODO implement test
+    fail();
+  }
 }

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/BaseClientServerTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/BaseClientServerTest.java
@@ -1,0 +1,51 @@
+package io.rsocket.transport.netty;
+
+import io.rsocket.test.ClientSetupRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public abstract class BaseClientServerTest<T extends ClientSetupRule<?, ?>> {
+  @Rule public final T setup = createClientServer();
+
+  protected abstract T createClientServer();
+
+  @Test(timeout = 10000)
+  public void testFireNForget10() {
+    setup.testFireAndForget(10);
+  }
+
+  @Test(timeout = 10000)
+  public void testPushMetadata10() {
+    setup.testMetadata(10);
+  }
+
+  @Test(timeout = 10000)
+  public void testRequestResponse1() {
+    setup.testRequestResponseN(1);
+  }
+
+  @Test(timeout = 10000)
+  public void testRequestResponse10() {
+    setup.testRequestResponseN(10);
+  }
+
+  @Test(timeout = 10000)
+  public void testRequestResponse100() {
+    setup.testRequestResponseN(100);
+  }
+
+  @Test(timeout = 10000)
+  public void testRequestResponse10_000() {
+    setup.testRequestResponseN(10_000);
+  }
+
+  @Test(timeout = 10000)
+  public void testRequestStream() {
+    setup.testRequestStream();
+  }
+
+  @Test(timeout = 10000)
+  public void testRequestStreamWithRequestN() {
+    setup.testRequestStreamWithRequestN();
+  }
+}

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientServerTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientServerTest.java
@@ -15,9 +15,10 @@
  */
 package io.rsocket.transport.netty;
 
-public class WebsocketClientServerTest extends BaseClientServerTest<WebsocketClientSetupRule> {
+public class SecureWebsocketClientServerTest
+    extends BaseClientServerTest<SecureWebsocketClientSetupRule> {
   @Override
-  protected WebsocketClientSetupRule createClientServer() {
-    return new WebsocketClientSetupRule();
+  protected SecureWebsocketClientSetupRule createClientServer() {
+    return new SecureWebsocketClientSetupRule();
   }
 }

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientServerTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientServerTest.java
@@ -15,6 +15,9 @@
  */
 package io.rsocket.transport.netty;
 
+import org.junit.Ignore;
+
+@Ignore
 public class SecureWebsocketClientServerTest
     extends BaseClientServerTest<SecureWebsocketClientSetupRule> {
   @Override

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientSetupRule.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientSetupRule.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.transport.netty;
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.rsocket.test.ClientSetupRule;
+import io.rsocket.transport.netty.client.WebsocketClientTransport;
+import io.rsocket.transport.netty.server.NettyContextCloseable;
+import io.rsocket.transport.netty.server.WebsocketServerTransport;
+import java.net.InetSocketAddress;
+import reactor.ipc.netty.http.client.HttpClient;
+import reactor.ipc.netty.http.server.HttpServer;
+
+public class SecureWebsocketClientSetupRule
+    extends ClientSetupRule<InetSocketAddress, NettyContextCloseable> {
+
+  public SecureWebsocketClientSetupRule() {
+    super(
+        () -> new InetSocketAddress("localhost", 0),
+        (address, server) ->
+            WebsocketClientTransport.create(
+                HttpClient.create(
+                    options ->
+                        options
+                                .connect(server.address())
+                            .sslSupport(c -> c.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                            ),
+                "/"),
+        address ->
+            WebsocketServerTransport.create(
+                HttpServer.create(options -> options.listen(address).sslSelfSigned())));
+  }
+}

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/TcpClientServerTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/TcpClientServerTest.java
@@ -15,51 +15,9 @@
  */
 package io.rsocket.transport.netty;
 
-import io.rsocket.test.ClientSetupRule;
-import org.junit.Rule;
-import org.junit.Test;
-
-public class TcpClientServerTest {
-
-  @Rule public final ClientSetupRule setup = new TcpClientSetupRule();
-
-  @Test(timeout = 10000)
-  public void testFireNForget10() {
-    setup.testFireAndForget(10);
-  }
-
-  @Test(timeout = 10000)
-  public void testPushMetadata10() {
-    setup.testMetadata(10);
-  }
-
-  @Test(timeout = 10000)
-  public void testRequestResponse1() {
-    setup.testRequestResponseN(1);
-  }
-
-  @Test(timeout = 10000)
-  public void testRequestResponse10() {
-    setup.testRequestResponseN(10);
-  }
-
-  @Test(timeout = 10000)
-  public void testRequestResponse100() {
-    setup.testRequestResponseN(100);
-  }
-
-  @Test(timeout = 10000)
-  public void testRequestResponse10_000() {
-    setup.testRequestResponseN(10_000);
-  }
-
-  @Test(timeout = 10000)
-  public void testRequestStream() {
-    setup.testRequestStream();
-  }
-
-  @Test(timeout = 10000)
-  public void testRequestStreamWithRequestN() {
-    setup.testRequestStreamWithRequestN();
+public class TcpClientServerTest extends BaseClientServerTest<TcpClientSetupRule> {
+  @Override
+  protected TcpClientSetupRule createClientServer() {
+    return new TcpClientSetupRule();
   }
 }


### PR DESCRIPTION
Secure websocket test (failing)

```
22:15:46,145 ERROR [reactor-http-nio-1] (Loggers.java) - Handler failure while no child channelOperation was present
io.netty.handler.ssl.NotSslRecordException: not an SSL/TLS record: 474554202f20485454502f312e310d0a757067726164653a20776562736f636b65740d0a636f6e6e656374696f6e3a20757067726164650d0a7365632d776562736f636b65742d6b65793a20617068514e3979663979514e63424f4b7331537964513d3d0d0a686f73743a206c6f63616c686f73743a35343237390d0a7365632d776562736f636b65742d6f726967696e3a20687474703a2f2f6c6f63616c686f73743a35343237390d0a7365632d776562736f636b65742d76657273696f6e3a2031330d0a757365722d6167656e743a2052656163746f724e657474792f302e362e332e52454c454153450d0a6163636570743a202a2f2a0d0a0d0a
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1060)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:411)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:248)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1334)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:926)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:134)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:624)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:559)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:476)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:438)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858)
	at java.lang.Thread.run(Thread.java:748)
```