### PR TITLE
Maven Central POM Requirements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,29 @@ subprojects {
 
                     artifact sourcesJar
                     artifact javadocJar
+
+                    pom.withXml {
+                        asNode().':version' + {
+                            resolveStrategy = DELEGATE_FIRST
+
+                            name project.name
+                            description project.description
+                            url 'http://rsocket.io'
+
+                            licenses {
+                                license {
+                                    name 'The Apache Software License, Version 2.0'
+                                    url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                                }
+                            }
+
+                            scm {
+                                connection 'scm:git:https://github.com/rsocket/rsocket-java.git'
+                                developerConnection 'scm:git:https://github.com/rsocket/rsocket-java.git'
+                                url 'https://github.com/rsocket/rsocket-java'
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -110,6 +133,8 @@ buildScan {
     termsOfServiceUrl = 'https://gradle.com/terms-of-service'
     termsOfServiceAgree = 'yes'
 }
+
+description = 'RSocket: Stream Oriented Messaging Passing with Reactive Stream Semantics.'
 
 googleJavaFormat {
     toolVersion = '1.5'

--- a/rsocket-core/build.gradle
+++ b/rsocket-core/build.gradle
@@ -37,4 +37,6 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
 }
 
+description = "Core functionality for the RSocket library"
+
 apply from: 'jmh.gradle'

--- a/rsocket-examples/build.gradle
+++ b/rsocket-examples/build.gradle
@@ -28,3 +28,5 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-library'
     testCompile 'org.mockito:mockito-core'
 }
+
+description = 'Example usage of the RSocket library'

--- a/rsocket-load-balancer/build.gradle
+++ b/rsocket-load-balancer/build.gradle
@@ -30,3 +30,5 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.mockito:mockito-core'
 }
+
+description = 'Transparent Load Balancer for RSocket'

--- a/rsocket-spectator/build.gradle
+++ b/rsocket-spectator/build.gradle
@@ -25,3 +25,5 @@ dependencies {
     implementation project(':rsocket-core')
     implementation 'com.netflix.spectator:spectator-api'
 }
+
+description = 'Transparent Metrics exposure to Spectator'

--- a/rsocket-test/build.gradle
+++ b/rsocket-test/build.gradle
@@ -25,3 +25,5 @@ dependencies {
     implementation 'junit:junit'
     implementation 'org.mockito:mockito-core'
 }
+
+description = 'Test utilities for RSocket projects'

--- a/rsocket-transport-aeron/build.gradle
+++ b/rsocket-transport-aeron/build.gradle
@@ -30,3 +30,5 @@ dependencies {
     testImplementation project(':rsocket-test')
     testImplementation 'junit:junit'
 }
+
+description = 'Aeron RSocket transport implementation'

--- a/rsocket-transport-local/build.gradle
+++ b/rsocket-transport-local/build.gradle
@@ -27,3 +27,5 @@ dependencies {
     testImplementation project(':rsocket-test')
     testImplementation 'junit:junit'
 }
+
+description = 'Local RSocket transport implementation'

--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -29,3 +29,5 @@ dependencies {
     testImplementation project(':rsocket-test')
     testImplementation 'junit:junit'
 }
+
+description = 'Reactor Netty RSocket transport implementations (TCP, Websocket)'


### PR DESCRIPTION
In order to publish to Maven Central, POMs must contain a minimum set of elements.  The automatically generated POM from Gradle's `maven-publish` plugin does not contain these elements.  This change adds build functionality to ensure that the generated POMs are Maven Central compatible.