### PR TITLE
More performance improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ subprojects {
     ext['netty.version'] = '4.1.29.Final'
     ext['netty-boringssl.version'] = '2.0.18.Final'
     ext['hdrhistogram.version'] = '2.1.10'
-    ext['jctool.version'] = '2.1.2'
     ext['mockito.version'] = '2.23.0'
     ext['slf4j.version'] = '1.7.25'
     ext['jmh.version'] = '1.21'
@@ -56,7 +55,6 @@ subprojects {
             dependency "io.micrometer:micrometer-core:${ext['micrometer.version']}"
             dependency "org.assertj:assertj-core:${ext['assertj.version']}"
             dependency "org.hdrhistogram:HdrHistogram:${ext['hdrhistogram.version']}"
-            dependency "org.jctools:jctools-core:${ext['jctool.version']}"
             dependency "org.mockito:mockito-core:${ ext['mockito.version']}"
             dependency "org.slf4j:slf4j-api:${ext['slf4j.version']}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@
 # limitations under the License.
 #
 
-version=0.11.14.BUILD-SNAPSHOT
+version=0.11.13

--- a/rsocket-core/build.gradle
+++ b/rsocket-core/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
 
     testRuntimeOnly 'ch.qos.logback:logback-classic'
-    testRuntimeOnly 'org.jctools:jctools-core'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     // TODO: Remove after JUnit5 migration

--- a/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
@@ -22,14 +22,12 @@ import io.rsocket.exceptions.ConnectionErrorException;
 import io.rsocket.framing.FrameType;
 import io.rsocket.internal.LimitableRequestPublisher;
 import io.rsocket.internal.UnboundedProcessor;
+import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.core.publisher.SignalType;
-import reactor.core.publisher.UnicastProcessor;
+import reactor.core.publisher.*;
 
 import java.util.Collections;
 import java.util.Map;
@@ -42,18 +40,18 @@ import static io.rsocket.frame.FrameHeaderFlyweight.FLAGS_M;
 
 /** Server side RSocket. Receives {@link Frame}s from a {@link RSocketClient} */
 class RSocketServer implements RSocket {
-
+  
   private final DuplexConnection connection;
   private final RSocket requestHandler;
   private final Function<Frame, ? extends Payload> frameDecoder;
   private final Consumer<Throwable> errorConsumer;
-
+  
   private final Map<Integer, Subscription> sendingSubscriptions;
-  private final Map<Integer, UnicastProcessor<Payload>> channelProcessors;
-
+  private final Map<Integer, Processor<Payload,Payload>> channelProcessors;
+  
   private final UnboundedProcessor<Frame> sendProcessor;
   private KeepAliveHandler keepAliveHandler;
-
+  
   /*client responder*/
   RSocketServer(
       DuplexConnection connection,
@@ -62,7 +60,7 @@ class RSocketServer implements RSocket {
       Consumer<Throwable> errorConsumer) {
     this(connection, requestHandler, frameDecoder, errorConsumer, 0, 0);
   }
-
+  
   /*server responder*/
   RSocketServer(
       DuplexConnection connection,
@@ -77,18 +75,18 @@ class RSocketServer implements RSocket {
     this.errorConsumer = errorConsumer;
     this.sendingSubscriptions = Collections.synchronizedMap(new IntObjectHashMap<>());
     this.channelProcessors    = Collections.synchronizedMap(new IntObjectHashMap<>());
-
+    
     // DO NOT Change the order here. The Send processor must be subscribed to before receiving
     // connections
     this.sendProcessor = new UnboundedProcessor<>();
-
+    
     connection
         .send(sendProcessor)
         .doFinally(this::handleSendProcessorCancel)
         .subscribe(null, this::handleSendProcessorError);
-
+    
     Disposable receiveDisposable = connection.receive().subscribe(this::handleFrame, errorConsumer);
-
+    
     this.connection
         .onClose()
         .doFinally(
@@ -97,11 +95,11 @@ class RSocketServer implements RSocket {
               receiveDisposable.dispose();
             })
         .subscribe(null, errorConsumer);
-
+    
     if (tickPeriod != 0) {
       keepAliveHandler =
           KeepAliveHandler.ofServer(new KeepAliveHandler.KeepAlive(tickPeriod, ackTimeout));
-
+      
       keepAliveHandler
           .timeout()
           .subscribe(
@@ -116,7 +114,7 @@ class RSocketServer implements RSocket {
       keepAliveHandler = null;
     }
   }
-
+  
   private void handleSendProcessorError(Throwable t) {
     for (Subscription subscription : sendingSubscriptions.values()) {
       try {
@@ -125,21 +123,21 @@ class RSocketServer implements RSocket {
         errorConsumer.accept(e);
       }
     }
-
-    for (UnicastProcessor subscription : channelProcessors.values()) {
+    
+    for (Processor<Payload,Payload> subscription : channelProcessors.values()) {
       try {
-        subscription.cancel();
+        subscription.onError(t);
       } catch (Throwable e) {
         errorConsumer.accept(e);
       }
     }
   }
-
+  
   private void handleSendProcessorCancel(SignalType t) {
     if (SignalType.ON_ERROR == t) {
       return;
     }
-
+    
     for (Subscription subscription : sendingSubscriptions.values()) {
       try {
         subscription.cancel();
@@ -147,16 +145,16 @@ class RSocketServer implements RSocket {
         errorConsumer.accept(e);
       }
     }
-
-    for (UnicastProcessor subscription : channelProcessors.values()) {
+    
+    for (Processor<Payload,Payload> subscription : channelProcessors.values()) {
       try {
-        subscription.cancel();
+        subscription.onComplete();
       } catch (Throwable e) {
         errorConsumer.accept(e);
       }
     }
   }
-
+  
   @Override
   public Mono<Void> fireAndForget(Payload payload) {
     try {
@@ -165,7 +163,7 @@ class RSocketServer implements RSocket {
       return Mono.error(t);
     }
   }
-
+  
   @Override
   public Mono<Payload> requestResponse(Payload payload) {
     try {
@@ -174,7 +172,7 @@ class RSocketServer implements RSocket {
       return Mono.error(t);
     }
   }
-
+  
   @Override
   public Flux<Payload> requestStream(Payload payload) {
     try {
@@ -183,7 +181,7 @@ class RSocketServer implements RSocket {
       return Flux.error(t);
     }
   }
-
+  
   @Override
   public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
     try {
@@ -192,7 +190,7 @@ class RSocketServer implements RSocket {
       return Flux.error(t);
     }
   }
-
+  
   @Override
   public Mono<Void> metadataPush(Payload payload) {
     try {
@@ -201,43 +199,45 @@ class RSocketServer implements RSocket {
       return Mono.error(t);
     }
   }
-
+  
   @Override
   public void dispose() {
     connection.dispose();
   }
-
+  
   @Override
   public boolean isDisposed() {
     return connection.isDisposed();
   }
-
+  
   @Override
   public Mono<Void> onClose() {
     return connection.onClose();
   }
-
+  
   private void cleanup() {
     if (keepAliveHandler != null) {
       keepAliveHandler.dispose();
     }
     cleanUpSendingSubscriptions();
     cleanUpChannelProcessors();
-
+    
     requestHandler.dispose();
     sendProcessor.dispose();
   }
-
+  
   private synchronized void cleanUpSendingSubscriptions() {
     sendingSubscriptions.values().forEach(Subscription::cancel);
     sendingSubscriptions.clear();
   }
-
+  
   private synchronized void cleanUpChannelProcessors() {
-    channelProcessors.values().forEach(Subscription::cancel);
+    channelProcessors
+        .values()
+        .forEach(Processor::onComplete);
     channelProcessors.clear();
   }
-
+  
   private void handleFrame(Frame frame) {
     try {
       int streamId = frame.getStreamId();
@@ -313,14 +313,14 @@ class RSocketServer implements RSocket {
       frame.release();
     }
   }
-
+  
   private void handleFireAndForget(int streamId, Mono<Void> result) {
     result
         .doOnSubscribe(subscription -> sendingSubscriptions.put(streamId, subscription))
         .doFinally(signalType -> sendingSubscriptions.remove(streamId))
         .subscribe(null, errorConsumer);
   }
-
+  
   private void handleRequestResponse(int streamId, Mono<Payload> response) {
     response
         .doOnSubscribe(subscription -> sendingSubscriptions.put(streamId, subscription))
@@ -340,7 +340,7 @@ class RSocketServer implements RSocket {
         .doFinally(signalType -> sendingSubscriptions.remove(streamId))
         .subscribe(sendProcessor::onNext, t -> handleError(streamId, t));
   }
-
+  
   private void handleStream(int streamId, Flux<Payload> response, int initialRequestN) {
     response
         .transform(
@@ -364,44 +364,44 @@ class RSocketServer implements RSocket {
               sendProcessor.onNext(frame);
             });
   }
-
+  
   private void handleChannel(int streamId, Payload payload, int initialRequestN) {
     UnicastProcessor<Payload> frames = UnicastProcessor.create();
     channelProcessors.put(streamId, frames);
-
+    
     Flux<Payload> payloads =
         frames
             .doOnCancel(() -> sendProcessor.onNext(Frame.Cancel.from(streamId)))
             .doOnError(t -> sendProcessor.onNext(Frame.Error.from(streamId, t)))
             .doOnRequest(l -> sendProcessor.onNext(Frame.RequestN.from(streamId, l)))
             .doFinally(signalType -> channelProcessors.remove(streamId));
-
+    
     // not chained, as the payload should be enqueued in the Unicast processor before this method
     // returns
     // and any later payload can be processed
     frames.onNext(payload);
-
+    
     handleStream(streamId, requestChannel(payloads), initialRequestN);
   }
-
+  
   private void handleKeepAliveFrame(Frame frame) {
     if (keepAliveHandler != null) {
       keepAliveHandler.receive(frame);
     }
   }
-
+  
   private void handleCancelFrame(int streamId) {
     Subscription subscription = sendingSubscriptions.remove(streamId);
     if (subscription != null) {
       subscription.cancel();
     }
   }
-
+  
   private void handleError(int streamId, Throwable t) {
     errorConsumer.accept(t);
     sendProcessor.onNext(Frame.Error.from(streamId, t));
   }
-
+  
   private void handleRequestN(int streamId, Frame frame) {
     final Subscription subscription = sendingSubscriptions.get(streamId);
     if (subscription != null) {

--- a/rsocket-core/src/main/java/io/rsocket/internal/UnicastMonoProcessor.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/UnicastMonoProcessor.java
@@ -1,0 +1,191 @@
+package io.rsocket.internal;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
+import reactor.core.publisher.Operators;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+import reactor.util.function.Tuple2;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.LongSupplier;
+import java.util.stream.Stream;
+
+public class UnicastMonoProcessor<O> extends Mono<O>
+    implements Processor<O, O>,
+        CoreSubscriber<O>,
+        Disposable,
+        Subscription,
+        Scannable,
+        LongSupplier {
+
+  @SuppressWarnings("rawtypes")
+  static final AtomicIntegerFieldUpdater<UnicastMonoProcessor> ONCE =
+      AtomicIntegerFieldUpdater.newUpdater(UnicastMonoProcessor.class, "once");
+
+  private final MonoProcessor<O> processor;
+
+  @SuppressWarnings("unused")
+  private volatile int once;
+
+  private UnicastMonoProcessor() {
+    this.processor = MonoProcessor.create();
+  }
+
+  public static <O> UnicastMonoProcessor<O> create() {
+    return new UnicastMonoProcessor<>();
+  }
+
+  @Override
+  public Stream<? extends Scannable> actuals() {
+    return processor.actuals();
+  }
+
+  @Override
+  public boolean isScanAvailable() {
+    return processor.isScanAvailable();
+  }
+
+  @Override
+  public String name() {
+    return processor.name();
+  }
+
+  @Override
+  public String stepName() {
+    return processor.stepName();
+  }
+
+  @Override
+  public Stream<String> steps() {
+    return processor.steps();
+  }
+
+  @Override
+  public Stream<? extends Scannable> parents() {
+    return processor.parents();
+  }
+
+  @Override
+  @Nullable
+  public <T> T scan(Attr<T> key) {
+    return processor.scan(key);
+  }
+
+  @Override
+  public <T> T scanOrDefault(Attr<T> key, T defaultValue) {
+    return processor.scanOrDefault(key, defaultValue);
+  }
+
+  @Override
+  public Stream<Tuple2<String, String>> tags() {
+    return processor.tags();
+  }
+
+  @Override
+  public long getAsLong() {
+    return processor.getAsLong();
+  }
+
+  @Override
+  public void onSubscribe(Subscription s) {
+    processor.onSubscribe(s);
+  }
+
+  @Override
+  public void onNext(O o) {
+    processor.onNext(o);
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    processor.onError(t);
+  }
+
+  @Nullable
+  public Throwable getError() {
+    return processor.getError();
+  }
+
+  public boolean isCancelled() {
+    return processor.isCancelled();
+  }
+
+  public boolean isError() {
+    return processor.isError();
+  }
+
+  public boolean isSuccess() {
+    return processor.isSuccess();
+  }
+
+  public boolean isTerminated() {
+    return processor.isTerminated();
+  }
+
+  @Nullable
+  public O peek() {
+    return processor.peek();
+  }
+
+  public long downstreamCount() {
+    return processor.downstreamCount();
+  }
+
+  public boolean hasDownstreams() {
+    return processor.hasDownstreams();
+  }
+
+  @Override
+  public void onComplete() {
+    processor.onComplete();
+  }
+
+  @Override
+  public void request(long n) {
+    processor.request(n);
+  }
+
+  @Override
+  public void cancel() {
+    processor.cancel();
+  }
+
+  @Override
+  public void dispose() {
+    processor.dispose();
+  }
+
+  @Override
+  public Context currentContext() {
+    return processor.currentContext();
+  }
+
+  @Override
+  public boolean isDisposed() {
+    return processor.isDisposed();
+  }
+
+  @Override
+  public Object scanUnsafe(Attr key) {
+    return processor.scanUnsafe(key);
+  }
+
+  @Override
+  public void subscribe(CoreSubscriber<? super O> actual) {
+    Objects.requireNonNull(actual, "subscribe");
+    if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
+      processor.subscribe(actual);
+    } else {
+      Operators.error(
+          actual,
+          new IllegalStateException("UnicastMonoProcessor allows only a single Subscriber"));
+    }
+  }
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/SendPublisher.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/SendPublisher.java
@@ -10,6 +10,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Operators;
 import reactor.util.concurrent.Queues;
@@ -27,20 +28,23 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
 
   private static final int MAX_SIZE = Queues.SMALL_BUFFER_SIZE;
   private static final int REFILL_SIZE = MAX_SIZE / 2;
-  private static final AtomicReferenceFieldUpdater<SendPublisher, Object>
-      INNER_SUBSCRIBER =
-          AtomicReferenceFieldUpdater.newUpdater(
-              SendPublisher.class, Object.class, "innerSubscriber");
+  private static final AtomicReferenceFieldUpdater<SendPublisher, Object> INNER_SUBSCRIBER =
+      AtomicReferenceFieldUpdater.newUpdater(SendPublisher.class, Object.class, "innerSubscriber");
+  private static final AtomicIntegerFieldUpdater<SendPublisher> TERMINATED =
+      AtomicIntegerFieldUpdater.newUpdater(SendPublisher.class, "terminated");
   private final Publisher<Frame> source;
   private final Channel channel;
   private final EventLoop eventLoop;
-  private final Queue<V> queue;
-  private final AtomicBoolean terminated = new AtomicBoolean();
+  private final Queue<Frame> queue;
   private final AtomicBoolean completed = new AtomicBoolean();
   private final Function<Frame, V> transformer;
   private final SizeOf<V> sizeOf;
-  
+
+  @SuppressWarnings("unused")
+  private volatile int terminated;
+
   private int pending;
+
   @SuppressWarnings("unused")
   private volatile int wip;
 
@@ -51,18 +55,31 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
 
   private long requestedUpstream = MAX_SIZE;
 
+  private boolean fuse;
+
   @SuppressWarnings("unchecked")
   SendPublisher(
       Publisher<Frame> source, Channel channel, Function<Frame, V> transformer, SizeOf<V> sizeOf) {
-    this.source = source;
-    this.channel = channel;
-    this.queue = Queues.<V>small().get();
-    this.eventLoop = channel.eventLoop();
-    this.transformer = transformer;
-    this.sizeOf = sizeOf;
+    this(Queues.<Frame>small().get(), source, channel, transformer, sizeOf);
   }
 
   @SuppressWarnings("unchecked")
+  SendPublisher(
+      Queue<Frame> queue,
+      Publisher<Frame> source,
+      Channel channel,
+      Function<Frame, V> transformer,
+      SizeOf<V> sizeOf) {
+    this.source = source;
+    this.channel = channel;
+    this.queue = queue;
+    this.eventLoop = channel.eventLoop();
+    this.transformer = transformer;
+    this.sizeOf = sizeOf;
+
+    fuse = queue instanceof Fuseable.QueueSubscription;
+  }
+
   private ChannelPromise writeCleanupPromise(V poll) {
     return channel
         .newPromise()
@@ -90,9 +107,9 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
     if (pending == 0
         && completed.get()
         && queue.isEmpty()
-        && !terminated.get()
+        && terminated == 0
         && !is.pendingFlush.get()) {
-      terminated.set(true);
+      TERMINATED.set(SendPublisher.this, 1);
       is.destination.onComplete();
     }
   }
@@ -101,12 +118,13 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
   public void subscribe(CoreSubscriber<? super Frame> destination) {
     InnerSubscriber innerSubscriber = new InnerSubscriber(destination);
     if (!INNER_SUBSCRIBER.compareAndSet(this, null, innerSubscriber)) {
-      throw new IllegalStateException("SendPublisher only allows one subscription");
+      Operators.error(
+          destination, new IllegalStateException("SendPublisher only allows one subscription"));
+    } else {
+      InnerSubscription innerSubscription = new InnerSubscription(innerSubscriber);
+      destination.onSubscribe(innerSubscription);
+      source.subscribe(innerSubscriber);
     }
-
-    InnerSubscription innerSubscription = new InnerSubscription(innerSubscriber);
-    destination.onSubscribe(innerSubscription);
-    source.subscribe(innerSubscriber);
   }
 
   @FunctionalInterface
@@ -132,8 +150,8 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
 
     @Override
     public void onNext(Frame t) {
-      if (!terminated.get()) {
-        if (!queue.offer(transformer.apply(t))) {
+      if (terminated == 0) {
+        if (!fuse && !queue.offer(t)) {
           throw new IllegalStateException("missing back pressure");
         }
         tryDrain();
@@ -142,7 +160,7 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
 
     @Override
     public void onError(Throwable t) {
-      if (terminated.compareAndSet(false, true)) {
+      if (TERMINATED.compareAndSet(SendPublisher.this, 0, 1)) {
         try {
           s.cancel();
           destination.onError(t);
@@ -180,7 +198,7 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
     }
 
     private void tryDrain() {
-      if (wip == 0 && !terminated.get() && WIP.getAndIncrement(SendPublisher.this) == 0) {
+      if (wip == 0 && terminated == 0 && WIP.getAndIncrement(SendPublisher.this) == 0) {
         try {
           if (eventLoop.inEventLoop()) {
             drain();
@@ -202,8 +220,9 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
 
           long r = Math.min(requested, requestedUpstream);
           while (r-- > 0) {
-            V poll = queue.poll();
-            if (poll != null && !terminated.get()) {
+            Frame frame = queue.poll();
+            if (frame != null && terminated == 0) {
+              V poll = transformer.apply(frame);
               int readableBytes = sizeOf.size(poll);
               pending++;
               if (channel.isWritable() && readableBytes <= channel.bytesBeforeUnwritable()) {
@@ -225,7 +244,7 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
             eventLoop.execute(this::flush);
           }
 
-          if (terminated.get()) {
+          if (terminated == 1) {
             break;
           }
 
@@ -259,7 +278,13 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<Frame> {
 
     @Override
     public void cancel() {
-      terminated.set(true);
+      TERMINATED.set(SendPublisher.this, 1);
+      while (!queue.isEmpty()) {
+        Frame poll = queue.poll();
+        if (poll != null) {
+          ReferenceCountUtil.safeRelease(poll);
+        }
+      }
     }
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
@@ -23,10 +23,12 @@ import io.rsocket.Frame;
 import io.rsocket.frame.FrameHeaderFlyweight;
 import org.reactivestreams.Publisher;
 import reactor.core.Disposable;
+import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.FutureMono;
+import reactor.util.concurrent.Queues;
 
 import java.util.Objects;
 
@@ -41,79 +43,93 @@ import static io.rsocket.frame.FrameHeaderFlyweight.FRAME_LENGTH_SIZE;
  * back on for frames received.
  */
 public final class WebsocketDuplexConnection implements DuplexConnection {
-    
-    private final Connection connection;
-    private final Disposable channelClosed;
-    
-    /**
-     * Creates a new instance
-     *
-     * @param connection the {@link Connection} to for managing the server
-     */
-    public WebsocketDuplexConnection(Connection connection) {
-        this.connection = Objects.requireNonNull(connection, "connection must not be null");
-        this.channelClosed =
-            FutureMono.from(connection.channel().closeFuture())
-                .doFinally(
-                    s -> {
-                        if (!isDisposed()) {
-                            dispose();
-                        }
-                    })
-                .subscribe();
-    }
-    
-    @Override
-    public void dispose() {
-        connection.dispose();
-    }
-    
-    @Override
-    public boolean isDisposed() {
-        return connection.isDisposed();
-    }
-    
-    @Override
-    public Mono<Void> onClose() {
-        return connection
-                   .onDispose()
-                   .doFinally(
-                       s -> {
-                           if (!channelClosed.isDisposed()) {
-                               channelClosed.dispose();
-                           }
-                       });
-    }
-    
-    @Override
-    public Flux<Frame> receive() {
-        return connection
-                   .inbound()
-                   .receive()
-                   .map(
-                       buf -> {
-                           CompositeByteBuf composite = connection.channel().alloc().compositeBuffer();
-                           ByteBuf length = wrappedBuffer(new byte[FRAME_LENGTH_SIZE]);
-                           FrameHeaderFlyweight.encodeLength(length, 0, buf.readableBytes());
-                           composite.addComponents(true, length, buf.retain());
-                           return Frame.from(composite);
-                       });
-    }
-    
-    @Override
-    public Mono<Void> send(Publisher<Frame> frames) {
-        return Flux.from(frames)
-                   .transform(
-                       frameFlux ->
-                           new SendPublisher<>(
-                               frameFlux,
-                               connection.channel(),
-                               this::toBinaryWebSocketFrame,
-                               binaryWebSocketFrame -> binaryWebSocketFrame.content().readableBytes()))
-                   .then();
-    }
-    
-    private BinaryWebSocketFrame toBinaryWebSocketFrame(Frame frame) {
-        return new BinaryWebSocketFrame(frame.content().skipBytes(FRAME_LENGTH_SIZE).retain());
-    }
+
+  private final Connection connection;
+  private final Disposable channelClosed;
+
+  /**
+   * Creates a new instance
+   *
+   * @param connection the {@link Connection} to for managing the server
+   */
+  public WebsocketDuplexConnection(Connection connection) {
+    this.connection = Objects.requireNonNull(connection, "connection must not be null");
+    this.channelClosed =
+        FutureMono.from(connection.channel().closeFuture())
+            .doFinally(
+                s -> {
+                  if (!isDisposed()) {
+                    dispose();
+                  }
+                })
+            .subscribe();
+  }
+
+  @Override
+  public void dispose() {
+    connection.dispose();
+  }
+
+  @Override
+  public boolean isDisposed() {
+    return connection.isDisposed();
+  }
+
+  @Override
+  public Mono<Void> onClose() {
+    return connection
+        .onDispose()
+        .doFinally(
+            s -> {
+              if (!channelClosed.isDisposed()) {
+                channelClosed.dispose();
+              }
+            });
+  }
+
+  @Override
+  public Flux<Frame> receive() {
+    return connection
+        .inbound()
+        .receive()
+        .map(
+            buf -> {
+              CompositeByteBuf composite = connection.channel().alloc().compositeBuffer();
+              ByteBuf length = wrappedBuffer(new byte[FRAME_LENGTH_SIZE]);
+              FrameHeaderFlyweight.encodeLength(length, 0, buf.readableBytes());
+              composite.addComponents(true, length, buf.retain());
+              return Frame.from(composite);
+            });
+  }
+
+  @Override
+  public Mono<Void> send(Publisher<Frame> frames) {
+    return Flux.from(frames)
+        .transform(
+            frameFlux -> {
+              if (frameFlux instanceof Fuseable.QueueSubscription) {
+                Fuseable.QueueSubscription<Frame> queueSubscription =
+                    (Fuseable.QueueSubscription<Frame>) frameFlux;
+                queueSubscription.requestFusion(Fuseable.ASYNC);
+                return new SendPublisher<>(
+                    queueSubscription,
+                    frameFlux,
+                    connection.channel(),
+                    this::toBinaryWebSocketFrame,
+                    binaryWebSocketFrame -> binaryWebSocketFrame.content().readableBytes());
+              } else {
+                return new SendPublisher<>(
+                    Queues.<Frame>small().get(),
+                    frameFlux,
+                    connection.channel(),
+                    this::toBinaryWebSocketFrame,
+                    binaryWebSocketFrame -> binaryWebSocketFrame.content().readableBytes());
+              }
+            })
+        .then();
+  }
+
+  private BinaryWebSocketFrame toBinaryWebSocketFrame(Frame frame) {
+    return new BinaryWebSocketFrame(frame.content().skipBytes(FRAME_LENGTH_SIZE).retain());
+  }
 }


### PR DESCRIPTION
SendPublisher can use the queue from the UnboadedProcessor now
Removed dependency on JCTools
Use MonoProcessor for request/reply instead of UnicastProcessor
