### PR TITLE
fixes uncontrolled data sending in case of direct propagation of request from requester

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -100,7 +100,11 @@ class RSocketClient implements RSocket {
     connection
         .send(
             sendProcessor.doOnRequest(
-                r -> senders.forEach((__, lrp) -> lrp.increaseInternalLimit(r))))
+                r -> {
+                  for (LimitableRequestPublisher lrp : senders.values()) {
+                    lrp.increaseInternalLimit(r);
+                  }
+                }))
         .doFinally(this::handleSendProcessorCancel)
         .subscribe(null, this::handleSendProcessorError);
 

--- a/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
@@ -94,15 +94,15 @@ class RSocketServer implements ResponderRSocket {
     connection
         .send(
             sendProcessor.doOnRequest(
-                r ->
-                    sendingSubscriptions.forEach(
-                        (__, s) -> {
-                          if (s instanceof LimitableRequestPublisher) {
-                            LimitableRequestPublisher lrp = (LimitableRequestPublisher) s;
+                r -> {
+                  for (Subscription s : sendingSubscriptions.values()) {
+                    if (s instanceof LimitableRequestPublisher) {
+                      LimitableRequestPublisher lrp = (LimitableRequestPublisher) s;
 
-                            lrp.increaseInternalLimit(r);
-                          }
-                        })))
+                      lrp.increaseInternalLimit(r);
+                    }
+                  }
+                }))
         .doFinally(this::handleSendProcessorCancel)
         .subscribe(null, this::handleSendProcessorError);
 

