### PR TITLE
Maven Dependency Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.rsocket:reactivesocket:0.9.20'
+    implementation 'io.rsocket:reactivesocket:0.9.20'
 }
 ```
 

--- a/artifactory.gradle
+++ b/artifactory.gradle
@@ -15,24 +15,25 @@
  */
 
 if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey')) {
-    artifactory {
-        publish {
-            contextUrl = 'https://oss.jfrog.org'
-
-            repository {
-                repoKey = 'oss-snapshot-local'
-
-                // Credentials for oss.jfrog.org are a user's Bintray credentials
-                username = project.property('bintrayUser')
-                password = project.property('bintrayKey')
-            }
-        }
-    }
 
     subprojects {
         plugins.withId('com.jfrog.artifactory') {
-            artifactoryPublish {
-                publications('maven')
+            artifactory {
+                publish {
+                    contextUrl = 'https://oss.jfrog.org'
+
+                    repository {
+                        repoKey = 'oss-snapshot-local'
+
+                        // Credentials for oss.jfrog.org are a user's Bintray credentials
+                        username = project.property('bintrayUser')
+                        password = project.property('bintrayKey')
+                    }
+
+                    defaults {
+                        publications('maven')
+                    }
+                }
             }
         }
     }

--- a/rsocket-core/build.gradle
+++ b/rsocket-core/build.gradle
@@ -27,11 +27,12 @@ plugins {
 dependencies {
     api 'io.netty:netty-buffer'
     api 'io.projectreactor:reactor-core'
-    api 'io.projectreactor.addons:reactor-extra'
 
-    implementation 'com.google.code.findbugs:jsr305'
-    implementation 'org.jctools:jctools-core'
+    implementation 'io.projectreactor.addons:reactor-extra'
     implementation 'org.slf4j:slf4j-api'
+
+    compileOnly 'com.google.code.findbugs:jsr305'
+    compileOnly 'org.jctools:jctools-core'
 
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.assertj:assertj-core'
@@ -39,6 +40,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
 
     testRuntimeOnly 'ch.qos.logback:logback-classic'
+    testRuntimeOnly 'org.jctools:jctools-core'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     // TODO: Remove after JUnit5 migration
@@ -53,6 +55,8 @@ jar {
 }
 
 shadowJar {
+    configurations = [project.configurations.compileOnly]
+
     dependencies {
         include(dependency('org.jctools:jctools-core'))
     }

--- a/rsocket-core/src/test/java/io/rsocket/util/DefaultPayloadTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/util/DefaultPayloadTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
 import io.rsocket.Payload;
-import javax.annotation.Nullable;
 import org.junit.Test;
 
 public class DefaultPayloadTest {
@@ -34,7 +33,7 @@ public class DefaultPayloadTest {
     assertDataAndMetadata(p, DATA_VAL, METADATA_VAL);
   }
 
-  public void assertDataAndMetadata(Payload p, String dataVal, @Nullable String metadataVal) {
+  public void assertDataAndMetadata(Payload p, String dataVal, String metadataVal) {
     assertThat("Unexpected data.", p.getDataUtf8(), equalTo(dataVal));
     if (metadataVal == null) {
       assertThat("Non-null metadata", p.hasMetadata(), equalTo(false));

--- a/rsocket-examples/build.gradle
+++ b/rsocket-examples/build.gradle
@@ -19,17 +19,17 @@ plugins {
 }
 
 dependencies {
-    compile project(':rsocket-core')
-    compile project(':rsocket-transport-local')
-    compile project(':rsocket-transport-netty')
+    implementation project(':rsocket-core')
+    implementation project(':rsocket-transport-local')
+    implementation project(':rsocket-transport-netty')
 
-    testCompile project(':rsocket-test')
-    testCompile 'org.junit.jupiter:junit-jupiter-api'
-    testCompile 'org.mockito:mockito-core'
+    testImplementation project(':rsocket-test')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.mockito:mockito-core'
 
     // TODO: Remove after JUnit5 migration
     testCompileOnly 'junit:junit'
-    testCompile 'org.hamcrest:hamcrest-library'
+    testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 

--- a/rsocket-load-balancer/build.gradle
+++ b/rsocket-load-balancer/build.gradle
@@ -22,7 +22,8 @@ plugins {
 }
 
 dependencies {
-    implementation project(':rsocket-core')
+    api project(':rsocket-core')
+
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(':rsocket-test')

--- a/rsocket-micrometer/build.gradle
+++ b/rsocket-micrometer/build.gradle
@@ -22,11 +22,12 @@ plugins {
 }
 
 dependencies {
-    implementation project(':rsocket-core')
-    implementation 'com.google.code.findbugs:jsr305'
-    implementation 'io.micrometer:micrometer-core'
+    api project(':rsocket-core')
+    api 'io.micrometer:micrometer-core'
+
     implementation 'org.slf4j:slf4j-api'
 
+    compileOnly 'com.google.code.findbugs:jsr305'
 
     testImplementation project(':rsocket-test')
     testImplementation 'io.projectreactor:reactor-test'

--- a/rsocket-transport-aeron/build.gradle
+++ b/rsocket-transport-aeron/build.gradle
@@ -22,9 +22,9 @@ plugins {
 }
 
 dependencies {
+    api project(':rsocket-core')
     api 'io.aeron:aeron-all'
 
-    implementation project(':rsocket-core')
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(':rsocket-test')

--- a/rsocket-transport-local/build.gradle
+++ b/rsocket-transport-local/build.gradle
@@ -22,8 +22,9 @@ plugins {
 }
 
 dependencies {
-    implementation project(':rsocket-core')
-    implementation 'com.google.code.findbugs:jsr305'
+    api project(':rsocket-core')
+
+    compileOnly 'com.google.code.findbugs:jsr305'
 
     testImplementation project(':rsocket-test')
     testImplementation 'io.projectreactor:reactor-test'

--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -22,9 +22,8 @@ plugins {
 }
 
 dependencies {
+    api project(':rsocket-core')
     api 'io.projectreactor.ipc:reactor-netty'
-
-    implementation project(':rsocket-core')
 
     testImplementation project(':rsocket-test')
     testImplementation 'org.junit.jupiter:junit-jupiter-api'


### PR DESCRIPTION
Previously, an update the build system resulted in the Maven dependencies being aggressively calculated, before each project add dependencies to itself. This change updates the ordering of this calculation such that it happens after each project configures itself.  In addition, this change goes through each project and ensures that the dependencies are scoped appropriately in order to achieve the a minimal and accurate Maven POM.

[Sample of the generated POMs](https://gist.github.com/nebhale/668720e6fff89df77424f03d731a79bc)