### PR TITLE
General performance improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.7.1' apply false
     id 'com.jfrog.artifactory' version '4.7.3' apply false
     id 'com.jfrog.bintray' version '1.8.4' apply false
-    id 'me.champeau.gradle.jmh' version '0.4.7' apply false
-    id 'io.spring.dependency-management' version '1.0.6.RELEASE' apply false
+    id 'me.champeau.gradle.jmh' version '0.4.8' apply false
+    id 'io.spring.dependency-management' version '1.0.7.RELEASE' apply false
     id 'io.morethan.jmhreport' version '0.9.0' apply false
 }
 

--- a/rsocket-core/jmh.gradle
+++ b/rsocket-core/jmh.gradle
@@ -19,6 +19,8 @@ dependencies {
     jmh configurations.implementation
     jmh 'org.openjdk.jmh:jmh-core'
     jmh 'org.openjdk.jmh:jmh-generator-annprocess'
+    jmh 'io.projectreactor:reactor-test'
+    jmh project(':rsocket-transport-local')
 }
 
 jmhCompileGeneratedClasses.enabled = false

--- a/rsocket-core/src/jmh/java/io/rsocket/MaxPerfSubscriber.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/MaxPerfSubscriber.java
@@ -1,0 +1,38 @@
+package io.rsocket;
+
+import java.util.concurrent.CountDownLatch;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+
+public class MaxPerfSubscriber implements CoreSubscriber<Payload> {
+
+  final CountDownLatch latch = new CountDownLatch(1);
+  final Blackhole blackhole;
+
+  public MaxPerfSubscriber(Blackhole blackhole) {
+    this.blackhole = blackhole;
+  }
+
+  @Override
+  public void onSubscribe(Subscription s) {
+    s.request(Long.MAX_VALUE);
+  }
+
+  @Override
+  public void onNext(Payload payload) {
+    payload.release();
+    blackhole.consume(payload);
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    blackhole.consume(t);
+    latch.countDown();
+  }
+
+  @Override
+  public void onComplete() {
+    latch.countDown();
+  }
+}

--- a/rsocket-core/src/jmh/java/io/rsocket/PerfSubscriber.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/PerfSubscriber.java
@@ -1,0 +1,42 @@
+package io.rsocket;
+
+import java.util.concurrent.CountDownLatch;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+
+public class PerfSubscriber implements CoreSubscriber<Payload> {
+
+  final CountDownLatch latch = new CountDownLatch(1);
+  final Blackhole blackhole;
+
+  Subscription s;
+
+  public PerfSubscriber(Blackhole blackhole) {
+    this.blackhole = blackhole;
+  }
+
+  @Override
+  public void onSubscribe(Subscription s) {
+    this.s = s;
+    s.request(1);
+  }
+
+  @Override
+  public void onNext(Payload payload) {
+    payload.release();
+    blackhole.consume(payload);
+    s.request(1);
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    blackhole.consume(t);
+    latch.countDown();
+  }
+
+  @Override
+  public void onComplete() {
+    latch.countDown();
+  }
+}

--- a/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
@@ -22,7 +22,7 @@ import reactor.core.publisher.Mono;
 
 @BenchmarkMode(Mode.Throughput)
 @Fork(
-    value = 1 // , jvmArgsAppend = {"-Dio.netty.leakDetection.level=paranoid"}
+    value = 1 , jvmArgsAppend = {"-Dio.netty.leakDetection.level=advanced"}
     )
 @Warmup(iterations = 10)
 @Measurement(iterations = 10, time = 10)
