### PR TITLE
null pointer caused by race condition

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -79,7 +79,7 @@ class RSocketClient implements RSocket {
     this.receivers = new IntObjectHashMap<>(256, 0.9f);
     this.missedAckCounter = new AtomicInteger();
   
-    // DO NOT Change the order here. The Send processor must be subscribed to before the receiving connections
+    // DO NOT Change the order here. The Send processor must be subscribed to before receiving connections
     this.sendProcessor = EmitterProcessor.create();
 
     if (!Duration.ZERO.equals(tickPeriod)) {

--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -78,7 +78,7 @@ class RSocketClient implements RSocket {
     this.senders = new IntObjectHashMap<>(256, 0.9f);
     this.receivers = new IntObjectHashMap<>(256, 0.9f);
     this.missedAckCounter = new AtomicInteger();
-  
+
     // DO NOT Change the order here. The Send processor must be subscribed to before receiving connections
     this.sendProcessor = EmitterProcessor.create();
 
@@ -99,13 +99,13 @@ class RSocketClient implements RSocket {
     }
 
     connection.onClose().doFinally(signalType -> cleanup()).doOnError(errorConsumer).subscribe();
-  
+
     connection
         .send(sendProcessor)
         .doOnError(this::handleSendProcessorError)
         .doFinally(this::handleSendProcessorCancel)
         .subscribe();
-    
+
     connection
         .receive()
         .doOnSubscribe(subscription -> started.onComplete())

--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -78,6 +78,8 @@ class RSocketClient implements RSocket {
     this.senders = new IntObjectHashMap<>(256, 0.9f);
     this.receivers = new IntObjectHashMap<>(256, 0.9f);
     this.missedAckCounter = new AtomicInteger();
+  
+    // DO NOT Change the order here. The Send processor must be subscribed to before the receiving connections
     this.sendProcessor = EmitterProcessor.create();
 
     if (!Duration.ZERO.equals(tickPeriod)) {
@@ -97,18 +99,18 @@ class RSocketClient implements RSocket {
     }
 
     connection.onClose().doFinally(signalType -> cleanup()).doOnError(errorConsumer).subscribe();
-
+  
+    connection
+        .send(sendProcessor)
+        .doOnError(this::handleSendProcessorError)
+        .doFinally(this::handleSendProcessorCancel)
+        .subscribe();
+    
     connection
         .receive()
         .doOnSubscribe(subscription -> started.onComplete())
         .doOnNext(this::handleIncomingFrames)
         .doOnError(errorConsumer)
-        .subscribe();
-
-    connection
-        .send(sendProcessor)
-        .doOnError(this::handleSendProcessorError)
-        .doFinally(this::handleSendProcessorCancel)
         .subscribe();
   }
 

--- a/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
@@ -56,7 +56,7 @@ class RSocketServer implements RSocket {
     this.sendingSubscriptions = new IntObjectHashMap<>();
     this.channelProcessors = new IntObjectHashMap<>();
   
-    // DO NOT Change the order here. The Send processor must be subscribed to before the receiving connections
+    // DO NOT Change the order here. The Send processor must be subscribed to before receiving connections
     this.sendProcessor = EmitterProcessor.create();
   
     connection

--- a/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
@@ -55,16 +55,16 @@ class RSocketServer implements RSocket {
     this.errorConsumer = errorConsumer;
     this.sendingSubscriptions = new IntObjectHashMap<>();
     this.channelProcessors = new IntObjectHashMap<>();
-  
+
     // DO NOT Change the order here. The Send processor must be subscribed to before receiving connections
     this.sendProcessor = EmitterProcessor.create();
-  
+
     connection
         .send(sendProcessor)
         .doOnError(this::handleSendProcessorError)
         .doFinally(this::handleSendProcessorCancel)
         .subscribe();
-    
+
     this.receiveDisposable =
         connection.receive().flatMap(this::handleFrame).doOnError(errorConsumer).then().subscribe();
 
@@ -77,7 +77,6 @@ class RSocketServer implements RSocket {
               receiveDisposable.dispose();
             })
         .subscribe();
-
   }
 
   private void handleSendProcessorError(Throwable t) {


### PR DESCRIPTION
There was a race condition in the RSocketServer where the connection was receiving data before the sendProcessor was created. This was leading to a null point exception. I moved the order so that the sendProcessor is constructed and subscribed too before receiving incoming frames. 