### PR TITLE
Introduce JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,22 @@ subprojects {
             dependency 'com.google.code.findbugs:jsr305:3.0.2'
             dependency 'com.netflix.spectator:spectator-api:0.63.0'
             dependency 'io.netty:netty-buffer:4.1.21.Final'
-            dependency 'junit:junit:4.12'
             dependency 'io.aeron:aeron-all:1.4.1'
             dependency 'org.hamcrest:hamcrest-library:1.3'
             dependency 'org.hdrhistogram:HdrHistogram:2.1.10'
             dependency 'org.mockito:mockito-core:2.16.0'
             dependency 'org.openjdk.jmh:jmh-core:1.20'
+
+            dependencySet(group: 'org.junit.jupiter', version: '5.1.0') {
+                entry 'junit-jupiter-api'
+                entry 'junit-jupiter-engine'
+            }
+
+            // TODO: Remove after JUnit5 migration
+            dependency 'junit:junit:4.12'
+            dependencySet(group: 'org.junit.vintage', version: '5.1.0') {
+                entry 'junit-vintage-engine'
+            }
 
             dependencySet(group: 'org.openjdk.jmh', version: '1.20') {
                 entry 'jmh-core'
@@ -72,6 +82,10 @@ subprojects {
 
             // TODO: Cleanup warnings so no need to exclude
             options.compilerArgs << '-Xlint:all,-overloads,-rawtypes,-unchecked'
+        }
+
+        test {
+            useJUnitPlatform()
         }
     }
 

--- a/rsocket-core/build.gradle
+++ b/rsocket-core/build.gradle
@@ -32,9 +32,15 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation 'io.projectreactor:reactor-test'
-    testImplementation 'junit:junit'
     testImplementation 'org.hamcrest:hamcrest-library'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.mockito:mockito-core'
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+
+    // TODO: Remove after JUnit5 migration
+    testCompileOnly 'junit:junit'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 
 description = "Core functionality for the RSocket library"

--- a/rsocket-examples/build.gradle
+++ b/rsocket-examples/build.gradle
@@ -24,9 +24,13 @@ dependencies {
     compile project(':rsocket-transport-netty')
 
     testCompile project(':rsocket-test')
-    testCompile 'junit:junit'
     testCompile 'org.hamcrest:hamcrest-library'
+    testCompile 'org.junit.jupiter:junit-jupiter-api'
     testCompile 'org.mockito:mockito-core'
+
+    // TODO: Remove after JUnit5 migration
+    testCompileOnly 'junit:junit'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 
 description = 'Example usage of the RSocket library'

--- a/rsocket-load-balancer/build.gradle
+++ b/rsocket-load-balancer/build.gradle
@@ -26,9 +26,13 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(':rsocket-test')
-    testImplementation 'junit:junit'
     testImplementation 'org.hamcrest:hamcrest-library'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.mockito:mockito-core'
+
+    // TODO: Remove after JUnit5 migration
+    testCompileOnly 'junit:junit'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 
 description = 'Transparent Load Balancer for RSocket'

--- a/rsocket-test/build.gradle
+++ b/rsocket-test/build.gradle
@@ -22,8 +22,11 @@ dependencies {
     api 'org.hdrhistogram:HdrHistogram'
 
     implementation project(':rsocket-core')
-    implementation 'junit:junit'
+    implementation 'org.junit.jupiter:junit-jupiter-api'
     implementation 'org.mockito:mockito-core'
+
+    // TODO: Remove after JUnit5 migration
+    implementation 'junit:junit'
 }
 
 description = 'Test utilities for RSocket projects'

--- a/rsocket-transport-aeron/build.gradle
+++ b/rsocket-transport-aeron/build.gradle
@@ -28,7 +28,11 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(':rsocket-test')
-    testImplementation 'junit:junit'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+
+    // TODO: Remove after JUnit5 migration
+    testCompileOnly 'junit:junit'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 
 description = 'Aeron RSocket transport implementation'

--- a/rsocket-transport-local/build.gradle
+++ b/rsocket-transport-local/build.gradle
@@ -25,7 +25,11 @@ dependencies {
     implementation project(':rsocket-core')
 
     testImplementation project(':rsocket-test')
-    testImplementation 'junit:junit'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+
+    // TODO: Remove after JUnit5 migration
+    testCompileOnly 'junit:junit'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 
 description = 'Local RSocket transport implementation'

--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -27,7 +27,11 @@ dependencies {
     implementation project(':rsocket-core')
 
     testImplementation project(':rsocket-test')
-    testImplementation 'junit:junit'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+
+    // TODO: Remove after JUnit5 migration
+    testCompileOnly 'junit:junit'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 
 description = 'Reactor Netty RSocket transport implementations (TCP, Websocket)'


### PR DESCRIPTION
This change introduces JUnit 5 to the build.  It enables JUnit 5 support in Gradle and adds the required dependencies to write JUnit 5 types.  The change does not remove the JUnit 4 dependencies yet, as the tests have not been converted.