### PR TITLE
Fixed sending complete signal for mono.empty()

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
@@ -302,6 +302,7 @@ class RSocketServer implements RSocket {
               payload.release();
               return frame;
             })
+        .switchIfEmpty(Mono.fromCallable(() -> Frame.PayloadFrame.from(streamId, FrameType.COMPLETE)))
         .doFinally(signalType -> sendingSubscriptions.remove(streamId))
         .subscribe(sendProcessor::onNext, t -> handleError(streamId, t));
   }


### PR DESCRIPTION
fixes #520 