### PR TITLE
java 9 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: java
 jdk:
 - oraclejdk8
+- oraclejdk9
 
 # force upgrade Java8 as per https://github.com/travis-ci/travis-ci/issues/4042 (fixes compilation issue)
 addons:
   apt:
     packages:
       - oracle-java8-installer
+      - oracle-java9-installer
 
 dist: trusty
 #group: edge

--- a/build.gradle
+++ b/build.gradle
@@ -44,13 +44,9 @@ subprojects {
     group = 'io.rsocket'
     version = mavenversion
 
-    compileJava {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
-        options.compilerArgs << '-Xlint:all,-overloads,-rawtypes,-unchecked'
-    }
-
     ext {
+        isJava9 = System.getenv('TRAVIS_JDK_VERSION') == 'oraclejdk9'
+        jdkVersion = isJava9 ? 1.9 : 1.8
         // common
         jsr305Version = '3.0.2'
         reactorVersion = '3.1.0.RELEASE'
@@ -59,6 +55,7 @@ subprojects {
         slf4jVersion = '1.7.25'
         // aeron
         aeronVersion = '1.4.1'
+        javaxAnnotationVersion = '1.3.1'
         // netty
         reactorNettyVersion = '0.7.0.M2'
         // spectator
@@ -74,6 +71,12 @@ subprojects {
         hamcrestVersion = '1.3'
         mockitoVersion = '2.10.0'
         jmhVersion = '1.19'
+    }
+
+    compileJava {
+        sourceCompatibility = jdkVersion
+        targetCompatibility = jdkVersion
+        options.compilerArgs << '-Xlint:all,-overloads,-rawtypes,-unchecked'
     }
 
     // custom tasks for creating source/javadoc jars

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # This script will build the project.
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$TRAVIS_JDK_VERSION" == "oraclejdk9" ]; then
+  echo -e "Build Branch with JDK9 [$JAVA_HOME] => Branch [$TRAVIS_BRANCH]"
+  ./gradlew build
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then

--- a/rsocket-transport-aeron/build.gradle
+++ b/rsocket-transport-aeron/build.gradle
@@ -17,6 +17,7 @@
 dependencies {
     compile project(':rsocket-core')
     compile "io.aeron:aeron-all:1.4.1"
+    compile "javax.annotation:javax.annotation-api:1.3.1"
 
     testCompile project(':rsocket-test')
 }


### PR DESCRIPTION
add jdk 9 to travis
compile with java 9

#### Fix dependency error [stackoverflow/java-9-how-to-get-access-to-javax-annotation-resource-at-run-time](https://stackoverflow.com/questions/46502001/java-9-how-to-get-access-to-javax-annotation-resource-at-run-time)
java.xml.ws.annotation module is deprecated for removal
```
error: cannot find symbol
@javax.annotation.Generated(
                 ^
  symbol:   class Generated
  location: package javax.annotation
```