### PR TITLE
netty tcp driver hangs on large channels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ subprojects {
 
     dependencies {
         compile "io.projectreactor:reactor-core:3.1.0.RELEASE"
-        compile "io.netty:netty-buffer:4.1.15.Final"
+        compile "io.netty:netty-buffer:4.1.16.Final"
         compile "org.reactivestreams:reactive-streams:1.0.1"
         compile "org.slf4j:slf4j-api:1.7.25"
         compile "com.google.code.findbugs:jsr305:3.0.2"

--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -16,11 +16,12 @@
 
 dependencies {
     compile project(':rsocket-core')
-    compile "io.projectreactor.ipc:reactor-netty:0.7.0.RELEASE"
-    compile "io.netty:netty-handler:4.1.15.Final"
-    compile "io.netty:netty-handler-proxy:4.1.15.Final"
-    compile "io.netty:netty-codec-http:4.1.15.Final"
-    compile "io.netty:netty-transport-native-epoll:4.1.15.Final"
+    compile "io.projectreactor.ipc:reactor-netty:0.7.1.RELEASE"
+    compile "io.netty:netty-handler:4.1.16.Final"
+    compile "io.netty:netty-handler-proxy:4.1.16.Final"
+    compile "io.netty:netty-codec-http:4.1.16.Final"
+    compile "io.netty:netty-transport-native-epoll:4.1.16.Final"
+    compile "io.netty:netty-transport-native-kqueue:4.1.16.Final"
 
     testCompile project(':rsocket-test')
 }


### PR DESCRIPTION
When streaming data from a channel RSocket would hang. Moved the subscription to a single channel in the DuplexConnection. For some reason while this fixes things for TCP with WebSocket it breaks other tests. This doesn't show up until you start streaming more than 20k or so items.