### PR TITLE
Add log4j dependnecy to examples project

### DIFF
--- a/rsocket-examples/build.gradle
+++ b/rsocket-examples/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     compile project(':rsocket-spectator')
     compile project(':rsocket-transport-netty')
     compile project(':rsocket-transport-local')
+    compile "org.slf4j:slf4j-log4j12:1.7.25"
 
     testCompile project(':rsocket-test')
 }

--- a/rsocket-examples/src/main/resources/log4j.properties
+++ b/rsocket-examples/src/main/resources/log4j.properties
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=DEBUG, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] %c{1} - %m%n


### PR DESCRIPTION
Now there is logging outupt. I've also tweaked the logging settings to
start at DEBUG and to show the class name at least.