@@ -38,7 +38,7 @@ public class RSocketPerf {
   Closeable server;
 
   @Setup
-  public void setUp(Blackhole blackhole) {
+  public void setUp() {
     server =
         RSocketFactory.receive()
             .acceptor(
@@ -49,8 +49,6 @@ public class RSocketPerf {
                           @Override
                           public Mono<Void> fireAndForget(Payload payload) {
                             payload.release();
-                            blackhole.consume(payload);
-
                             return Mono.empty();
                           }
 

--- a/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
@@ -22,7 +22,7 @@ import reactor.core.publisher.Mono;
 
 @BenchmarkMode(Mode.Throughput)
 @Fork(
-    value = 1 , jvmArgsAppend = {"-Dio.netty.leakDetection.level=advanced"}
+    value = 1 //, jvmArgsAppend = {"-Dio.netty.leakDetection.level=advanced"}
     )
 @Warmup(iterations = 10)
 @Measurement(iterations = 10, time = 10)

--- a/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
@@ -1,0 +1,144 @@
+package io.rsocket;
+
+import io.rsocket.frame.decoder.PayloadDecoder;
+import io.rsocket.transport.local.LocalClientTransport;
+import io.rsocket.transport.local.LocalServerTransport;
+import io.rsocket.util.EmptyPayload;
+import java.util.stream.IntStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@BenchmarkMode(Mode.Throughput)
+@Fork(
+    value = 1 // , jvmArgsAppend = {"-Dio.netty.leakDetection.level=paranoid"}
+    )
+@Warmup(iterations = 10)
+@Measurement(iterations = 10, time = 10)
+@State(Scope.Benchmark)
+public class RSocketPerf {
+
+  static final Payload PAYLOAD = EmptyPayload.INSTANCE;
+  static final Mono<Payload> PAYLOAD_MONO = Mono.just(PAYLOAD);
+  static final Flux<Payload> PAYLOAD_FLUX =
+      Flux.fromArray(IntStream.range(0, 100000).mapToObj(__ -> PAYLOAD).toArray(Payload[]::new));
+
+  RSocket client;
+  Closeable server;
+
+  @Setup
+  public void setUp(Blackhole blackhole) {
+    server =
+        RSocketFactory.receive()
+            .acceptor(
+                (setup, sendingSocket) ->
+                    Mono.just(
+                        new AbstractRSocket() {
+
+                          @Override
+                          public Mono<Void> fireAndForget(Payload payload) {
+                            payload.release();
+                            blackhole.consume(payload);
+
+                            return Mono.empty();
+                          }
+
+                          @Override
+                          public Mono<Payload> requestResponse(Payload payload) {
+                            payload.release();
+                            return PAYLOAD_MONO;
+                          }
+
+                          @Override
+                          public Flux<Payload> requestStream(Payload payload) {
+                            payload.release();
+                            return PAYLOAD_FLUX;
+                          }
+
+                          @Override
+                          public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+                            return Flux.from(payloads);
+                          }
+                        }))
+            .transport(LocalServerTransport.create("server"))
+            .start()
+            .block();
+
+    client =
+        RSocketFactory.connect()
+            .frameDecoder(PayloadDecoder.ZERO_COPY)
+            .transport(LocalClientTransport.create("server"))
+            .start()
+            .block();
+  }
+
+  @Benchmark
+  @SuppressWarnings("unchecked")
+  public PerfSubscriber fireAndForget(Blackhole blackhole) throws InterruptedException {
+    PerfSubscriber subscriber = new PerfSubscriber(blackhole);
+    client.fireAndForget(PAYLOAD).subscribe((CoreSubscriber) subscriber);
+    subscriber.latch.await();
+
+    return subscriber;
+  }
+
+  @Benchmark
+  public PerfSubscriber requestResponse(Blackhole blackhole) throws InterruptedException {
+    PerfSubscriber subscriber = new PerfSubscriber(blackhole);
+    client.requestResponse(PAYLOAD).subscribe(subscriber);
+    subscriber.latch.await();
+
+    return subscriber;
+  }
+
+  @Benchmark
+  public PerfSubscriber requestStreamWithRequestByOneStrategy(Blackhole blackhole)
+      throws InterruptedException {
+    PerfSubscriber subscriber = new PerfSubscriber(blackhole);
+    client.requestStream(PAYLOAD).subscribe(subscriber);
+    subscriber.latch.await();
+
+    return subscriber;
+  }
+
+  @Benchmark
+  public MaxPerfSubscriber requestStreamWithRequestAllStrategy(Blackhole blackhole)
+      throws InterruptedException {
+    MaxPerfSubscriber subscriber = new MaxPerfSubscriber(blackhole);
+    client.requestStream(PAYLOAD).subscribe(subscriber);
+    subscriber.latch.await();
+
+    return subscriber;
+  }
+
+  @Benchmark
+  public PerfSubscriber requestChannelWithRequestByOneStrategy(Blackhole blackhole)
+      throws InterruptedException {
+    PerfSubscriber subscriber = new PerfSubscriber(blackhole);
+    client.requestChannel(PAYLOAD_FLUX).subscribe(subscriber);
+    subscriber.latch.await();
+
+    return subscriber;
+  }
+
+  @Benchmark
+  public MaxPerfSubscriber requestChannelWithRequestAllStrategy(Blackhole blackhole)
+      throws InterruptedException {
+    MaxPerfSubscriber subscriber = new MaxPerfSubscriber(blackhole);
+    client.requestChannel(PAYLOAD_FLUX).subscribe(subscriber);
+    subscriber.latch.await();
+
+    return subscriber;
+  }
+}

--- a/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
@@ -22,10 +22,10 @@ import reactor.core.publisher.Mono;
 
 @BenchmarkMode(Mode.Throughput)
 @Fork(
-    value = 1 //, jvmArgsAppend = {"-Dio.netty.leakDetection.level=advanced"}
+    value = 1 // , jvmArgsAppend = {"-Dio.netty.leakDetection.level=advanced"}
     )
 @Warmup(iterations = 10)
-@Measurement(iterations = 10, time = 10)
+@Measurement(iterations = 10, time = 20)
 @State(Scope.Benchmark)
 public class RSocketPerf {
 

--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -41,7 +41,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 import reactor.core.publisher.UnicastProcessor;
-import reactor.util.concurrent.Queues;
 
 /** Client Side of a RSocket socket. Sends {@link ByteBuf}s to a {@link RSocketServer} */
 class RSocketClient implements RSocket {
@@ -226,8 +225,7 @@ class RSocketClient implements RSocket {
           int streamId = streamIdSupplier.nextStreamId();
 
           final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
-          final UnicastProcessor<Payload> receiver =
-              UnicastProcessor.create(Queues.<Payload>one().get());
+          final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
 
           receivers.put(streamId, receiver);
 
@@ -277,8 +275,7 @@ class RSocketClient implements RSocket {
     return lifecycle.activeFlux(
         () -> {
           final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
-          final UnicastProcessor<Payload> receiver =
-              UnicastProcessor.create(Queues.<Payload>one().get());
+          final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
           final int streamId = streamIdSupplier.nextStreamId();
 
           return receiver

--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -29,16 +29,19 @@ import io.rsocket.internal.UnicastMonoProcessor;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
+import java.util.function.Supplier;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
+import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 import reactor.core.publisher.UnicastProcessor;
+import reactor.util.concurrent.Queues;
 
 /** Client Side of a RSocket socket. Sends {@link ByteBuf}s to a {@link RSocketServer} */
 class RSocketClient implements RSocket {
@@ -73,14 +76,14 @@ class RSocketClient implements RSocket {
 
     connection.onClose().doFinally(signalType -> terminate()).subscribe(null, errorConsumer);
 
-    connection
-        .send(
-            sendProcessor.doOnRequest(
-                r -> {
-                  for (LimitableRequestPublisher lrp : senders.values()) {
-                    lrp.increaseInternalLimit(r);
-                  }
-                }))
+    sendProcessor
+        .doOnRequest(
+            r -> {
+              for (LimitableRequestPublisher lrp : senders.values()) {
+                lrp.increaseInternalLimit(r);
+              }
+            })
+        .transform(connection::send)
         .doFinally(this::handleSendProcessorCancel)
         .subscribe(null, this::handleSendProcessorError);
 
@@ -169,223 +172,226 @@ class RSocketClient implements RSocket {
   }
 
   private Mono<Void> handleFireAndForget(Payload payload) {
-    return lifecycle
-        .active()
-        .then(
-            Mono.fromRunnable(
-                () -> {
-                  final int streamId = streamIdSupplier.nextStreamId();
-                  ByteBuf requestFrame =
-                      RequestFireAndForgetFrameFlyweight.encode(
-                          allocator,
-                          streamId,
-                          false,
-                          payload.hasMetadata() ? payload.sliceMetadata().retain() : null,
-                          payload.sliceData().retain());
-                  payload.release();
-                  sendProcessor.onNext(requestFrame);
-                }));
-  }
-
-  private Flux<Payload> handleRequestStream(final Payload payload) {
-    return lifecycle
-        .active()
-        .thenMany(
-            Flux.defer(
-                () -> {
-                  int streamId = streamIdSupplier.nextStreamId();
-
-                  UnicastProcessor<Payload> receiver = UnicastProcessor.create();
-                  receivers.put(streamId, receiver);
-
-                  AtomicBoolean first = new AtomicBoolean(false);
-
-                  return receiver
-                      .doOnRequest(
-                          n -> {
-                            if (first.compareAndSet(false, true) && !receiver.isDisposed()) {
-                              sendProcessor.onNext(
-                                  RequestStreamFrameFlyweight.encode(
-                                      allocator,
-                                      streamId,
-                                      false,
-                                      n,
-                                      payload.sliceMetadata().retain(),
-                                      payload.sliceData().retain()));
-                            } else if (contains(streamId) && !receiver.isDisposed()) {
-                              sendProcessor.onNext(
-                                  RequestNFrameFlyweight.encode(allocator, streamId, n));
-                            }
-                            sendProcessor.drain();
-                          })
-                      .doOnError(
-                          t -> {
-                            if (contains(streamId) && !receiver.isDisposed()) {
-                              sendProcessor.onNext(
-                                  ErrorFrameFlyweight.encode(allocator, streamId, t));
-                            }
-                          })
-                      .doOnCancel(
-                          () -> {
-                            if (contains(streamId) && !receiver.isDisposed()) {
-                              sendProcessor.onNext(
-                                  CancelFrameFlyweight.encode(allocator, streamId));
-                            }
-                          })
-                      .doFinally(
-                          s -> {
-                            receivers.remove(streamId);
-                          });
-                }));
+    return lifecycle.active(
+        () -> {
+          final int streamId = streamIdSupplier.nextStreamId();
+          ByteBuf requestFrame =
+              RequestFireAndForgetFrameFlyweight.encode(
+                  allocator,
+                  streamId,
+                  false,
+                  payload.hasMetadata() ? payload.sliceMetadata().retain() : null,
+                  payload.sliceData().retain());
+          payload.release();
+          sendProcessor.onNext(requestFrame);
+        });
   }
 
   private Mono<Payload> handleRequestResponse(final Payload payload) {
-    return lifecycle
-        .active()
-        .then(
-            Mono.defer(
-                () -> {
-                  int streamId = streamIdSupplier.nextStreamId();
-                  ByteBuf requestFrame =
-                      RequestResponseFrameFlyweight.encode(
-                          allocator,
-                          streamId,
-                          false,
-                          payload.sliceMetadata().retain(),
-                          payload.sliceData().retain());
-                  payload.release();
+    return lifecycle.activeMono(
+        () -> {
+          int streamId = streamIdSupplier.nextStreamId();
+          final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
+          final ByteBuf requestFrame =
+              RequestResponseFrameFlyweight.encode(
+                  allocator,
+                  streamId,
+                  false,
+                  payload.sliceMetadata().retain(),
+                  payload.sliceData().retain());
 
-                  UnicastMonoProcessor<Payload> receiver = UnicastMonoProcessor.create();
-                  receivers.put(streamId, receiver);
+          payload.release();
 
-                  sendProcessor.onNext(requestFrame);
-                  return receiver
-                      .doOnError(
-                          t ->
-                              sendProcessor.onNext(
-                                  ErrorFrameFlyweight.encode(allocator, streamId, t)))
-                      .doFinally(
-                          s -> {
-                            if (s == SignalType.CANCEL) {
-                              sendProcessor.onNext(
-                                  CancelFrameFlyweight.encode(allocator, streamId));
-                            }
+          UnicastMonoProcessor<Payload> receiver = UnicastMonoProcessor.create();
+          receivers.put(streamId, receiver);
 
-                            receivers.remove(streamId);
-                          });
-                }));
+          sendProcessor.onNext(requestFrame);
+          return receiver
+              .doOnError(
+                  t -> sendProcessor.onNext(ErrorFrameFlyweight.encode(allocator, streamId, t)))
+              .doFinally(
+                  s -> {
+                    if (s == SignalType.CANCEL) {
+                      sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
+                    }
+
+                    receivers.remove(streamId);
+                  });
+        });
+  }
+
+  private Flux<Payload> handleRequestStream(final Payload payload) {
+    return lifecycle.activeFlux(
+        () -> {
+          int streamId = streamIdSupplier.nextStreamId();
+
+          final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
+          final UnicastProcessor<Payload> receiver =
+              UnicastProcessor.create(Queues.<Payload>one().get());
+
+          receivers.put(streamId, receiver);
+
+          return receiver
+              .doOnRequest(
+                  new LongConsumer() {
+
+                    // No need to make it atomic; See
+                    // https://github.com/reactive-streams/reactive-streams-jvm#2.7
+                    boolean firstRequest = true;
+
+                    @Override
+                    public void accept(long n) {
+                      if (firstRequest && !receiver.isDisposed()) {
+                        firstRequest = false;
+                        sendProcessor.onNext(
+                            RequestStreamFrameFlyweight.encode(
+                                allocator,
+                                streamId,
+                                false,
+                                n,
+                                payload.sliceMetadata().retain(),
+                                payload.sliceData().retain()));
+                        payload.release();
+                      } else if (contains(streamId) && !receiver.isDisposed()) {
+                        sendProcessor.onNext(RequestNFrameFlyweight.encode(allocator, streamId, n));
+                      }
+                    }
+                  })
+              .doOnError(
+                  t -> {
+                    if (contains(streamId) && !receiver.isDisposed()) {
+                      sendProcessor.onNext(ErrorFrameFlyweight.encode(allocator, streamId, t));
+                    }
+                  })
+              .doOnCancel(
+                  () -> {
+                    if (contains(streamId) && !receiver.isDisposed()) {
+                      sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
+                    }
+                  })
+              .doFinally(s -> receivers.remove(streamId));
+        });
   }
 
   private Flux<Payload> handleChannel(Flux<Payload> request) {
-    return lifecycle
-        .active()
-        .thenMany(
-            Flux.defer(
-                () -> {
-                  final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
-                  final int streamId = streamIdSupplier.nextStreamId();
-                  final AtomicBoolean firstRequest = new AtomicBoolean(true);
+    return lifecycle.activeFlux(
+        () -> {
+          final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
+          final UnicastProcessor<Payload> receiver =
+              UnicastProcessor.create(Queues.<Payload>one().get());
+          final int streamId = streamIdSupplier.nextStreamId();
 
-                  return receiver
-                      .doOnRequest(
-                          n -> {
-                            if (firstRequest.compareAndSet(true, false)) {
-                              final AtomicBoolean firstPayload = new AtomicBoolean(true);
-                              final Flux<ByteBuf> requestFrames =
-                                  request
-                                      .transform(
-                                          f -> {
-                                            LimitableRequestPublisher<Payload> wrapped =
-                                                LimitableRequestPublisher.wrap(
-                                                    f, sendProcessor.available());
-                                            // Need to set this to one for first the frame
-                                            wrapped.increaseRequestLimit(1);
-                                            senders.put(streamId, wrapped);
-                                            receivers.put(streamId, receiver);
+          return receiver
+              .doOnRequest(
+                  new LongConsumer() {
 
-                                            return wrapped;
-                                          })
-                                      .map(
-                                          payload -> {
-                                            final ByteBuf requestFrame;
-                                            if (firstPayload.compareAndSet(true, false)) {
-                                              requestFrame =
-                                                  RequestChannelFrameFlyweight.encode(
-                                                      allocator,
-                                                      streamId,
-                                                      false,
-                                                      false,
-                                                      n,
-                                                      payload.sliceMetadata().retain(),
-                                                      payload.sliceData().retain());
-                                            } else {
-                                              requestFrame =
-                                                  PayloadFrameFlyweight.encode(
-                                                      allocator, streamId, false, false, true,
-                                                      payload);
-                                            }
-                                            return requestFrame;
-                                          })
-                                      .doOnComplete(
-                                          () -> {
-                                            if (contains(streamId) && !receiver.isDisposed()) {
-                                              sendProcessor.onNext(
-                                                  PayloadFrameFlyweight.encodeComplete(
-                                                      allocator, streamId));
-                                            }
-                                            if (firstPayload.get()) {
-                                              receiver.onComplete();
-                                            }
-                                          });
+                    // No need to make it atomic; See
+                    // https://github.com/reactive-streams/reactive-streams-jvm#2.7
+                    boolean firstRequest = true;
 
-                              requestFrames.subscribe(
-                                  sendProcessor::onNext,
-                                  t -> {
+                    @Override
+                    public void accept(long n) {
+                      if (firstRequest) {
+                        firstRequest = false;
+                        request
+                            .transform(
+                                f -> {
+                                  LimitableRequestPublisher<Payload> wrapped =
+                                      LimitableRequestPublisher.wrap(f, sendProcessor.available());
+                                  // Need to set this to one for first the frame
+                                  wrapped.request(1);
+                                  senders.put(streamId, wrapped);
+                                  receivers.put(streamId, receiver);
+
+                                  return wrapped;
+                                })
+                            .subscribe(
+                                new BaseSubscriber<Payload>() {
+
+                                  // no need to make it atomic; See
+                                  // https://github.com/reactive-streams/reactive-streams-jvm#1.3
+                                  boolean firstPayload = true;
+
+                                  @Override
+                                  protected void hookOnNext(Payload payload) {
+                                    final ByteBuf frame;
+
+                                    if (firstPayload) {
+                                      firstPayload = false;
+                                      frame =
+                                          RequestChannelFrameFlyweight.encode(
+                                              allocator,
+                                              streamId,
+                                              false,
+                                              false,
+                                              n,
+                                              payload.sliceMetadata().retain(),
+                                              payload.sliceData().retain());
+                                    } else {
+                                      frame =
+                                          PayloadFrameFlyweight.encode(
+                                              allocator, streamId, false, false, true, payload);
+                                    }
+
+                                    sendProcessor.onNext(frame);
+                                    payload.release();
+                                  }
+
+                                  @Override
+                                  protected void hookOnComplete() {
+                                    if (contains(streamId) && !receiver.isDisposed()) {
+                                      sendProcessor.onNext(
+                                          PayloadFrameFlyweight.encodeComplete(
+                                              allocator, streamId));
+                                    }
+                                    if (firstPayload) {
+                                      receiver.onComplete();
+                                    }
+                                  }
+
+                                  @Override
+                                  protected void hookOnError(Throwable t) {
                                     errorConsumer.accept(t);
                                     receiver.dispose();
-                                  });
-                            } else {
-                              if (contains(streamId) && !receiver.isDisposed()) {
-                                sendProcessor.onNext(
-                                    RequestNFrameFlyweight.encode(allocator, streamId, n));
-                              }
-                            }
-                          })
-                      .doOnError(
-                          t -> {
-                            if (contains(streamId) && !receiver.isDisposed()) {
-                              sendProcessor.onNext(
-                                  ErrorFrameFlyweight.encode(allocator, streamId, t));
-                            }
-                          })
-                      .doOnCancel(
-                          () -> {
-                            if (contains(streamId) && !receiver.isDisposed()) {
-                              sendProcessor.onNext(
-                                  CancelFrameFlyweight.encode(allocator, streamId));
-                            }
-                          })
-                      .doFinally(
-                          s -> {
-                            receivers.remove(streamId);
-                            LimitableRequestPublisher sender = senders.remove(streamId);
-                            if (sender != null) {
-                              sender.cancel();
-                            }
-                          });
-                }));
+                                  }
+                                });
+                      } else {
+                        if (contains(streamId) && !receiver.isDisposed()) {
+                          sendProcessor.onNext(
+                              RequestNFrameFlyweight.encode(allocator, streamId, n));
+                        }
+                      }
+                    }
+                  })
+              .doOnError(
+                  t -> {
+                    if (contains(streamId) && !receiver.isDisposed()) {
+                      sendProcessor.onNext(ErrorFrameFlyweight.encode(allocator, streamId, t));
+                    }
+                  })
+              .doOnCancel(
+                  () -> {
+                    if (contains(streamId) && !receiver.isDisposed()) {
+                      sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
+                    }
+                  })
+              .doFinally(
+                  s -> {
+                    receivers.remove(streamId);
+                    LimitableRequestPublisher sender = senders.remove(streamId);
+                    if (sender != null) {
+                      sender.cancel();
+                    }
+                  });
+        });
   }
 
   private Mono<Void> handleMetadataPush(Payload payload) {
-    return lifecycle
-        .active()
-        .then(
-            Mono.fromRunnable(
-                () -> {
-                  sendProcessor.onNext(
-                      MetadataPushFrameFlyweight.encode(
-                          allocator, payload.sliceMetadata().retain()));
-                }));
+    return lifecycle.active(
+        () -> {
+          sendProcessor.onNext(
+              MetadataPushFrameFlyweight.encode(allocator, payload.sliceMetadata().retain()));
+        });
   }
 
   private boolean contains(int streamId) {
@@ -490,8 +496,7 @@ class RSocketClient implements RSocket {
             LimitableRequestPublisher sender = senders.get(streamId);
             if (sender != null) {
               int n = RequestNFrameFlyweight.requestN(frame);
-              sender.increaseRequestLimit(n);
-              sendProcessor.drain();
+              sender.request(n >= Integer.MAX_VALUE ? Long.MAX_VALUE : n);
             }
             break;
           }
@@ -537,13 +542,36 @@ class RSocketClient implements RSocket {
             Lifecycle.class, Throwable.class, "terminationError");
     private volatile Throwable terminationError;
 
-    public Mono<Void> active() {
+    public Mono<Void> active(Runnable runnable) {
       return Mono.create(
           sink -> {
             if (terminationError == null) {
+              runnable.run();
               sink.success();
             } else {
               sink.error(terminationError);
+            }
+          });
+    }
+
+    public <T> Mono<T> activeMono(Supplier<? extends Mono<? extends T>> supplier) {
+      return Mono.defer(
+          () -> {
+            if (terminationError == null) {
+              return supplier.get();
+            } else {
+              return Mono.error(terminationError);
+            }
+          });
+    }
+
+    public <T> Flux<T> activeFlux(Supplier<? extends Flux<T>> supplier) {
+      return Flux.defer(
+          () -> {
+            if (terminationError == null) {
+              return supplier.get();
+            } else {
+              return Flux.error(terminationError);
             }
           });
     }

--- a/rsocket-core/src/main/java/io/rsocket/internal/LimitableRequestPublisher.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/LimitableRequestPublisher.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.internal;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -27,9 +27,15 @@ import reactor.core.publisher.Operators;
 
 /** */
 public class LimitableRequestPublisher<T> extends Flux<T> implements Subscription {
+
+  private static final int NOT_CANCELED_STATE = 0;
+  private static final int CANCELED_STATE = 1;
+
   private final Publisher<T> source;
 
-  private final AtomicBoolean canceled;
+  private volatile int canceled;
+  private static final AtomicIntegerFieldUpdater<LimitableRequestPublisher> CANCELED =
+      AtomicIntegerFieldUpdater.newUpdater(LimitableRequestPublisher.class, "canceled");
 
   private final long prefetch;
 
@@ -37,14 +43,13 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
 
   private long externalRequested;
 
-  private volatile boolean subscribed;
+  private boolean subscribed;
 
-  private volatile @Nullable Subscription internalSubscription;
+  private @Nullable Subscription internalSubscription;
 
   private LimitableRequestPublisher(Publisher<T> source, long prefetch) {
     this.source = source;
     this.prefetch = prefetch;
-    this.canceled = new AtomicBoolean();
   }
 
   public static <T> LimitableRequestPublisher<T> wrap(Publisher<T> source, long prefetch) {
@@ -60,23 +65,20 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
 
       subscribed = true;
     }
+    final InnerOperator s = new InnerOperator(destination);
 
-    destination.onSubscribe(new InnerSubscription());
-    source.subscribe(new InnerSubscriber(destination));
+    destination.onSubscribe(s);
+    source.subscribe(s);
     increaseInternalLimit(prefetch);
-  }
-
-  public void increaseRequestLimit(long n) {
-    synchronized (this) {
-      externalRequested = Operators.addCap(n, externalRequested);
-    }
-
-    requestN();
   }
 
   public void increaseInternalLimit(long n) {
     synchronized (this) {
-      internalRequested = Operators.addCap(n, internalRequested);
+      long requested = internalRequested;
+      if (requested == Long.MAX_VALUE) {
+        return;
+      }
+      internalRequested = Operators.addCap(n, requested);
     }
 
     requestN();
@@ -84,22 +86,36 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
 
   @Override
   public void request(long n) {
-    increaseRequestLimit(n);
+    synchronized (this) {
+      long requested = externalRequested;
+      if (requested == Long.MAX_VALUE) {
+        return;
+      }
+      externalRequested = Operators.addCap(n, requested);
+    }
+
+    requestN();
   }
 
   private void requestN() {
     long r;
+    final Subscription s;
+
     synchronized (this) {
-      if (internalSubscription == null) {
+      s = internalSubscription;
+      if (s == null) {
         return;
       }
 
-      if (externalRequested != Long.MAX_VALUE || internalRequested != Long.MAX_VALUE) {
-        r = Math.min(internalRequested, externalRequested);
-        if (externalRequested != Long.MAX_VALUE) {
+      long er = externalRequested;
+      long ir = internalRequested;
+
+      if (er != Long.MAX_VALUE || ir != Long.MAX_VALUE) {
+        r = Math.min(ir, er);
+        if (er != Long.MAX_VALUE) {
           externalRequested -= r;
         }
-        if (internalRequested != Long.MAX_VALUE) {
+        if (ir != Long.MAX_VALUE) {
           internalRequested -= r;
         }
       } else {
@@ -108,22 +124,34 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
     }
 
     if (r > 0) {
-      internalSubscription.request(r);
+      s.request(r);
     }
   }
 
   public void cancel() {
-    if (canceled.compareAndSet(false, true) && internalSubscription != null) {
-      internalSubscription.cancel();
-      internalSubscription = null;
-      subscribed = false;
+    if (!isCanceled() && CANCELED.compareAndSet(this, NOT_CANCELED_STATE, CANCELED_STATE)) {
+      Subscription s;
+
+      synchronized (this) {
+        s = internalSubscription;
+        internalSubscription = null;
+        subscribed = false;
+      }
+
+      if (s != null) {
+        s.cancel();
+      }
     }
   }
 
-  private class InnerSubscriber implements Subscriber<T> {
-    Subscriber<? super T> destination;
+  private boolean isCanceled() {
+    return canceled == 1;
+  }
 
-    private InnerSubscriber(Subscriber<? super T> destination) {
+  private class InnerOperator implements CoreSubscriber<T>, Subscription {
+    final Subscriber<? super T> destination;
+
+    private InnerOperator(Subscriber<? super T> destination) {
       this.destination = destination;
     }
 
@@ -132,7 +160,7 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
       synchronized (LimitableRequestPublisher.this) {
         LimitableRequestPublisher.this.internalSubscription = s;
 
-        if (canceled.get()) {
+        if (isCanceled()) {
           s.cancel();
           subscribed = false;
           LimitableRequestPublisher.this.internalSubscription = null;
@@ -160,9 +188,7 @@ public class LimitableRequestPublisher<T> extends Flux<T> implements Subscriptio
     public void onComplete() {
       destination.onComplete();
     }
-  }
 
-  private class InnerSubscription implements Subscription {
     @Override
     public void request(long n) {}
 

--- a/rsocket-core/src/test/java/io/rsocket/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketTest.java
@@ -85,6 +85,12 @@ public class RSocketTest {
   }
 
   @Test(timeout = 2000)
+  public void testStream() throws Exception {
+    Flux<Payload> responses = rule.crs.requestStream(DefaultPayload.create("Payload In"));
+    StepVerifier.create(responses).expectNextCount(10).expectComplete().verify();
+  }
+
+  @Test(timeout = 2000)
   public void testChannel() throws Exception {
     Flux<Payload> requests =
         Flux.range(0, 10).map(i -> DefaultPayload.create("streaming in -> " + i));
@@ -136,7 +142,9 @@ public class RSocketTest {
 
                 @Override
                 public Flux<Payload> requestStream(Payload payload) {
-                  return Flux.never();
+                  return Flux.range(1, 10)
+                      .map(
+                          i -> DefaultPayload.create("server got -> [" + payload.toString() + "]"));
                 }
 
                 @Override

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationDuplexConnectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationDuplexConnectionTest.java
@@ -24,7 +24,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ReferenceCountUtil;
 import io.rsocket.DuplexConnection;
 import io.rsocket.frame.*;
 import io.rsocket.util.DefaultPayload;
@@ -125,7 +124,7 @@ final class FragmentationDuplexConnectionTest {
         .assertNext(
             byteBuf -> {
               Assert.assertEquals(data, RequestResponseFrameFlyweight.data(byteBuf));
-              ReferenceCountUtil.safeRelease(byteBuf);
+              //              ReferenceCountUtil.safeRelease(byteBuf);
             })
         .verifyComplete();
   }

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationDuplexConnectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationDuplexConnectionTest.java
@@ -124,7 +124,6 @@ final class FragmentationDuplexConnectionTest {
         .assertNext(
             byteBuf -> {
               Assert.assertEquals(data, RequestResponseFrameFlyweight.data(byteBuf));
-              //              ReferenceCountUtil.safeRelease(byteBuf);
             })
         .verifyComplete();
   }

--- a/rsocket-core/src/test/java/io/rsocket/internal/LimitableRequestPublisherTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/LimitableRequestPublisherTest.java
@@ -1,0 +1,33 @@
+package io.rsocket.internal;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.DirectProcessor;
+import reactor.test.util.RaceTestUtils;
+
+class LimitableRequestPublisherTest {
+
+  @Test
+  @RepeatedTest(2)
+  public void requestLimitRacingTest() throws InterruptedException {
+    Queue<Long> requests = new ArrayDeque<>(10000);
+    LimitableRequestPublisher<Object> limitableRequestPublisher =
+        LimitableRequestPublisher.wrap(DirectProcessor.create().doOnRequest(requests::add), 0);
+
+    Runnable request1 = () -> limitableRequestPublisher.request(1);
+    Runnable request2 = () -> limitableRequestPublisher.increaseInternalLimit(2);
+
+    limitableRequestPublisher.subscribe();
+
+    for (int i = 0; i < 10000; i++) {
+      RaceTestUtils.race(request1, request2);
+    }
+
+    Thread.sleep(1000);
+
+    Assertions.assertThat(requests.stream().mapToLong(l -> l).sum()).isEqualTo(10000);
+  }
+}

--- a/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/channel/ChannelEchoClient.java
+++ b/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/channel/ChannelEchoClient.java
@@ -22,38 +22,42 @@ import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.RSocketFactory;
 import io.rsocket.SocketAcceptor;
-import io.rsocket.transport.netty.client.TcpClientTransport;
-import io.rsocket.transport.netty.server.TcpServerTransport;
-import io.rsocket.util.DefaultPayload;
+import io.rsocket.frame.decoder.PayloadDecoder;
+import io.rsocket.transport.local.LocalClientTransport;
+import io.rsocket.transport.local.LocalServerTransport;
+import io.rsocket.util.ByteBufPayload;
 import java.time.Duration;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public final class ChannelEchoClient {
+  static final Payload payload1 = ByteBufPayload.create("Hello ");
 
   public static void main(String[] args) {
     RSocketFactory.receive()
+        .frameDecoder(PayloadDecoder.ZERO_COPY)
         .acceptor(new SocketAcceptorImpl())
-        .transport(TcpServerTransport.create("localhost", 7000))
+        .transport(LocalServerTransport.create("localhost"))
         .start()
         .subscribe();
 
     RSocket socket =
         RSocketFactory.connect()
-            .transport(TcpClientTransport.create("localhost", 7000))
+            .keepAliveAckTimeout(Duration.ofMinutes(10))
+            .frameDecoder(PayloadDecoder.ZERO_COPY)
+            .transport(LocalClientTransport.create("localhost"))
             .start()
             .block();
 
-    socket
-        .requestChannel(
-            Flux.interval(Duration.ofMillis(1000)).map(i -> DefaultPayload.create("Hello")))
-        .map(Payload::getDataUtf8)
-        .doOnNext(System.out::println)
-        .take(10)
-        .doFinally(signalType -> socket.dispose())
-        .then()
-        .block();
+    Flux.range(0, 100000000)
+        .concatMap(i -> socket.fireAndForget(payload1.retain()))
+        //        .doOnNext(p -> {
+        ////            System.out.println(p.getDataUtf8());
+        //            p.release();
+        //        })
+        .blockLast();
   }
 
   private static class SocketAcceptorImpl implements SocketAcceptor {
@@ -61,12 +65,22 @@ public final class ChannelEchoClient {
     public Mono<RSocket> accept(ConnectionSetupPayload setupPayload, RSocket reactiveSocket) {
       return Mono.just(
           new AbstractRSocket() {
+
+            @Override
+            public Mono<Void> fireAndForget(Payload payload) {
+              //                  System.out.println(payload.getDataUtf8());
+              payload.release();
+              return Mono.empty();
+            }
+
+            @Override
+            public Mono<Payload> requestResponse(Payload payload) {
+              return Mono.just(payload);
+            }
+
             @Override
             public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
-              return Flux.from(payloads)
-                  .map(Payload::getDataUtf8)
-                  .map(s -> "Echo: " + s)
-                  .map(DefaultPayload::create);
+              return Flux.from(payloads).subscribeOn(Schedulers.single());
             }
           });
     }

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.UnicastProcessor;
+import reactor.util.concurrent.Queues;
 
 /**
  * An implementation of {@link ClientTransport} that connects to a {@link ServerTransport} in the
@@ -61,8 +62,10 @@ public final class LocalClientTransport implements ClientTransport {
             return Mono.error(new IllegalArgumentException("Could not find server: " + name));
           }
 
-          UnicastProcessor<ByteBuf> in = UnicastProcessor.create();
-          UnicastProcessor<ByteBuf> out = UnicastProcessor.create();
+          UnicastProcessor<ByteBuf> in =
+              UnicastProcessor.create(Queues.<ByteBuf>unboundedMultiproducer().get());
+          UnicastProcessor<ByteBuf> out =
+              UnicastProcessor.create(Queues.<ByteBuf>unboundedMultiproducer().get());
           MonoProcessor<Void> closeNotifier = MonoProcessor.create();
 
           server.accept(new LocalDuplexConnection(out, in, closeNotifier));

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
@@ -73,12 +73,13 @@ final class LocalDuplexConnection implements DuplexConnection {
   public Mono<Void> send(Publisher<ByteBuf> frames) {
     Objects.requireNonNull(frames, "frames must not be null");
 
-    return Flux.from(frames)
-        .doOnNext(
-            byteBuf -> {
-              byteBuf.retain();
-              out.onNext(byteBuf);
-            })
-        .then();
+    return Flux.from(frames).doOnNext(out::onNext).then();
+  }
+
+  @Override
+  public Mono<Void> sendOne(ByteBuf frame) {
+    Objects.requireNonNull(frame, "frame must not be null");
+    out.onNext(frame);
+    return Mono.empty();
   }
 }


### PR DESCRIPTION
## This PR provides a list of dramatical performance improvements:

1) Reduce the number of used Atomics within the code base. As you can see in PR, there were a few places with applied `first` elements strategy. In all of those cases, usage of atomic was redundant since Reactive-Streams spec and Reactors implementation guarantees happens-before and [serialized](https://github.com/reactive-streams/reactive-streams-java#term_serially) access to the object (Subscriber / Subscription) so having an additional object with volatile access is redundant and give more overhead
2) Reduce the number of allocated objects. In many cases, we use too many Reactors operators where actual logic can be implemented within one `BaseSubscriber`. Thus, this PR eliminates redundant transformations and minimize function flow. Also, dynamic invocations give its overhead, so there are upcoming changes in Reactor 3 (https://github.com/reactor/reactor-core/issues/1556) that improves performance as well.
3) Simplifies Lifecycle to more specific cases, so the number of used operators (hence allocated objects) also is reduced to the minimum.

## General bugfixes and improvements

Along with performance improvements, this PR introduces Jmh tests so you can run benchmarks locally and observe 10-20% perf improvements comparing to the previous implementation.

Finally, this PR provides a couple of bugfixes found during development and testing 

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>
