### PR TITLE
Fix types in RSocketFactory

### DIFF
--- a/rsocket-examples/src/test/java/io/rsocket/integration/IntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/IntegrationTest.java
@@ -122,8 +122,6 @@ public class IntegrationTest {
                 })
             .transport(serverTransport)
             .start()
-            // TODO fix the Types through RSocketFactory.Start
-            .cast(NettyContextCloseable.class)
             .block();
 
     client =

--- a/rsocket-examples/src/test/java/io/rsocket/integration/TcpIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/TcpIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import io.rsocket.AbstractRSocket;
-import io.rsocket.Closeable;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.RSocketFactory;
@@ -47,15 +46,11 @@ public class TcpIntegrationTest {
   @Before
   public void startup() {
     TcpServerTransport serverTransport = TcpServerTransport.create(0);
-    RSocketFactory.Start<Closeable> transport =
+    server =
         RSocketFactory.receive()
             .acceptor((setup, sendingSocket) -> Mono.just(new RSocketProxy(handler)))
-            .transport(serverTransport);
-    server =
-        transport
+            .transport(serverTransport)
             .start()
-            // TODO fix the Types through RSocketFactory.Start
-            .cast(NettyContextCloseable.class)
             .block();
   }
 

--- a/rsocket-test/src/main/java/io/rsocket/test/ClientSetupRule.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/ClientSetupRule.java
@@ -49,7 +49,6 @@ public class ClientSetupRule<T, S extends Closeable> extends ExternalResource {
                 .acceptor((setup, sendingSocket) -> Mono.just(new TestRSocket()))
                 .transport(serverTransportSupplier.apply(address))
                 .start()
-                .map(s -> (S) s) // TODO fix casting
                 .block();
 
     this.clientConnector =


### PR DESCRIPTION
Removes the need for casting when server transport returns a subtype of Closeable, e.g. NettyContextCloseable.