### PR TITLE
Always Reassemble Regardless of MTU

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -211,9 +211,7 @@ public class RSocketFactory {
                           dataMimeType,
                           setupPayload);
 
-                  if (mtu > 0) {
-                    connection = new FragmentationDuplexConnection(connection, mtu);
-                  }
+                  connection = new FragmentationDuplexConnection(connection, mtu);
 
                   ClientServerInputMultiplexer multiplexer =
                       new ClientServerInputMultiplexer(connection, plugins);

--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/FragmentationDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/FragmentationDuplexConnection.java
@@ -68,7 +68,7 @@ public final class FragmentationDuplexConnection implements DuplexConnection {
    *
    * @param byteBufAllocator the {@link ByteBufAllocator} to use
    * @param delegate the {@link DuplexConnection} to decorate
-   * @param maxFragmentSize the maximum fragment size
+   * @param maxFragmentSize the maximum fragment size. A value of 0 indicates that frames should not be fragmented.
    * @throws NullPointerException if {@code byteBufAllocator} or {@code delegate} are {@code null}
    * @throws IllegalArgumentException if {@code maxFragmentSize} is not {@code positive}
    */
@@ -79,7 +79,7 @@ public final class FragmentationDuplexConnection implements DuplexConnection {
         Objects.requireNonNull(byteBufAllocator, "byteBufAllocator must not be null");
     this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
 
-    NumberUtils.requirePositive(maxFragmentSize, "maxFragmentSize must be positive");
+    NumberUtils.requireNonNegative(maxFragmentSize, "maxFragmentSize must be positive");
 
     this.frameFragmenter = new FrameFragmenter(byteBufAllocator, maxFragmentSize);
   }

--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/FrameFragmenter.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/FrameFragmenter.java
@@ -124,7 +124,7 @@ final class FrameFragmenter {
   }
 
   private boolean shouldFragment(Frame frame) {
-    if (!(frame instanceof FragmentableFrame)) {
+    if (maxFragmentSize == 0 || !(frame instanceof FragmentableFrame)) {
       return false;
     }
 

--- a/rsocket-core/src/main/java/io/rsocket/util/NumberUtils.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/NumberUtils.java
@@ -38,6 +38,25 @@ public final class NumberUtils {
   private NumberUtils() {}
 
   /**
+   * Requires that an {@code int} is greater than or equal to zero.
+   *
+   * @param i the {@code int} to test
+   * @param message detail message to be used in the event that a {@link IllegalArgumentException}
+   *     is thrown
+   * @return the {@code int} if greater than or equal to zero
+   * @throws IllegalArgumentException if {@code i} is less than zero
+   */
+  public static int requireNonNegative(int i, String message) {
+    Objects.requireNonNull(message, "message must not be null");
+
+    if (i < 0) {
+      throw new IllegalArgumentException(message);
+    }
+
+    return i;
+  }
+
+  /**
    * Requires that a {@code long} is greater than zero.
    *
    * @param l the {@code long} to test

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/FrameFragmenterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/FrameFragmenterTest.java
@@ -173,4 +173,16 @@ final class FrameFragmenterTest {
         .isThrownBy(() -> new FrameFragmenter(DEFAULT, 2).fragment(null))
         .withMessage("frame must not be null");
   }
+
+  @DisplayName("does not fragment with zero maxFragmentLength")
+  @Test
+  void fragmentZeroMaxFragmentLength() {
+    PayloadFrame frame = createPayloadFrame(DEFAULT, false, false, null, getRandomByteBuf(2));
+
+    new FrameFragmenter(DEFAULT, 0)
+        .fragment(frame)
+        .as(StepVerifier::create)
+        .expectNext(frame)
+        .verifyComplete();
+  }
 }

--- a/rsocket-core/src/test/java/io/rsocket/util/NumberUtilsTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/util/NumberUtilsTest.java
@@ -25,7 +25,37 @@ import org.junit.jupiter.api.Test;
 
 final class NumberUtilsTest {
 
-  @DisplayName("returns long value with positive int")
+  @DisplayName("returns int value with postitive int")
+  @Test
+  void requireNonNegativeInt() {
+    assertThat(NumberUtils.requireNonNegative(Integer.MAX_VALUE, "test-message"))
+        .isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @DisplayName(
+      "requireNonNegative with int argument throws IllegalArgumentException with negative value")
+  @Test
+  void requireNonNegativeIntNegative() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> NumberUtils.requireNonNegative(Integer.MIN_VALUE, "test-message"))
+        .withMessage("test-message");
+  }
+
+  @DisplayName("requireNonNegative with int argument throws NullPointerException with null message")
+  @Test
+  void requireNonNegativeIntNullMessage() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> NumberUtils.requireNonNegative(Integer.MIN_VALUE, null))
+        .withMessage("message must not be null");
+  }
+
+  @DisplayName("requireNonNegative returns int value with zero")
+  @Test
+  void requireNonNegativeIntZero() {
+    assertThat(NumberUtils.requireNonNegative(0, "test-message")).isEqualTo(0);
+  }
+
+  @DisplayName("requirePositive returns int value with positive int")
   @Test
   void requirePositiveInt() {
     assertThat(NumberUtils.requirePositive(Integer.MAX_VALUE, "test-message"))
@@ -52,13 +82,12 @@ final class NumberUtilsTest {
   @DisplayName("requirePositive with int argument throws IllegalArgumentException with zero value")
   @Test
   void requirePositiveIntZero() {
-
     assertThatIllegalArgumentException()
         .isThrownBy(() -> NumberUtils.requirePositive(0, "test-message"))
         .withMessage("test-message");
   }
 
-  @DisplayName("returns long value with positive long")
+  @DisplayName("requirePositive returns long value with positive long")
   @Test
   void requirePositiveLong() {
     assertThat(NumberUtils.requirePositive(Long.MAX_VALUE, "test-message"))
@@ -85,7 +114,6 @@ final class NumberUtilsTest {
   @DisplayName("requirePositive with long argument throws IllegalArgumentException with zero value")
   @Test
   void requirePositiveLongZero() {
-
     assertThatIllegalArgumentException()
         .isThrownBy(() -> NumberUtils.requirePositive(0L, "test-message"))
         .withMessage("test-message");


### PR DESCRIPTION
Previously, if a user configured a non-positive (<=0) MTU for fragmentation, both fragmentation and reassembly were disabled.  Given that a receiver must always be prepared to reassemble fragmented frames (there is no handshake or flag that both parties must agree to) requiring fragmentation to enable reassembly was to strict.  This change updates the fragmenter to handle an MTU of size 0 as an indicator that there should be no fragmentation, but still enable reassembly.  The RSocketFactory was also updated to ensure that the fragmenter is always added, rather than skipping it when the MTU was zero.