### PR TITLE
Fix Reference Count Leak

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/FrameFragmenter.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/FrameFragmenter.java
@@ -17,7 +17,7 @@
 package io.rsocket.fragmentation;
 
 import static io.rsocket.framing.PayloadFrame.createPayloadFrame;
-import static io.rsocket.util.DisposableUtil.disposeQuietly;
+import static io.rsocket.util.DisposableUtils.disposeQuietly;
 import static java.lang.Math.min;
 
 import io.netty.buffer.ByteBuf;

--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/FrameReassembler.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/FrameReassembler.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.fragmentation;
 
-import static io.rsocket.util.DisposableUtil.disposeQuietly;
+import static io.rsocket.util.DisposableUtils.disposeQuietly;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
 import io.netty.buffer.ByteBuf;

--- a/rsocket-core/src/main/java/io/rsocket/framing/AbstractRecyclableFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/AbstractRecyclableFrame.java
@@ -16,12 +16,14 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.ReferenceCounted;
 import java.util.Objects;
 import reactor.util.annotation.Nullable;
 
@@ -51,7 +53,7 @@ abstract class AbstractRecyclableFrame<SELF extends AbstractRecyclableFrame<SELF
   @SuppressWarnings("unchecked")
   public final void dispose() {
     if (byteBuf != null) {
-      byteBuf.release();
+      release(byteBuf);
     }
 
     byteBuf = null;

--- a/rsocket-core/src/main/java/io/rsocket/framing/DataFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/DataFrame.java
@@ -51,6 +51,7 @@ public interface DataFrame extends Frame {
    * it.
    *
    * @return the data directly
+   * @see #getDataAsUtf8()
    * @see #mapData(Function)
    */
   ByteBuf getUnsafeData();

--- a/rsocket-core/src/main/java/io/rsocket/framing/ErrorFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/ErrorFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.framing.FrameType.ERROR;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
@@ -70,7 +71,13 @@ public final class ErrorFrame extends AbstractRecyclableDataFrame<ErrorFrame> {
   public static ErrorFrame createErrorFrame(
       ByteBufAllocator byteBufAllocator, int errorCode, @Nullable String data) {
 
-    return createErrorFrame(byteBufAllocator, errorCode, getUtf8AsByteBuf(data));
+    ByteBuf dataByteBuf = getUtf8AsByteBuf(data);
+
+    try {
+      return createErrorFrame(byteBufAllocator, errorCode, dataByteBuf);
+    } finally {
+      release(dataByteBuf);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/framing/ExtensionFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/ExtensionFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.framing.FrameType.EXT;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
@@ -79,8 +80,16 @@ public final class ExtensionFrame extends AbstractRecyclableMetadataAndDataFrame
       @Nullable String metadata,
       @Nullable String data) {
 
-    return createExtensionFrame(
-        byteBufAllocator, ignore, extendedType, getUtf8AsByteBuf(metadata), getUtf8AsByteBuf(data));
+    ByteBuf metadataByteBuf = getUtf8AsByteBuf(metadata);
+    ByteBuf dataByteBuf = getUtf8AsByteBuf(data);
+
+    try {
+      return createExtensionFrame(
+          byteBufAllocator, ignore, extendedType, metadataByteBuf, dataByteBuf);
+    } finally {
+      release(metadataByteBuf);
+      release(dataByteBuf);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/framing/MetadataFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/MetadataFrame.java
@@ -55,6 +55,7 @@ public interface MetadataFrame extends Frame {
    * if you store it.
    *
    * @return the metadata directly, or {@code null} if the Metadata flag is not set
+   * @see #getMetadataAsUtf8()
    * @see #mapMetadata(Function)
    */
   @Nullable

--- a/rsocket-core/src/main/java/io/rsocket/framing/MetadataPushFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/MetadataPushFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.framing.FrameType.METADATA_PUSH;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
@@ -69,8 +70,13 @@ public final class MetadataPushFrame extends AbstractRecyclableMetadataFrame<Met
   public static MetadataPushFrame createMetadataPushFrame(
       ByteBufAllocator byteBufAllocator, String metadata) {
 
-    return createMetadataPushFrame(
-        byteBufAllocator, getUtf8AsByteBufRequired(metadata, "metadata must not be null"));
+    ByteBuf metadataByteBuf = getUtf8AsByteBufRequired(metadata, "metadata must not be null");
+
+    try {
+      return createMetadataPushFrame(byteBufAllocator, metadataByteBuf);
+    } finally {
+      release(metadataByteBuf);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/framing/PayloadFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/PayloadFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
 import io.netty.buffer.ByteBuf;
@@ -78,8 +79,15 @@ public final class PayloadFrame extends AbstractRecyclableFragmentableFrame<Payl
       @Nullable String metadata,
       @Nullable String data) {
 
-    return createPayloadFrame(
-        byteBufAllocator, follows, complete, getUtf8AsByteBuf(metadata), getUtf8AsByteBuf(data));
+    ByteBuf metadataByteBuf = getUtf8AsByteBuf(metadata);
+    ByteBuf dataByteBuf = getUtf8AsByteBuf(data);
+
+    try {
+      return createPayloadFrame(byteBufAllocator, follows, complete, metadataByteBuf, dataByteBuf);
+    } finally {
+      release(metadataByteBuf);
+      release(dataByteBuf);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/framing/RequestChannelFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/RequestChannelFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
 import io.netty.buffer.ByteBuf;
@@ -83,13 +84,16 @@ public final class RequestChannelFrame
       @Nullable String metadata,
       @Nullable String data) {
 
-    return createRequestChannelFrame(
-        byteBufAllocator,
-        follows,
-        complete,
-        initialRequestN,
-        getUtf8AsByteBuf(metadata),
-        getUtf8AsByteBuf(data));
+    ByteBuf metadataByteBuf = getUtf8AsByteBuf(metadata);
+    ByteBuf dataByteBuf = getUtf8AsByteBuf(data);
+
+    try {
+      return createRequestChannelFrame(
+          byteBufAllocator, follows, complete, initialRequestN, metadataByteBuf, dataByteBuf);
+    } finally {
+      release(metadataByteBuf);
+      release(dataByteBuf);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/framing/RequestFireAndForgetFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/RequestFireAndForgetFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
 import io.netty.buffer.ByteBuf;
@@ -74,8 +75,16 @@ public final class RequestFireAndForgetFrame
       @Nullable String metadata,
       @Nullable String data) {
 
-    return createRequestFireAndForgetFrame(
-        byteBufAllocator, follows, getUtf8AsByteBuf(metadata), getUtf8AsByteBuf(data));
+    ByteBuf metadataByteBuf = getUtf8AsByteBuf(metadata);
+    ByteBuf dataByteBuf = getUtf8AsByteBuf(data);
+
+    try {
+      return createRequestFireAndForgetFrame(
+          byteBufAllocator, follows, metadataByteBuf, dataByteBuf);
+    } finally {
+      release(metadataByteBuf);
+      release(dataByteBuf);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/framing/RequestResponseFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/RequestResponseFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
 import io.netty.buffer.ByteBuf;
@@ -74,8 +75,15 @@ public final class RequestResponseFrame
       @Nullable String metadata,
       @Nullable String data) {
 
-    return createRequestResponseFrame(
-        byteBufAllocator, follows, getUtf8AsByteBuf(metadata), getUtf8AsByteBuf(data));
+    ByteBuf metadataByteBuf = getUtf8AsByteBuf(metadata);
+    ByteBuf dataByteBuf = getUtf8AsByteBuf(data);
+
+    try {
+      return createRequestResponseFrame(byteBufAllocator, follows, metadataByteBuf, dataByteBuf);
+    } finally {
+      release(metadataByteBuf);
+      release(dataByteBuf);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/framing/RequestStreamFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/RequestStreamFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.util.RecyclerFactory.createRecycler;
 
 import io.netty.buffer.ByteBuf;
@@ -79,12 +80,16 @@ public final class RequestStreamFrame
       @Nullable String metadata,
       @Nullable String data) {
 
-    return createRequestStreamFrame(
-        byteBufAllocator,
-        follows,
-        initialRequestN,
-        getUtf8AsByteBuf(metadata),
-        getUtf8AsByteBuf(data));
+    ByteBuf metadataByteBuf = getUtf8AsByteBuf(metadata);
+    ByteBuf dataByteBuf = getUtf8AsByteBuf(data);
+
+    try {
+      return createRequestStreamFrame(
+          byteBufAllocator, follows, initialRequestN, metadataByteBuf, dataByteBuf);
+    } finally {
+      release(metadataByteBuf);
+      release(dataByteBuf);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/framing/ResumeFrame.java
+++ b/rsocket-core/src/main/java/io/rsocket/framing/ResumeFrame.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.framing;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.framing.FrameType.RESUME;
 import static io.rsocket.framing.LengthUtils.getLengthAsUnsignedShort;
 import static io.rsocket.util.NumberUtils.requireUnsignedShort;
@@ -70,12 +71,19 @@ public final class ResumeFrame extends AbstractRecyclableFrame<ResumeFrame> {
       long lastReceivedServerPosition,
       long firstAvailableClientPosition) {
 
-    return createResumeFrame(
-        byteBufAllocator,
+    ByteBuf resumeIdentificationTokenByteBuf =
         getUtf8AsByteBufRequired(
-            resumeIdentificationToken, "resumeIdentificationToken must not be null"),
-        lastReceivedServerPosition,
-        firstAvailableClientPosition);
+            resumeIdentificationToken, "resumeIdentificationToken must not be null");
+
+    try {
+      return createResumeFrame(
+          byteBufAllocator,
+          resumeIdentificationTokenByteBuf,
+          lastReceivedServerPosition,
+          firstAvailableClientPosition);
+    } finally {
+      release(resumeIdentificationToken);
+    }
   }
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/util/AbstractionLeakingFrameUtils.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/AbstractionLeakingFrameUtils.java
@@ -16,9 +16,10 @@
 
 package io.rsocket.util;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.rsocket.framing.FrameLengthFrame.createFrameLengthFrame;
 import static io.rsocket.framing.StreamIdFrame.createStreamIdFrame;
-import static io.rsocket.util.DisposableUtil.disposeQuietly;
+import static io.rsocket.util.DisposableUtils.disposeQuietly;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Frame;
@@ -60,7 +61,7 @@ public final class AbstractionLeakingFrameUtils {
       return Tuples.of(streamIdFrame.getStreamId(), frame);
     } finally {
       disposeQuietly(frameLengthFrame, streamIdFrame);
-      abstractionLeakingFrame.release();
+      release(abstractionLeakingFrame);
     }
   }
 

--- a/rsocket-core/src/main/java/io/rsocket/util/DisposableUtils.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/DisposableUtils.java
@@ -19,9 +19,9 @@ import java.util.Arrays;
 import reactor.core.Disposable;
 
 /** Utilities for working with the {@link Disposable} type. */
-public final class DisposableUtil {
+public final class DisposableUtils {
 
-  private DisposableUtil() {}
+  private DisposableUtils() {}
 
   /**
    * Calls the {@link Disposable#dispose()} method if the instance is not null. If any exceptions
@@ -34,7 +34,9 @@ public final class DisposableUtil {
         .forEach(
             disposable -> {
               try {
-                disposable.dispose();
+                if (disposable != null) {
+                  disposable.dispose();
+                }
               } catch (RuntimeException e) {
                 // Suppress any exceptions during disposal
               }


### PR DESCRIPTION
Previously, there were a couple of frames that converted `String`s to `ByteBuf`s automatically as part of construction.  Those frames though, retained any `ByteBuf`s passed into them so that they could be released by the creators as necessary.  Since the automatic construction was not doing this release on the `String`-based `ByteBuf`s, there was a minor leak of references.  This change updates those locations to release the `String`-based `ByteBuf`s and accurately account for their retention and release.