### PR TITLE
Support websocket as part of a larger server

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/util/CloseableAdapter.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/CloseableAdapter.java
@@ -1,0 +1,27 @@
+package io.rsocket.util;
+
+import io.rsocket.Closeable;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
+
+public class CloseableAdapter implements Closeable {
+  private final MonoProcessor<Void> onClose = MonoProcessor.create();
+  private Runnable closeFunction;
+
+  public CloseableAdapter(Runnable closeFunction) {
+    this.closeFunction = closeFunction;
+  }
+
+  @Override public Mono<Void> close() {
+    return Mono.defer(
+        () -> {
+          closeFunction.run();
+          onClose.onComplete();
+          return onClose;
+        });
+  }
+
+  @Override public Mono<Void> onClose() {
+    return onClose();
+  }
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -1,0 +1,43 @@
+package io.rsocket.transport.netty.server;
+
+import io.rsocket.Closeable;
+import io.rsocket.transport.ServerTransport;
+import io.rsocket.transport.netty.WebsocketDuplexConnection;
+import io.rsocket.util.CloseableAdapter;
+import java.util.function.BiFunction;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+import reactor.ipc.netty.http.server.HttpServerRoutes;
+import reactor.ipc.netty.http.websocket.WebsocketInbound;
+import reactor.ipc.netty.http.websocket.WebsocketOutbound;
+
+public class WebsocketRouteTransport implements ServerTransport<Closeable> {
+  private HttpServerRoutes routes;
+  private String path;
+
+  public WebsocketRouteTransport(HttpServerRoutes routes, String path) {
+    this.routes = routes;
+    this.path = path;
+  }
+
+  @Override public Mono<Closeable> start(ConnectionAcceptor acceptor) {
+    return Mono.defer(() -> {
+      routes.ws(path, newHandler(acceptor));
+
+      return Mono.just(new CloseableAdapter(() -> {
+        // TODO close route somehow
+      }));
+    });
+  }
+
+  public static BiFunction<WebsocketInbound, WebsocketOutbound, Publisher<Void>> newHandler(
+      ConnectionAcceptor acceptor) {
+    return (in, out) -> {
+      WebsocketDuplexConnection connection =
+          new WebsocketDuplexConnection(in, out, in.context());
+      acceptor.apply(connection).subscribe();
+
+      return out.neverComplete();
+    };
+  }
+}


### PR DESCRIPTION
Given an existing project using reactor-netty, what does the API for creating a websocket server on a particular path look like e.g. "/ws".  This helps with serving same domain HTML content that uses the websocket.