### PR TITLE
Extract Project Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,6 @@ plugins {
     id 'io.morethan.jmhreport' version '0.7.0' apply false
 }
 
-allprojects {
-    version = hasProperty('version') ? property('version') : '0.11.0.BUILD-SNAPSHOT'
-}
-
 subprojects {
     apply plugin: 'io.spring.dependency-management'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+version=0.11.0.BUILD-SNAPSHOT


### PR DESCRIPTION
Previously the project version in the build was explicitly specified within the build script itself.  This way of specifying the project version makes the value non-overrideable from the command line.  This change moves that value to the `gradle.properties` file where it becomes a "normal" property, overridable using the standard `-P` syntax.