### PR TITLE
check for nulls in Frame

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/Frame.java
+++ b/rsocket-core/src/main/java/io/rsocket/Frame.java
@@ -159,7 +159,7 @@ public class Frame implements Payload, ByteBufHolder {
    */
   @Override
   public boolean release() {
-    if (content.release()) {
+    if (content != null && content.release()) {
       recycle();
       return true;
     }
@@ -175,7 +175,7 @@ public class Frame implements Payload, ByteBufHolder {
    */
   @Override
   public boolean release(int decrement) {
-    if (content.release(decrement)) {
+    if (content != null && content.release(decrement)) {
       recycle();
       return true;
     }


### PR DESCRIPTION
Currently there are times when  Frames are being released and the content field is null. This checks to see if the content is null and prevents a NullPointerException from being thrown.