### PR TITLE
Infinite recursion

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/util/CloseableAdapter.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/CloseableAdapter.java
@@ -24,6 +24,6 @@ public class CloseableAdapter implements Closeable {
 
   @Override
   public Mono<Void> onClose() {
-    return onClose();
+    return onClose;
   }
 }


### PR DESCRIPTION
Method 'onClose()' recurses infinitely, and can only end by throwing an exception