### PR TITLE
fixes issue with requestChannel never completes if server cancels (#592)

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -471,7 +471,6 @@ class RSocketClient implements RSocket {
         case CANCEL:
         {
           LimitableRequestPublisher sender = senders.remove(streamId);
-          receivers.remove(streamId);
           if (sender != null) {
             sender.cancel();
           }


### PR DESCRIPTION
This PR fixes #592 for 1.0.x brunch

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>