--- a/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
@@ -49,6 +49,7 @@ class RSocketServer implements ResponderRSocket {
   private final PayloadDecoder payloadDecoder;
   private final Consumer<Throwable> errorConsumer;
 
+  private final Map<Integer, LimitableRequestPublisher> sendingLimitableSubscriptions;
   private final Map<Integer, Subscription> sendingSubscriptions;
   private final Map<Integer, Processor<Payload, Payload>> channelProcessors;
 
@@ -84,6 +85,7 @@ class RSocketServer implements ResponderRSocket {
 
     this.payloadDecoder = payloadDecoder;
     this.errorConsumer = errorConsumer;
+    this.sendingLimitableSubscriptions = Collections.synchronizedMap(new IntObjectHashMap<>());
     this.sendingSubscriptions = Collections.synchronizedMap(new IntObjectHashMap<>());
     this.channelProcessors = Collections.synchronizedMap(new IntObjectHashMap<>());
 
@@ -95,12 +97,8 @@ class RSocketServer implements ResponderRSocket {
         .send(
             sendProcessor.doOnRequest(
                 r -> {
-                  for (Subscription s : sendingSubscriptions.values()) {
-                    if (s instanceof LimitableRequestPublisher) {
-                      LimitableRequestPublisher lrp = (LimitableRequestPublisher) s;
-
-                      lrp.increaseInternalLimit(r);
-                    }
+                  for (LimitableRequestPublisher lrp : sendingLimitableSubscriptions.values()) {
+                    lrp.increaseInternalLimit(r);
                   }
                 }))
         .doFinally(this::handleSendProcessorCancel)
@@ -148,6 +146,17 @@ class RSocketServer implements ResponderRSocket {
               }
             });
 
+    sendingLimitableSubscriptions
+        .values()
+        .forEach(
+            subscription -> {
+              try {
+                subscription.cancel();
+              } catch (Throwable e) {
+                errorConsumer.accept(e);
+              }
+            });
+
     channelProcessors
         .values()
         .forEach(
@@ -166,6 +175,17 @@ class RSocketServer implements ResponderRSocket {
     }
 
     sendingSubscriptions
+        .values()
+        .forEach(
+            subscription -> {
+              try {
+                subscription.cancel();
+              } catch (Throwable e) {
+                errorConsumer.accept(e);
+              }
+            });
+
+    sendingLimitableSubscriptions
         .values()
         .forEach(
             subscription -> {
@@ -271,6 +291,9 @@ class RSocketServer implements ResponderRSocket {
   private synchronized void cleanUpSendingSubscriptions() {
     sendingSubscriptions.values().forEach(Subscription::cancel);
     sendingSubscriptions.clear();
+
+    sendingLimitableSubscriptions.values().forEach(Subscription::cancel);
+    sendingLimitableSubscriptions.clear();
   }
 
   private synchronized void cleanUpChannelProcessors() {
@@ -402,11 +425,11 @@ class RSocketServer implements ResponderRSocket {
             frameFlux -> {
               LimitableRequestPublisher<Payload> payloads =
                   LimitableRequestPublisher.wrap(frameFlux, sendProcessor.available());
-              sendingSubscriptions.put(streamId, payloads);
+              sendingLimitableSubscriptions.put(streamId, payloads);
               payloads.increaseRequestLimit(initialRequestN);
               return payloads;
             })
-        .doFinally(signalType -> sendingSubscriptions.remove(streamId))
+        .doFinally(signalType -> sendingLimitableSubscriptions.remove(streamId))
         .subscribe(
             payload -> {
               ByteBuf byteBuf = null;
@@ -459,6 +482,11 @@ class RSocketServer implements ResponderRSocket {
 
   private void handleCancelFrame(int streamId) {
     Subscription subscription = sendingSubscriptions.remove(streamId);
+
+    if (subscription == null) {
+      subscription = sendingLimitableSubscriptions.get(streamId);
+    }
+
     if (subscription != null) {
       subscription.cancel();
     }
@@ -470,7 +498,12 @@ class RSocketServer implements ResponderRSocket {
   }
 
   private void handleRequestN(int streamId, ByteBuf frame) {
-    final Subscription subscription = sendingSubscriptions.get(streamId);
+    Subscription subscription = sendingSubscriptions.get(streamId);
+
+    if (subscription == null) {
+      subscription = sendingLimitableSubscriptions.get(streamId);
+    }
+
     if (subscription != null) {
       int n = RequestNFrameFlyweight.requestN(frame);
       subscription.request(n >= Integer.MAX_VALUE ? Long.MAX_VALUE : n);

--- a/rsocket-core/src/main/java/io/rsocket/internal/LimitableRequestPublisher.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/LimitableRequestPublisher.java
@@ -31,6 +31,8 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
 
   private final AtomicBoolean canceled;
 
+  private final long prefetch;
+
   private long internalRequested;
 
   private long externalRequested;
@@ -39,13 +41,14 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
 
   private volatile @Nullable Subscription internalSubscription;
 
-  private LimitableRequestPublisher(Publisher<T> source) {
+  private LimitableRequestPublisher(Publisher<T> source, long prefetch) {
     this.source = source;
+    this.prefetch = prefetch;
     this.canceled = new AtomicBoolean();
   }
 
-  public static <T> LimitableRequestPublisher<T> wrap(Publisher<T> source) {
-    return new LimitableRequestPublisher<>(source);
+  public static <T> LimitableRequestPublisher<T> wrap(Publisher<T> source, long prefetch) {
+    return new LimitableRequestPublisher<>(source, prefetch);
   }
 
   @Override
@@ -60,11 +63,20 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
 
     destination.onSubscribe(new InnerSubscription());
     source.subscribe(new InnerSubscriber(destination));
+    increaseInternalLimit(prefetch);
   }
 
   public void increaseRequestLimit(long n) {
     synchronized (this) {
       externalRequested = Operators.addCap(n, externalRequested);
+    }
+
+    requestN();
+  }
+
+  public void increaseInternalLimit(long n) {
+    synchronized (this) {
+      internalRequested = Operators.addCap(n, internalRequested);
     }
 
     requestN();
@@ -82,9 +94,17 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
         return;
       }
 
-      r = Math.min(internalRequested, externalRequested);
-      externalRequested -= r;
-      internalRequested -= r;
+      if (externalRequested != Long.MAX_VALUE || internalRequested != Long.MAX_VALUE) {
+        r = Math.min(internalRequested, externalRequested);
+        if (externalRequested != Long.MAX_VALUE) {
+          externalRequested -= r;
+        }
+        if (internalRequested != Long.MAX_VALUE) {
+          internalRequested -= r;
+        }
+      } else {
+        r = Long.MAX_VALUE;
+      }
     }
 
     if (r > 0) {
@@ -144,13 +164,7 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
 
   private class InnerSubscription implements Subscription {
     @Override
-    public void request(long n) {
-      synchronized (LimitableRequestPublisher.this) {
-        internalRequested = Operators.addCap(n, internalRequested);
-      }
-
-      requestN();
-    }
+    public void request(long n) {}
 
     @Override
     public void cancel() {

--- a/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java
@@ -221,6 +221,10 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
     }
   }
 
+  public long available() {
+    return requested;
+  }
+
   @Override
   public int getPrefetch() {
     return Integer.MAX_VALUE;

--- a/rsocket-core/src/test/java/io/rsocket/RSocketClientTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketClientTest.java
@@ -219,7 +219,7 @@ public class RSocketClientTest {
     Assertions.assertThat(request.isDisposed()).isTrue();
   }
 
-  @Test(timeout = 2_000900)
+  @Test(timeout = 2_000)
   @SuppressWarnings("unchecked")
   public void
       testClientSideRequestChannelShouldNotHangInfinitelySendingElementsAndShouldProduceDataValuingConnectionBackpressure() {

--- a/rsocket-core/src/test/java/io/rsocket/RSocketClientTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketClientTest.java
@@ -28,12 +28,15 @@ import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.exceptions.ApplicationErrorException;
 import io.rsocket.exceptions.RejectedSetupException;
 import io.rsocket.frame.*;
+import io.rsocket.test.util.TestDuplexConnection;
 import io.rsocket.test.util.TestSubscriber;
 import io.rsocket.util.DefaultPayload;
 import io.rsocket.util.EmptyPayload;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
@@ -214,6 +217,32 @@ public class RSocketClientTest {
         .blockFirst();
 
     Assertions.assertThat(request.isDisposed()).isTrue();
+  }
+
+  @Test(timeout = 2_000900)
+  @SuppressWarnings("unchecked")
+  public void
+      testClientSideRequestChannelShouldNotHangInfinitelySendingElementsAndShouldProduceDataValuingConnectionBackpressure() {
+    final Queue<Long> requests = new ConcurrentLinkedQueue<>();
+    rule.connection.dispose();
+    rule.connection = new TestDuplexConnection();
+    rule.connection.setInitialSendRequestN(256);
+    rule.init();
+
+    rule.socket
+        .requestChannel(
+            Flux.<Payload>generate(s -> s.next(EmptyPayload.INSTANCE)).doOnRequest(requests::add))
+        .subscribe();
+
+    int streamId = rule.getStreamIdForRequestType(REQUEST_CHANNEL);
+
+    assertThat("Unexpected error.", rule.errors, is(empty()));
+
+    rule.connection.addToReceivedBuffer(
+        RequestNFrameFlyweight.encode(ByteBufAllocator.DEFAULT, streamId, 2));
+    rule.connection.addToReceivedBuffer(
+        RequestNFrameFlyweight.encode(ByteBufAllocator.DEFAULT, streamId, Integer.MAX_VALUE));
+    Assertions.assertThat(requests).containsOnly(1L, 2L, 253L);
   }
 
   public int sendRequestResponse(Publisher<Payload> response) {

--- a/rsocket-examples/src/test/java/io/rsocket/integration/TcpIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/TcpIntegrationTest.java
@@ -67,7 +67,7 @@ public class TcpIntegrationTest {
     server.dispose();
   }
 
-  @Test(timeout = 5_000L)
+  @Test(timeout = 15_000L)
   public void testCompleteWithoutNext() {
     handler =
         new AbstractRSocket() {
@@ -83,7 +83,7 @@ public class TcpIntegrationTest {
     assertFalse(hasElements);
   }
 
-  @Test(timeout = 5_000L)
+  @Test(timeout = 15_000L)
   public void testSingleStream() {
     handler =
         new AbstractRSocket() {
@@ -100,7 +100,7 @@ public class TcpIntegrationTest {
     assertEquals("RESPONSE", result.getDataUtf8());
   }
 
-  @Test(timeout = 5_000L)
+  @Test(timeout = 15_000L)
   public void testZeroPayload() {
     handler =
         new AbstractRSocket() {
@@ -117,7 +117,7 @@ public class TcpIntegrationTest {
     assertEquals("", result.getDataUtf8());
   }
 
-  @Test(timeout = 5_000L)
+  @Test(timeout = 15_000L)
   public void testRequestResponseErrors() {
     handler =
         new AbstractRSocket() {
@@ -151,7 +151,7 @@ public class TcpIntegrationTest {
     assertEquals("SUCCESS", response2.getDataUtf8());
   }
 
-  @Test(timeout = 5_000L)
+  @Test(timeout = 15_000L)
   public void testTwoConcurrentStreams() throws InterruptedException {
     ConcurrentHashMap<String, UnicastProcessor<Payload>> map = new ConcurrentHashMap<>();
     UnicastProcessor<Payload> processor1 = UnicastProcessor.create();


### PR DESCRIPTION
This PR provide a partial fix for #514 and reintroduce usage of `LimitableRequestPublisher` as of its initial design.

At a moment all connected `LimitableRequestPublisher` receives the same request size as from the connection. It means that upstream still an overflow UnboundProcessor but with less probability (it can happen in case we have super many requestChannel/requestStream connections which infinitely send data)

In the future PRs we have to revise the implementation of UnboundedProcessor in order to have proper guarantees on overflow prevention.

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>