### PR TITLE
Added the tck-main file 

### DIFF
--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaClientDriver.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaClientDriver.java
@@ -90,9 +90,7 @@ public class JavaClientDriver {
    * @return a RSocket
    */
   public RSocket createClient(String uri) {
-
-      ClientTransport clientTransport = UriTransportRegistry.clientForUri(uri);
-      return RSocketFactory.connect().transport(clientTransport).start().block();
+      return RSocketFactory.connect().transport(UriTransportRegistry.clientForUri(uri)).start().block();
   }
 
   /**

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaClientDriver.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/client/JavaClientDriver.java
@@ -33,7 +33,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -58,11 +57,11 @@ public class JavaClientDriver {
   private final Map<String, MySubscriber<Void>> fnfSubscribers;
   private final Map<String, String> idToType;
   private Supplier<RSocket> createClient;
-  private final URI uri;
+  private final String uri;
   private final String AGENT = "[CLIENT]";
   private ConsoleUtils consoleUtils = new ConsoleUtils(AGENT);
 
-  public JavaClientDriver(URI uri) throws FileNotFoundException {
+  public JavaClientDriver(String uri) throws FileNotFoundException {
     this.payloadSubscribers = new HashMap<>();
     this.fnfSubscribers = new HashMap<>();
     this.idToType = new HashMap<>();
@@ -90,13 +89,10 @@ public class JavaClientDriver {
    *
    * @return a RSocket
    */
-  public RSocket createClient(URI uri) {
-    if ("tcp".equals(uri.getScheme())) {
-      ClientTransport clientTransport = UriTransportRegistry.clientForUri(uri.toString());
+  public RSocket createClient(String uri) {
+
+      ClientTransport clientTransport = UriTransportRegistry.clientForUri(uri);
       return RSocketFactory.connect().transport(clientTransport).start().block();
-    } else {
-      throw new UnsupportedOperationException("uri unsupported: " + uri);
-    }
   }
 
   /**

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/common/TckIndividualTest.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/common/TckIndividualTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+
+package io.rsocket.tckdrivers.common;
+
+import java.util.List;
+
+public class TckIndividualTest {
+  public String name; // Test name
+  public List<String> test; // test instructions/commands
+  public String testFile; // Test belong to this file. File name is without client/server prefix
+  public static final String serverPrefix = "server";
+  public static final String clientPrefix = "client";
+
+  public TckIndividualTest(String name, List<String> test, String testFile) {
+    this.name = name;
+    this.test = test;
+    this.testFile = testFile;
+  }
+}

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/main/Main.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/main/Main.java
@@ -20,6 +20,7 @@ import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import io.airlift.airline.SingleCommand;
 import io.rsocket.tckdrivers.client.JavaClientDriver;
+import io.rsocket.tckdrivers.common.TckIndividualTest;
 import io.rsocket.tckdrivers.server.JavaTCPServer;
 import java.io.*;
 import java.net.URI;
@@ -68,9 +69,7 @@ public class Main {
    * @param host client connects with this host
    * @param port client connects on this port
    * @testsList list of tests to run
-   *
    */
-
   public static void runTests(String realfile, String host, int port, List<String> testsList)
       throws Exception {
     // we pass in our reactive socket here to the test suite
@@ -80,24 +79,21 @@ public class Main {
     List<List<String>> tests = new ArrayList<>();
     List<String> test = new ArrayList<>();
     File file = new File(filepath);
-    for (List<String> t : JavaClientDriver.extractTests(file)) {
+    for (TckIndividualTest t : JavaClientDriver.extractTests(file)) {
 
-      String name = "";
-      name = t.get(0).split("%%")[1];
       if (testsList.size() > 0) {
-        if (!testsList.contains(name)) {
+        if (!testsList.contains(t.name)) {
           continue;
         }
       }
       try {
         JavaClientDriver jd = new JavaClientDriver(new URI("tcp://" + host + ":" + port + "/rs"));
-        jd.runTest(t.subList(1, t.size()), name);
+        jd.runTest(t.test.subList(1, t.test.size()), t.name);
       } catch (Exception e) {
         e.printStackTrace();
       }
     }
   }
-
 
   public static void main(String[] args) {
     SingleCommand<Main> cmd = SingleCommand.singleCommand(Main.class);

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/main/Main.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/main/Main.java
@@ -23,7 +23,6 @@ import io.rsocket.tckdrivers.client.JavaClientDriver;
 import io.rsocket.tckdrivers.common.TckIndividualTest;
 import io.rsocket.tckdrivers.server.JavaTCPServer;
 import java.io.*;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -87,7 +86,7 @@ public class Main {
         }
       }
       try {
-        JavaClientDriver jd = new JavaClientDriver(new URI("tcp://" + host + ":" + port + "/rs"));
+        JavaClientDriver jd = new JavaClientDriver("tcp://" + host + ":" + port + "/rs");
         jd.runTest(t.test.subList(1, t.test.size()), t.name);
       } catch (Exception e) {
         e.printStackTrace();

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/main/Main.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/main/Main.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.rsocket.tckdrivers.main;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+import io.airlift.airline.SingleCommand;
+import io.rsocket.tckdrivers.client.JavaClientDriver;
+import io.rsocket.tckdrivers.server.JavaTCPServer;
+import java.io.*;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** This class is used to run both the server and the client, depending on the options given */
+@Command(
+  name = "rsocket-driver",
+  description = "This runs the client and servers that use the driver"
+)
+public class Main {
+
+  @Option(name = "--server", description = "set if you want to run the server")
+  public static boolean server;
+
+  @Option(name = "--client", description = "set if you want to run the client")
+  public static boolean client;
+
+  @Option(name = "--host", description = "The host to connect to for the client")
+  public static String host;
+
+  @Option(name = "--port", description = "The port")
+  public static int port;
+
+  @Option(
+    name = "--file",
+    description =
+        "The script file to parse, make sure to give the client and server the " + "correct files"
+  )
+  public static String file;
+
+  @Option(
+    name = "--tests",
+    description =
+        "For the client only, optional argument to list out the tests you"
+            + " want to run, should be comma separated names"
+  )
+  public static String tests;
+
+  /**
+   * A function that parses the test file, and run each test
+   *
+   * @param realfile file to read. If null, it reads clienttest.txt
+   * @param host client connects with this host
+   * @param port client connects on this port
+   * @testsList list of tests to run
+   *
+   */
+
+  public static void runTests(String realfile, String host, int port, List<String> testsList)
+      throws Exception {
+    // we pass in our reactive socket here to the test suite
+    String filepath = "rsocket-tck-drivers/src/test/resources/clienttest.txt";
+    if (realfile != null) filepath = realfile;
+
+    List<List<String>> tests = new ArrayList<>();
+    List<String> test = new ArrayList<>();
+    File file = new File(filepath);
+    for (List<String> t : JavaClientDriver.extractTests(file)) {
+
+      String name = "";
+      name = t.get(0).split("%%")[1];
+      if (testsList.size() > 0) {
+        if (!testsList.contains(name)) {
+          continue;
+        }
+      }
+      try {
+        JavaClientDriver jd = new JavaClientDriver(new URI("tcp://" + host + ":" + port + "/rs"));
+        jd.runTest(t.subList(1, t.size()), name);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+
+  public static void main(String[] args) {
+    SingleCommand<Main> cmd = SingleCommand.singleCommand(Main.class);
+    cmd.parse(args);
+    boolean passed = true;
+
+    if (server) {
+      new JavaTCPServer().run(file, port);
+    } else if (client) {
+      try {
+        if (tests != null) {
+          runTests(file, host, port, Arrays.asList(tests.split(",")));
+        } else {
+          runTests(file, host, port, new ArrayList<>());
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/server/JavaServerDriver.java
+++ b/rsocket-tck-drivers/src/main/java/io/rsocket/tckdrivers/server/JavaServerDriver.java
@@ -36,7 +36,6 @@ import io.rsocket.transport.netty.server.TcpServerTransport;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/rsocket-tck-drivers/src/test/java/io/rsocket/tckdrivers/TckTest.java
+++ b/rsocket-tck-drivers/src/test/java/io/rsocket/tckdrivers/TckTest.java
@@ -6,7 +6,6 @@ import io.rsocket.tckdrivers.client.JavaClientDriver;
 import io.rsocket.tckdrivers.common.ServerThread;
 import io.rsocket.tckdrivers.common.TckIndividualTest;
 import java.io.File;
-import java.net.URI;
 import java.util.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,7 +60,7 @@ public class TckTest {
 
     try {
 
-      JavaClientDriver jd = new JavaClientDriver(new URI("tcp://" + hostname + ":" + port + "/rs"));
+      JavaClientDriver jd = new JavaClientDriver("tcp://" + hostname + ":" + port + "/rs");
       jd.runTest(this.tckTest.test.subList(1, this.tckTest.test.size()), this.tckTest.name);
 
     } catch (Exception e) {

--- a/rsocket-tck-drivers/src/test/java/io/rsocket/tckdrivers/TckTest.java
+++ b/rsocket-tck-drivers/src/test/java/io/rsocket/tckdrivers/TckTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertNotNull;
 
 import io.rsocket.tckdrivers.client.JavaClientDriver;
 import io.rsocket.tckdrivers.common.ServerThread;
+import io.rsocket.tckdrivers.common.TckIndividualTest;
 import java.io.File;
 import java.net.URI;
 import java.util.*;
@@ -14,18 +15,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
 public class TckTest {
-
-  private static class TckIndividualTest {
-    String name; // Test name
-    List<String> test; // test instructions/commands
-    String testFile; // Test belong to this file. File name is without client/server prefix
-
-    public TckIndividualTest(String name, List<String> test, String testFile) {
-      this.name = name;
-      this.test = test;
-      this.testFile = testFile;
-    }
-  }
 
   /*
    * Start port. For every input test file a server instance will be launched.
@@ -39,9 +28,6 @@ public class TckTest {
    * with a prefix "server" or "client" to indicate whether they type.
    */
   private static final String path = "src/test/resources/";
-
-  private static final String serverPrefix = "server";
-  private static final String clientPrefix = "client";
   private static HashMap<String, Integer> clientPortMap = new HashMap<String, Integer>();
 
   private TckIndividualTest tckTest;
@@ -61,7 +47,7 @@ public class TckTest {
     if (null == port) {
 
       // starting a server
-      String serverFileName = serverPrefix + this.tckTest.testFile;
+      String serverFileName = TckIndividualTest.serverPrefix + this.tckTest.testFile;
       ServerThread st = new ServerThread(currentPort, path + serverFileName);
       st.start();
       st.awaitStart();
@@ -98,23 +84,20 @@ public class TckTest {
 
     for (int i = 0; i < listOfFiles.length; i++) {
       File file = listOfFiles[i];
-      if (file.isFile() && file.getName().startsWith(clientPrefix)) {
-        String testFile = file.getName().replaceFirst(clientPrefix, "");
-        String serverFileName = serverPrefix + testFile;
+      if (file.isFile() && file.getName().startsWith(TckIndividualTest.clientPrefix)) {
+        String testFile = file.getName().replaceFirst(TckIndividualTest.clientPrefix, "");
+        String serverFileName = TckIndividualTest.serverPrefix + testFile;
 
         File f = new File(path + serverFileName);
         if (f.exists() && !f.isDirectory()) {
 
           try {
 
-            for (List<String> t : JavaClientDriver.extractTests(file)) {
-
-              String name = "";
-              name = t.get(0).split("%%")[1];
+            for (TckIndividualTest t : JavaClientDriver.extractTests(file)) {
 
               Object testObject[] = new Object[2];
-              testObject[0] = name + " (" + testFile + ")";
-              testObject[1] = new TckIndividualTest(name, t, testFile);
+              testObject[0] = t.name + " (" + testFile + ")";
+              testObject[1] = t;
               testData.add(testObject);
             }
           } catch (Exception e) {


### PR DESCRIPTION
rsocket-cpp requires this to run cross implementation compatibility tests 

Removing this file did not break anything because Cross implementation compatibility tests were using an older version of rsocket-java

Following changes are temporary
      RSocket client = createClient(this.uri);
      this.createClient = () -> client;

This part will be rewritten when I will add the support for multiple clients. Each test will be run by a new client object(s).