### PR TITLE
Restore logging message. Fixes #559.

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
@@ -100,7 +100,7 @@ public class ClientServerInputMultiplexer implements Closeable {
               }
             },
             t -> {
-              LOGGER.error("test", t);
+              LOGGER.error("Error receiving frame:", t);
               dispose();
             });
   }


### PR DESCRIPTION
https://github.com/rsocket/rsocket-java/pull/467/files#diff-e9943f246be37dc1abf9a2821d305580R103

This change seems to be invalid and should be reverted