### PR TITLE
Upload to Bintray and Maven Central

### DIFF
--- a/bintray.gradle
+++ b/bintray.gradle
@@ -17,45 +17,42 @@
 if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey') &&
         project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')) {
 
-    bintray {
-        user = project.property('bintrayUser')
-        key = project.property('bintrayKey')
-
-        publish = true
-
-        pkg {
-            repo = 'RSocket'
-            name = 'rsocket-java'
-            licenses = ['Apache-2.0']
-
-            issueTrackerUrl = 'https://github.com/rsocket/rsocket-java/issues'
-            websiteUrl = 'https://github.com/rsocket/rsocket-java'
-            vcsUrl = 'https://github.com/rsocket/rsocket-java.git'
-
-            githubRepo = 'rsocket/rsocket-java' //Optional Github repository
-            githubReleaseNotesFile = 'README.md' //Optional Github readme file
-
-            version {
-                name = project.version
-                released = new Date()
-                vcsTag = project.version
-
-                gpg {
-                    sign = true
-                }
-
-                mavenCentralSync {
-                    user = project.property('sonatypeUsername')
-                    password = project.property('sonatypePassword')
-                }
-            }
-        }
-    }
-
     subprojects {
         plugins.withId('com.jfrog.bintray') {
             bintray {
-                publications('maven')
+                user = project.property('bintrayUser')
+                key = project.property('bintrayKey')
+
+                publications = ['maven']
+                publish = true
+
+                pkg {
+                    repo = 'RSocket'
+                    name = 'rsocket-java'
+                    licenses = ['Apache-2.0']
+
+                    issueTrackerUrl = 'https://github.com/rsocket/rsocket-java/issues'
+                    websiteUrl = 'https://github.com/rsocket/rsocket-java'
+                    vcsUrl = 'https://github.com/rsocket/rsocket-java.git'
+
+                    githubRepo = 'rsocket/rsocket-java' //Optional Github repository
+                    githubReleaseNotesFile = 'README.md' //Optional Github readme file
+
+                    version {
+                        name = project.version
+                        released = new Date()
+                        vcsTag = project.version
+
+                        gpg {
+                            sign = true
+                        }
+
+                        mavenCentralSync {
+                            user = project.property('sonatypeUsername')
+                            password = project.property('sonatypePassword')
+                        }
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,24 @@ subprojects {
                                 }
                             }
 
+                            developers {
+                                developer {
+                                    id 'robertroeser'
+                                    name 'Robert Roeser'
+                                    email 'robert@netifi.com'
+                                }
+                                developer {
+                                    id 'rdegnan'
+                                    name 'Ryland Degnan'
+                                    email 'ryland@netifi.com'
+                                }
+                                developer {
+                                    id 'yschimke'
+                                    name 'Yuri Schimke'
+                                    email 'yuri@schimke.ee'
+                                }
+                            }
+
                             scm {
                                 connection 'scm:git:https://github.com/rsocket/rsocket-java.git'
                                 developerConnection 'scm:git:https://github.com/rsocket/rsocket-java.git'


### PR DESCRIPTION
Previously, an update to the build system took a stab at uploading releases to Bintray and them promoting them to Maven Central.  Unsurprisingly, without a release to test against, this didn't work on the first try.  The first change required a move of the bintray configuration from the top-level project to each subproject that would be published.  Unlike before, this is now a subset of projects excluding things like the integration tests.  Second, this change finishes improvements to the Maven POM in order to meet the Maven Central requirements for publication.  Specifically three developers were added to the POMs in order for Sonatype to reach them if necessary.