### PR TITLE
working wss

### DIFF
--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientServerTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientServerTest.java
@@ -15,9 +15,6 @@
  */
 package io.rsocket.transport.netty;
 
-import org.junit.Ignore;
-
-@Ignore
 public class SecureWebsocketClientServerTest
     extends BaseClientServerTest<SecureWebsocketClientSetupRule> {
   @Override

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientSetupRule.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SecureWebsocketClientSetupRule.java
@@ -39,7 +39,7 @@ public class SecureWebsocketClientSetupRule
                                 .connect(server.address())
                             .sslSupport(c -> c.trustManager(InsecureTrustManagerFactory.INSTANCE))
                             ),
-                "/"),
+                "https://" + server.address().getHostName() + ":" + server.address().getPort() + "/"),
         address ->
             WebsocketServerTransport.create(
                 HttpServer.create(options -> options.listen(address).sslSelfSigned())));


### PR DESCRIPTION
For secure websocket, the path param in the HttpClient.ws call must be a complete URL instead of just the path.