### PR TITLE
Bintray Publish Version

### DIFF
--- a/bintray.gradle
+++ b/bintray.gradle
@@ -38,7 +38,7 @@ if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey') &&
             version {
                 name = project.version
                 released = new Date()
-                vcsTag = "v${project.version}"
+                vcsTag = project.version
 
                 gpg {
                     sign = true

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -17,6 +17,7 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ] && [ "$bin
 
     echo -e "Building Tag $TRAVIS_REPO_SLUG/$TRAVIS_TAG"
     ./gradlew \
+        -Pversion="$TRAVIS_TAG" \
         -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" \
         -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" \
         build bintrayUpload --stacktrace


### PR DESCRIPTION
Previously, an update to the build system forgot to include a flag to the Bintray publication of tags that used the tag value as the version being published.  This change updates that Travis script to fix this oversight.

In addition, a minor change was made to the Bintray configuration to match the tagging scheme used by the project.