### PR TITLE
Replace for loops with forEach in RSocketClient/Server to fix non-deterministic behavior

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -39,7 +39,7 @@ import java.util.function.Function;
 
 /** Client Side of a RSocket socket. Sends {@link Frame}s to a {@link RSocketServer} */
 class RSocketClient implements RSocket {
-  
+
   private final DuplexConnection connection;
   private final Function<Frame, ? extends Payload> frameDecoder;
   private final Consumer<Throwable> errorConsumer;
@@ -49,7 +49,7 @@ class RSocketClient implements RSocket {
   private final UnboundedProcessor<Frame> sendProcessor;
   private final Lifecycle lifecycle = new Lifecycle();
   private KeepAliveHandler keepAliveHandler;
-  
+
   /*server requester*/
   RSocketClient(
       DuplexConnection connection,
@@ -59,7 +59,7 @@ class RSocketClient implements RSocket {
     this(
         connection, frameDecoder, errorConsumer, streamIdSupplier, Duration.ZERO, Duration.ZERO, 0);
   }
-  
+
   /*client requester*/
   RSocketClient(
       DuplexConnection connection,
@@ -75,24 +75,24 @@ class RSocketClient implements RSocket {
     this.streamIdSupplier = streamIdSupplier;
     this.senders = Collections.synchronizedMap(new IntObjectHashMap<>());
     this.receivers = Collections.synchronizedMap(new IntObjectHashMap<>());
-    
+
     // DO NOT Change the order here. The Send processor must be subscribed to before receiving
     this.sendProcessor = new UnboundedProcessor<>();
-    
+
     connection.onClose().doFinally(signalType -> terminate()).subscribe(null, errorConsumer);
-    
+
     connection
         .send(sendProcessor)
         .doFinally(this::handleSendProcessorCancel)
         .subscribe(null, this::handleSendProcessorError);
-    
+
     connection.receive().subscribe(this::handleIncomingFrames, errorConsumer);
-    
+
     if (!Duration.ZERO.equals(tickPeriod)) {
       this.keepAliveHandler =
           KeepAliveHandler.ofClient(
               new KeepAliveHandler.KeepAlive(tickPeriod, ackTimeout, missedAcks));
-      
+
       keepAliveHandler
           .timeout()
           .subscribe(
@@ -109,306 +109,297 @@ class RSocketClient implements RSocket {
       keepAliveHandler = null;
     }
   }
-  
+
   private void handleSendProcessorError(Throwable t) {
     Throwable terminationError = lifecycle.getTerminationError();
     Throwable err = terminationError != null ? terminationError : t;
-    for (Subscriber subscriber : receivers.values()) {
+    receivers.values().forEach(subscriber -> {
       try {
         subscriber.onError(err);
       } catch (Throwable e) {
         errorConsumer.accept(e);
       }
-    }
-    
-    for (LimitableRequestPublisher p : senders.values()) {
-      p.cancel();
-    }
+    });
+
+    senders.values().forEach(LimitableRequestPublisher::cancel);
   }
-  
+
   private void handleSendProcessorCancel(SignalType t) {
     if (SignalType.ON_ERROR == t) {
       return;
     }
-    
-    for (Subscriber subscriber : receivers.values()) {
+
+    receivers.values().forEach(subscriber -> {
       try {
         subscriber.onError(new Throwable("closed connection"));
       } catch (Throwable e) {
         errorConsumer.accept(e);
       }
-    }
-    
-    for (LimitableRequestPublisher p : senders.values()) {
-      p.cancel();
-    }
+    });
+
+    senders.values().forEach(LimitableRequestPublisher::cancel);
   }
-  
+
   @Override
   public Mono<Void> fireAndForget(Payload payload) {
     return handleFireAndForget(payload);
   }
-  
+
   @Override
   public Mono<Payload> requestResponse(Payload payload) {
     return handleRequestResponse(payload);
   }
-  
+
   @Override
   public Flux<Payload> requestStream(Payload payload) {
     return handleRequestStream(payload);
   }
-  
+
   @Override
   public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
     return handleChannel(Flux.from(payloads));
   }
-  
+
   @Override
   public Mono<Void> metadataPush(Payload payload) {
     return handleMetadataPush(payload);
   }
-  
+
   @Override
   public double availability() {
     return connection.availability();
   }
-  
+
   @Override
   public void dispose() {
     connection.dispose();
   }
-  
+
   @Override
   public boolean isDisposed() {
     return connection.isDisposed();
   }
-  
+
   @Override
   public Mono<Void> onClose() {
     return connection.onClose();
   }
-  
+
   private Mono<Void> handleFireAndForget(Payload payload) {
     return lifecycle
-               .active()
-               .then(
-                   Mono.fromRunnable(
-                       () -> {
-                         final int streamId = streamIdSupplier.nextStreamId();
-                         final Frame requestFrame =
-                             Frame.Request.from(streamId, FrameType.REQUEST_FNF, payload, 1);
-                         payload.release();
-                         sendProcessor.onNext(requestFrame);
-                       }));
+        .active()
+        .then(
+            Mono.fromRunnable(
+                () -> {
+                  final int streamId = streamIdSupplier.nextStreamId();
+                  final Frame requestFrame =
+                      Frame.Request.from(streamId, FrameType.REQUEST_FNF, payload, 1);
+                  payload.release();
+                  sendProcessor.onNext(requestFrame);
+                }));
   }
-  
+
   private Flux<Payload> handleRequestStream(final Payload payload) {
     return lifecycle
-               .active()
-               .thenMany(
-                   Flux.defer(
-                       () -> {
-                         int streamId = streamIdSupplier.nextStreamId();
-                  
-                         UnicastProcessor<Payload> receiver = UnicastProcessor.create();
-                         receivers.put(streamId, receiver);
-                  
-                         AtomicBoolean first = new AtomicBoolean(false);
-                  
-                         return receiver
-                                    .doOnRequest(
-                                        n -> {
-                                          if (first.compareAndSet(false, true) && !receiver.isDisposed()) {
-                                            final Frame requestFrame =
-                                                Frame.Request.from(
-                                                    streamId, FrameType.REQUEST_STREAM, payload, n);
-                                            payload.release();
-                                            sendProcessor.onNext(requestFrame);
-                                          } else if (contains(streamId) && !receiver.isDisposed()) {
-                                            sendProcessor.onNext(Frame.RequestN.from(streamId, n));
-                                          }
-                                          sendProcessor.drain();
-                                        })
-                                    .doOnError(
-                                        t -> {
-                                          if (contains(streamId) && !receiver.isDisposed()) {
-                                            sendProcessor.onNext(Frame.Error.from(streamId, t));
-                                          }
-                                        })
-                                    .doOnCancel(
-                                        () -> {
-                                          if (contains(streamId) && !receiver.isDisposed()) {
-                                            sendProcessor.onNext(Frame.Cancel.from(streamId));
-                                          }
-                                        })
-                                    .doFinally(
-                                        s -> {
-                                          receivers.remove(streamId);
-                                        });
-                       }));
+        .active()
+        .thenMany(
+            Flux.defer(
+                () -> {
+                  int streamId = streamIdSupplier.nextStreamId();
+
+                  UnicastProcessor<Payload> receiver = UnicastProcessor.create();
+                  receivers.put(streamId, receiver);
+
+                  AtomicBoolean first = new AtomicBoolean(false);
+
+                  return receiver
+                      .doOnRequest(
+                          n -> {
+                            if (first.compareAndSet(false, true) && !receiver.isDisposed()) {
+                              final Frame requestFrame =
+                                  Frame.Request.from(
+                                      streamId, FrameType.REQUEST_STREAM, payload, n);
+                              payload.release();
+                              sendProcessor.onNext(requestFrame);
+                            } else if (contains(streamId) && !receiver.isDisposed()) {
+                              sendProcessor.onNext(Frame.RequestN.from(streamId, n));
+                            }
+                            sendProcessor.drain();
+                          })
+                      .doOnError(
+                          t -> {
+                            if (contains(streamId) && !receiver.isDisposed()) {
+                              sendProcessor.onNext(Frame.Error.from(streamId, t));
+                            }
+                          })
+                      .doOnCancel(
+                          () -> {
+                            if (contains(streamId) && !receiver.isDisposed()) {
+                              sendProcessor.onNext(Frame.Cancel.from(streamId));
+                            }
+                          })
+                      .doFinally(
+                          s -> {
+                            receivers.remove(streamId);
+                          });
+                }));
   }
-  
+
   private Mono<Payload> handleRequestResponse(final Payload payload) {
     return lifecycle
-               .active()
-               .then(
-                   Mono.defer(
-                       () -> {
-                         int streamId = streamIdSupplier.nextStreamId();
-                         final Frame requestFrame =
-                             Frame.Request.from(streamId, FrameType.REQUEST_RESPONSE, payload, 1);
-                         payload.release();
-  
-                         UnicastMonoProcessor<Payload> receiver = UnicastMonoProcessor.create();
-                         receivers.put(streamId, receiver);
-                  
-                         sendProcessor.onNext(requestFrame);
-                  
-                         return receiver
-                                    .doOnError(t -> sendProcessor.onNext(Frame.Error.from(streamId, t)))
-                                    .doFinally(
-                                        s -> {
-                                          if (s == SignalType.CANCEL) {
-                                            sendProcessor.onNext(Frame.Cancel.from(streamId));
-                                          }
-                            
-                                          receivers.remove(streamId);
-                                        });
-                       }));
+        .active()
+        .then(
+            Mono.defer(
+                () -> {
+                  int streamId = streamIdSupplier.nextStreamId();
+                  final Frame requestFrame =
+                      Frame.Request.from(streamId, FrameType.REQUEST_RESPONSE, payload, 1);
+                  payload.release();
+
+                  UnicastMonoProcessor<Payload> receiver = UnicastMonoProcessor.create();
+                  receivers.put(streamId, receiver);
+
+                  sendProcessor.onNext(requestFrame);
+
+                  return receiver
+                      .doOnError(t -> sendProcessor.onNext(Frame.Error.from(streamId, t)))
+                      .doFinally(
+                          s -> {
+                            if (s == SignalType.CANCEL) {
+                              sendProcessor.onNext(Frame.Cancel.from(streamId));
+                            }
+
+                            receivers.remove(streamId);
+                          });
+                }));
   }
-  
+
   private Flux<Payload> handleChannel(Flux<Payload> request) {
     return lifecycle
-               .active()
-               .thenMany(
-                   Flux.defer(
-                       () -> {
-                         final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
-                         final int streamId = streamIdSupplier.nextStreamId();
-                         final AtomicBoolean firstRequest = new AtomicBoolean(true);
-                  
-                         return receiver
-                                    .doOnRequest(
-                                        n -> {
-                                          if (firstRequest.compareAndSet(true, false)) {
-                                            final AtomicBoolean firstPayload = new AtomicBoolean(true);
-                                            final Flux<Frame> requestFrames =
-                                                request
-                                                    .transform(
-                                                        f -> {
-                                                          LimitableRequestPublisher<Payload> wrapped =
-                                                              LimitableRequestPublisher.wrap(f);
-                                                          // Need to set this to one for first the frame
-                                                          wrapped.increaseRequestLimit(1);
-                                                          senders.put(streamId, wrapped);
-                                                          receivers.put(streamId, receiver);
-                                            
-                                                          return wrapped;
-                                                        })
-                                                    .map(
-                                                        payload -> {
-                                                          final Frame requestFrame;
-                                                          if (firstPayload.compareAndSet(true, false)) {
-                                                            requestFrame =
-                                                                Frame.Request.from(
-                                                                    streamId,
-                                                                    FrameType.REQUEST_CHANNEL,
-                                                                    payload,
-                                                                    n);
-                                                          } else {
-                                                            requestFrame =
-                                                                Frame.PayloadFrame.from(
-                                                                    streamId, FrameType.NEXT, payload);
-                                                          }
-                                                          payload.release();
-                                                          return requestFrame;
-                                                        })
-                                                    .doOnComplete(
-                                                        () -> {
-                                                          if (contains(streamId) && !receiver.isDisposed()) {
-                                                            sendProcessor.onNext(
-                                                                Frame.PayloadFrame.from(
-                                                                    streamId, FrameType.COMPLETE));
-                                                          }
-                                                          if (firstPayload.get()) {
-                                                            receiver.onComplete();
-                                                          }
-                                                        });
-                              
-                                            requestFrames.subscribe(
-                                                sendProcessor::onNext,
-                                                t -> {
-                                                  errorConsumer.accept(t);
-                                                  receiver.dispose();
-                                                });
-                                          } else {
-                                            if (contains(streamId) && !receiver.isDisposed()) {
-                                              sendProcessor.onNext(Frame.RequestN.from(streamId, n));
+        .active()
+        .thenMany(
+            Flux.defer(
+                () -> {
+                  final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
+                  final int streamId = streamIdSupplier.nextStreamId();
+                  final AtomicBoolean firstRequest = new AtomicBoolean(true);
+
+                  return receiver
+                      .doOnRequest(
+                          n -> {
+                            if (firstRequest.compareAndSet(true, false)) {
+                              final AtomicBoolean firstPayload = new AtomicBoolean(true);
+                              final Flux<Frame> requestFrames =
+                                  request
+                                      .transform(
+                                          f -> {
+                                            LimitableRequestPublisher<Payload> wrapped =
+                                                LimitableRequestPublisher.wrap(f);
+                                            // Need to set this to one for first the frame
+                                            wrapped.increaseRequestLimit(1);
+                                            senders.put(streamId, wrapped);
+                                            receivers.put(streamId, receiver);
+
+                                            return wrapped;
+                                          })
+                                      .map(
+                                          payload -> {
+                                            final Frame requestFrame;
+                                            if (firstPayload.compareAndSet(true, false)) {
+                                              requestFrame =
+                                                  Frame.Request.from(
+                                                      streamId,
+                                                      FrameType.REQUEST_CHANNEL,
+                                                      payload,
+                                                      n);
+                                            } else {
+                                              requestFrame =
+                                                  Frame.PayloadFrame.from(
+                                                      streamId, FrameType.NEXT, payload);
                                             }
-                                          }
-                                        })
-                                    .doOnError(
-                                        t -> {
-                                          if (contains(streamId) && !receiver.isDisposed()) {
-                                            sendProcessor.onNext(Frame.Error.from(streamId, t));
-                                          }
-                                        })
-                                    .doOnCancel(
-                                        () -> {
-                                          if (contains(streamId) && !receiver.isDisposed()) {
-                                            sendProcessor.onNext(Frame.Cancel.from(streamId));
-                                          }
-                                        })
-                                    .doFinally(
-                                        s -> {
-                                          receivers.remove(streamId);
-                                          LimitableRequestPublisher sender = senders.remove(streamId);
-                                          if (sender != null) {
-                                            sender.cancel();
-                                          }
-                                        });
-                       }));
+                                            payload.release();
+                                            return requestFrame;
+                                          })
+                                      .doOnComplete(
+                                          () -> {
+                                            if (contains(streamId) && !receiver.isDisposed()) {
+                                              sendProcessor.onNext(
+                                                  Frame.PayloadFrame.from(
+                                                      streamId, FrameType.COMPLETE));
+                                            }
+                                            if (firstPayload.get()) {
+                                              receiver.onComplete();
+                                            }
+                                          });
+
+                              requestFrames.subscribe(
+                                  sendProcessor::onNext,
+                                  t -> {
+                                    errorConsumer.accept(t);
+                                    receiver.dispose();
+                                  });
+                            } else {
+                              if (contains(streamId) && !receiver.isDisposed()) {
+                                sendProcessor.onNext(Frame.RequestN.from(streamId, n));
+                              }
+                            }
+                          })
+                      .doOnError(
+                          t -> {
+                            if (contains(streamId) && !receiver.isDisposed()) {
+                              sendProcessor.onNext(Frame.Error.from(streamId, t));
+                            }
+                          })
+                      .doOnCancel(
+                          () -> {
+                            if (contains(streamId) && !receiver.isDisposed()) {
+                              sendProcessor.onNext(Frame.Cancel.from(streamId));
+                            }
+                          })
+                      .doFinally(
+                          s -> {
+                            receivers.remove(streamId);
+                            LimitableRequestPublisher sender = senders.remove(streamId);
+                            if (sender != null) {
+                              sender.cancel();
+                            }
+                          });
+                }));
   }
-  
+
   private Mono<Void> handleMetadataPush(Payload payload) {
     return lifecycle
-               .active()
-               .then(
-                   Mono.fromRunnable(
-                       () -> {
-                         final Frame requestFrame =
-                             Frame.Request.from(0, FrameType.METADATA_PUSH, payload, 1);
-                         payload.release();
-                         sendProcessor.onNext(requestFrame);
-                       }));
+        .active()
+        .then(
+            Mono.fromRunnable(
+                () -> {
+                  final Frame requestFrame =
+                      Frame.Request.from(0, FrameType.METADATA_PUSH, payload, 1);
+                  payload.release();
+                  sendProcessor.onNext(requestFrame);
+                }));
   }
-  
+
   private boolean contains(int streamId) {
     return receivers.containsKey(streamId);
   }
-  
+
   protected void terminate() {
-    
     lifecycle.setTerminationError(new ClosedChannelException());
-    
+
     if (keepAliveHandler != null) {
       keepAliveHandler.dispose();
     }
     try {
-      for (Processor<Payload, Payload> subscriber : receivers.values()) {
-        cleanUpSubscriber(subscriber);
-      }
-      for (LimitableRequestPublisher p : senders.values()) {
-        cleanUpLimitableRequestPublisher(p);
-      }
+      receivers.values().forEach(this::cleanUpSubscriber);
+      senders.values().forEach(this::cleanUpLimitableRequestPublisher);
     } finally {
       senders.clear();
       receivers.clear();
       sendProcessor.dispose();
     }
   }
-  
+
   private synchronized void cleanUpLimitableRequestPublisher(
       LimitableRequestPublisher<?> limitableRequestPublisher) {
     try {
@@ -417,7 +408,7 @@ class RSocketClient implements RSocket {
       errorConsumer.accept(t);
     }
   }
-  
+
   private synchronized void cleanUpSubscriber(Processor subscriber) {
     try {
       subscriber.onError(lifecycle.getTerminationError());
@@ -425,7 +416,7 @@ class RSocketClient implements RSocket {
       errorConsumer.accept(t);
     }
   }
-  
+
   private void handleIncomingFrames(Frame frame) {
     try {
       int streamId = frame.getStreamId();
@@ -439,7 +430,7 @@ class RSocketClient implements RSocket {
       frame.release();
     }
   }
-  
+
   private void handleStreamZero(FrameType type, Frame frame) {
     switch (type) {
       case ERROR:
@@ -462,7 +453,7 @@ class RSocketClient implements RSocket {
                 "Client received supported frame on stream 0: " + frame.toString()));
     }
   }
-  
+
   private void handleFrame(int streamId, FrameType type, Frame frame) {
     Subscriber<Payload> receiver = receivers.get(streamId);
     if (receiver == null) {
@@ -509,14 +500,14 @@ class RSocketClient implements RSocket {
       }
     }
   }
-  
+
   private void handleMissingResponseProcessor(int streamId, FrameType type, Frame frame) {
     if (!streamIdSupplier.isBeforeOrCurrent(streamId)) {
       if (type == FrameType.ERROR) {
         // message for stream that has never existed, we have a problem with
         // the overall connection and must tear down
         String errorMessage = frame.getDataUtf8();
-        
+
         throw new IllegalStateException(
             "Client received error for non-existent stream: "
                 + streamId
@@ -533,14 +524,14 @@ class RSocketClient implements RSocket {
     // receiving a frame after a given stream has been cancelled/completed,
     // so ignore (cancellation is async so there is a race condition)
   }
-  
+
   private static class Lifecycle {
-    
+
     private static final AtomicReferenceFieldUpdater<Lifecycle, Throwable> TERMINATION_ERROR =
         AtomicReferenceFieldUpdater.newUpdater(
             Lifecycle.class, Throwable.class, "terminationError");
     private volatile Throwable terminationError;
-    
+
     public Mono<Void> active() {
       return Mono.create(
           sink -> {
@@ -551,11 +542,11 @@ class RSocketClient implements RSocket {
             }
           });
     }
-    
+
     public void setTerminationError(Throwable err) {
       TERMINATION_ERROR.compareAndSet(this, null, err);
     }
-    
+
     public Throwable getTerminationError() {
       return terminationError;
     }


### PR DESCRIPTION
I encountered a null pointer exception inside RSocketClient::cleanUpSubscriber because subscriber was null. The only way this could happen is if the receivers map is modified while it is being iterated over. The solution is to use the forEach method instead of iterator, which is properly synchronized.