### PR TITLE
Workaround reactor-netty issues in setup rejection verification code

### DIFF
--- a/rsocket-core/src/test/java/io/rsocket/internal/SwitchTransformFluxTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/SwitchTransformFluxTest.java
@@ -1,7 +1,6 @@
 package io.rsocket.internal;
 
 import java.time.Duration;
-
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -9,101 +8,101 @@ import reactor.test.publisher.TestPublisher;
 
 public class SwitchTransformFluxTest {
 
-    @Test
-    public void backpressureTest() {
-        TestPublisher<Long> publisher = TestPublisher.createCold();
+  @Test
+  public void backpressureTest() {
+    TestPublisher<Long> publisher = TestPublisher.createCold();
 
-        Flux<String> switchTransformed = publisher
+    Flux<String> switchTransformed =
+        publisher
             .flux()
-            .transform(flux -> new SwitchTransformFlux<>(
-                flux,
-                (first, innerFlux) -> innerFlux.map(String::valueOf)
-            ));
+            .transform(
+                flux ->
+                    new SwitchTransformFlux<>(
+                        flux, (first, innerFlux) -> innerFlux.map(String::valueOf)));
 
-        publisher.next(1L);
+    publisher.next(1L);
 
-        StepVerifier.create(switchTransformed, 0)
-                    .thenRequest(1)
-                    .expectNext("1")
-                    .thenRequest(1)
-                    .then(() -> publisher.next(2L))
-                    .expectNext("2")
-                    .then(publisher::complete)
-                    .expectComplete()
-                    .verify(Duration.ofSeconds(10));
+    StepVerifier.create(switchTransformed, 0)
+        .thenRequest(1)
+        .expectNext("1")
+        .thenRequest(1)
+        .then(() -> publisher.next(2L))
+        .expectNext("2")
+        .then(publisher::complete)
+        .expectComplete()
+        .verify(Duration.ofSeconds(10));
 
-        publisher.assertWasRequested();
-        publisher.assertNoRequestOverflow();
-    }
+    publisher.assertWasRequested();
+    publisher.assertNoRequestOverflow();
+  }
 
-    @Test
-    public void shouldErrorOnOverflowTest() {
-        TestPublisher<Long> publisher = TestPublisher.createCold();
+  @Test
+  public void shouldErrorOnOverflowTest() {
+    TestPublisher<Long> publisher = TestPublisher.createCold();
 
-        Flux<String> switchTransformed = publisher
-                .flux()
-                .transform(flux -> new SwitchTransformFlux<>(
-                        flux,
-                        (first, innerFlux) -> innerFlux.map(String::valueOf)
-                ));
-
-        publisher.next(1L);
-
-        StepVerifier.create(switchTransformed, 0)
-                    .thenRequest(1)
-                    .expectNext("1")
-                    .then(() -> publisher.next(2L))
-                    .expectError()
-                    .verify(Duration.ofSeconds(10));
-
-        publisher.assertWasRequested();
-        publisher.assertNoRequestOverflow();
-    }
-
-    @Test
-    public void shouldPropagateonCompleteCorrectly() {
-        Flux<String> switchTransformed = Flux.empty()
-                                             .transform(flux -> new SwitchTransformFlux<>(
-                                                     flux,
-                                                     (first, innerFlux) -> innerFlux.map(String::valueOf)
-                                             ));
-
-        StepVerifier.create(switchTransformed)
-                    .expectComplete()
-                    .verify(Duration.ofSeconds(10));
-    }
-
-    @Test
-    public void shouldPropagateErrorCorrectly() {
-        Flux<String> switchTransformed = Flux.error(new RuntimeException("hello"))
-                .transform(flux -> new SwitchTransformFlux<>(
-                        flux,
-                        (first, innerFlux) -> innerFlux.map(String::valueOf)
-                ));
-
-        StepVerifier.create(switchTransformed)
-                    .expectErrorMessage("hello")
-                    .verify(Duration.ofSeconds(10));
-    }
-
-    @Test
-    public void shouldBeAbleToBeCancelledProperly() {
-        TestPublisher<Integer> publisher = TestPublisher.createCold();
-        Flux<String> switchTransformed = publisher
+    Flux<String> switchTransformed =
+        publisher
             .flux()
-            .transform(flux -> new SwitchTransformFlux<>(
-                flux,
-                (first, innerFlux) -> innerFlux.map(String::valueOf)
-            ));
+            .transform(
+                flux ->
+                    new SwitchTransformFlux<>(
+                        flux, (first, innerFlux) -> innerFlux.map(String::valueOf)));
 
-        publisher.emit(1, 2, 3, 4, 5);
+    publisher.next(1L);
 
-        StepVerifier.create(switchTransformed, 0)
-                    .thenCancel()
-                    .verify(Duration.ofSeconds(10));
+    StepVerifier.create(switchTransformed, 0)
+        .thenRequest(1)
+        .expectNext("1")
+        .then(() -> publisher.next(2L))
+        .expectError()
+        .verify(Duration.ofSeconds(10));
 
-        publisher.assertCancelled();
-        publisher.assertWasRequested();
+    publisher.assertWasRequested();
+    publisher.assertNoRequestOverflow();
+  }
 
-    }
+  @Test
+  public void shouldPropagateonCompleteCorrectly() {
+    Flux<String> switchTransformed =
+        Flux.empty()
+            .transform(
+                flux ->
+                    new SwitchTransformFlux<>(
+                        flux, (first, innerFlux) -> innerFlux.map(String::valueOf)));
+
+    StepVerifier.create(switchTransformed).expectComplete().verify(Duration.ofSeconds(10));
+  }
+
+  @Test
+  public void shouldPropagateErrorCorrectly() {
+    Flux<String> switchTransformed =
+        Flux.error(new RuntimeException("hello"))
+            .transform(
+                flux ->
+                    new SwitchTransformFlux<>(
+                        flux, (first, innerFlux) -> innerFlux.map(String::valueOf)));
+
+    StepVerifier.create(switchTransformed)
+        .expectErrorMessage("hello")
+        .verify(Duration.ofSeconds(10));
+  }
+
+  @Test
+  public void shouldBeAbleToBeCancelledProperly() {
+    TestPublisher<Integer> publisher = TestPublisher.createCold();
+    Flux<String> switchTransformed =
+        publisher
+            .flux()
+            .transform(
+                flux ->
+                    new SwitchTransformFlux<>(
+                        flux, (first, innerFlux) -> innerFlux.map(String::valueOf)));
+
+    publisher.emit(1, 2, 3, 4, 5);
+
+    StepVerifier.create(switchTransformed, 0).thenCancel().verify(Duration.ofSeconds(10));
+
+    publisher.assertCancelled();
+    publisher.assertWasRequested();
+  }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
@@ -18,12 +18,11 @@ package io.rsocket.transport.netty;
 
 import io.rsocket.DuplexConnection;
 import io.rsocket.Frame;
+import java.util.Objects;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
-
-import java.util.Objects;
 
 /** An implementation of {@link DuplexConnection} that connects via TCP. */
 public final class TcpDuplexConnection implements DuplexConnection {

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpUriHandler.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpUriHandler.java
@@ -53,9 +53,7 @@ public final class TcpUriHandler implements UriHandler {
       return Optional.empty();
     }
 
-    return Optional.of(TcpServerTransport.create(
-        TcpServer.create()
-          .host(uri.getHost())
-          .port(uri.getPort())));
+    return Optional.of(
+        TcpServerTransport.create(TcpServer.create().host(uri.getHost()).port(uri.getPort())));
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
@@ -67,7 +67,9 @@ public final class WebsocketDuplexConnection implements DuplexConnection {
 
   @Override
   public Flux<Frame> receive() {
-    return connection.inbound().receive()
+    return connection
+        .inbound()
+        .receive()
         .map(
             buf -> {
               CompositeByteBuf composite = connection.channel().alloc().compositeBuffer();
@@ -85,7 +87,9 @@ public final class WebsocketDuplexConnection implements DuplexConnection {
 
   @Override
   public Mono<Void> sendOne(Frame frame) {
-    return connection.outbound().sendObject(new BinaryWebSocketFrame(frame.content().skipBytes(FRAME_LENGTH_SIZE)))
+    return connection
+        .outbound()
+        .sendObject(new BinaryWebSocketFrame(frame.content().skipBytes(FRAME_LENGTH_SIZE)))
         .then();
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
@@ -93,8 +93,8 @@ public final class TcpClientTransport implements ClientTransport {
   @Override
   public Mono<DuplexConnection> connect() {
     return client
-      .doOnConnected(c -> c.addHandlerLast(new RSocketLengthCodec()))
-      .connect()
-      .map(TcpDuplexConnection::new);
+        .doOnConnected(c -> c.addHandlerLast(new RSocketLengthCodec()))
+        .connect()
+        .map(TcpDuplexConnection::new);
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
@@ -30,9 +30,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
-
 import reactor.core.publisher.Mono;
-import reactor.netty.Connection;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.tcp.TcpClient;
 
@@ -137,12 +135,12 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
 
   @Override
   public Mono<DuplexConnection> connect() {
-      return client
-          .headers(headers -> transportHeaders.get().forEach(headers::set))
-          .websocket()
-          .uri(path)
-          .connect()
-          .map(WebsocketDuplexConnection::new);
+    return client
+        .headers(headers -> transportHeaders.get().forEach(headers::set))
+        .websocket()
+        .uri(path)
+        .connect()
+        .map(WebsocketDuplexConnection::new);
   }
 
   @Override
@@ -153,14 +151,9 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
 
   private static TcpClient createClient(URI uri) {
     if (isSecure(uri)) {
-      return TcpClient.create()
-          .secure()
-          .host(uri.getHost())
-          .port(getPort(uri, 443));
+      return TcpClient.create().secure().host(uri.getHost()).port(getPort(uri, 443));
     } else {
-      return TcpClient.create()
-          .host(uri.getHost())
-          .port(getPort(uri, 80));
+      return TcpClient.create().host(uri.getHost()).port(getPort(uri, 80));
     }
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/CloseableChannel.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/CloseableChannel.java
@@ -23,8 +23,8 @@ import reactor.core.publisher.Mono;
 import reactor.netty.DisposableChannel;
 
 /**
- * An implementation of {@link Closeable} that wraps a {@link DisposableChannel}, enabling close-ability
- * and exposing the {@link DisposableChannel}'s address.
+ * An implementation of {@link Closeable} that wraps a {@link DisposableChannel}, enabling
+ * close-ability and exposing the {@link DisposableChannel}'s address.
  */
 public final class CloseableChannel implements Closeable {
 

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
@@ -20,10 +20,8 @@ import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.ServerTransport;
 import io.rsocket.transport.netty.RSocketLengthCodec;
 import io.rsocket.transport.netty.TcpDuplexConnection;
-
 import java.net.InetSocketAddress;
 import java.util.Objects;
-
 import reactor.core.publisher.Mono;
 import reactor.netty.tcp.TcpServer;
 
@@ -95,14 +93,12 @@ public final class TcpServerTransport implements ServerTransport<CloseableChanne
     Objects.requireNonNull(acceptor, "acceptor must not be null");
 
     return server
-        .doOnConnection(c -> {
-          c.addHandlerLast(new RSocketLengthCodec());
-          TcpDuplexConnection connection = new TcpDuplexConnection(c);
-          acceptor
-              .apply(connection)
-              .then(Mono.<Void>never())
-              .subscribe(c.disposeSubscriber());
-        })
+        .doOnConnection(
+            c -> {
+              c.addHandlerLast(new RSocketLengthCodec());
+              TcpDuplexConnection connection = new TcpDuplexConnection(c);
+              acceptor.apply(connection).then(Mono.<Void>never()).subscribe(c.disposeSubscriber());
+            })
         .bind()
         .map(CloseableChannel::new);
   }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -84,7 +84,7 @@ public final class WebsocketRouteTransport implements ServerTransport<Closeable>
     Objects.requireNonNull(acceptor, "acceptor must not be null");
 
     return (in, out) -> {
-      WebsocketDuplexConnection connection = new WebsocketDuplexConnection((Connection)in);
+      WebsocketDuplexConnection connection = new WebsocketDuplexConnection((Connection) in);
       return acceptor.apply(connection).then(out.neverComplete());
     };
   }

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SetupRejectionTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/SetupRejectionTest.java
@@ -13,13 +13,11 @@ import io.rsocket.transport.netty.server.CloseableChannel;
 import io.rsocket.transport.netty.server.TcpServerTransport;
 import io.rsocket.transport.netty.server.WebsocketServerTransport;
 import io.rsocket.util.DefaultPayload;
-
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketSecureTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketSecureTransportTest.java
@@ -25,7 +25,6 @@ import io.rsocket.transport.netty.server.WebsocketServerTransport;
 import java.net.InetSocketAddress;
 import java.security.cert.CertificateException;
 import java.time.Duration;
-
 import reactor.core.Exceptions;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.server.HttpServer;
@@ -39,21 +38,27 @@ final class WebsocketSecureTransportTest implements TransportTest {
           (address, server) ->
               WebsocketClientTransport.create(
                   HttpClient.create()
-                    .addressSupplier(server::address)
-                    .secure(ssl -> ssl.sslContext(
-                        SslContextBuilder.forClient()
-                            .trustManager(InsecureTrustManagerFactory.INSTANCE))),
+                      .addressSupplier(server::address)
+                      .secure(
+                          ssl ->
+                              ssl.sslContext(
+                                  SslContextBuilder.forClient()
+                                      .trustManager(InsecureTrustManagerFactory.INSTANCE))),
                   String.format(
                       "https://%s:%d/",
                       server.address().getHostName(), server.address().getPort())),
           address -> {
             try {
               SelfSignedCertificate ssc = new SelfSignedCertificate();
-              HttpServer server = HttpServer.from(
-                  TcpServer.create()
-                      .addressSupplier(() -> address)
-                      .secure(ssl -> ssl.sslContext(
-                          SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()))));
+              HttpServer server =
+                  HttpServer.from(
+                      TcpServer.create()
+                          .addressSupplier(() -> address)
+                          .secure(
+                              ssl ->
+                                  ssl.sslContext(
+                                      SslContextBuilder.forServer(
+                                          ssc.certificate(), ssc.privateKey()))));
               return WebsocketServerTransport.create(server);
             } catch (CertificateException e) {
               throw Exceptions.propagate(e);

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/CloseableChannelTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/CloseableChannelTest.java
@@ -46,11 +46,7 @@ final class CloseableChannelTest {
   @DisplayName("creates instance")
   @Test
   void constructor() {
-    channel
-        .map(CloseableChannel::new)
-        .as(StepVerifier::create)
-        .expectNextCount(1)
-        .verifyComplete();
+    channel.map(CloseableChannel::new).as(StepVerifier::create).expectNextCount(1).verifyComplete();
   }
 
   @DisplayName("constructor throws NullPointerException with null context")


### PR DESCRIPTION
Relates to https://github.com/reactor/reactor-netty/issues/460. Also applied formatter as separate commit