### PR TITLE
Slow Test Run Configuration

### DIFF
--- a/rsocket-test/src/main/java/io/rsocket/test/SlowTest.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/SlowTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * {@code @SlowTest} is used to signal that the annotated test class or test method is slow running
+ * and will be disabled unless enabled via setting the {@code TEST_SLOW_ENABLED} environment
+ * variable to {@code true}.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@EnabledIfEnvironmentVariable(named = "TEST_SLOW_ENABLED", matches = "(?i)true")
+@Test
+public @interface SlowTest {}

--- a/rsocket-test/src/main/java/io/rsocket/test/TransportTest.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TransportTest.java
@@ -140,7 +140,7 @@ public interface TransportTest {
   }
 
   @DisplayName("makes 1 requestChannel request with 2,000,000 payloads")
-  @Test
+  @SlowTest
   default void requestChannel2_000_000() {
     Flux<Payload> payloads = Flux.range(0, 2_000_000).map(this::createTestPayload);
 


### PR DESCRIPTION
Currently the `TransportTest#requestChannel2_000_000` test (for all transports) takes a very long time on some systems.  It's a useful test to have, but not necessarily to run at all times.  This change creates an `@SlowTest` annotation that is meta-annotated so that tests will only be enabled if `TEST_SLOW_ENABLED=true` has been set.

[resolves #511 ]