### PR TITLE
exposes access to connection acceptor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@
 # limitations under the License.
 #
 
-version=0.11.17
+version=0.11.19-SNAPSHOT

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -78,7 +78,7 @@ public final class WebsocketRouteTransport implements ServerTransport<Closeable>
    * @return a new Websocket handler
    * @throws NullPointerException if {@code acceptor} is {@code null}
    */
-  static BiFunction<WebsocketInbound, WebsocketOutbound, Publisher<Void>> newHandler(
+  public static BiFunction<WebsocketInbound, WebsocketOutbound, Publisher<Void>> newHandler(
       ConnectionAcceptor acceptor) {
 
     Objects.requireNonNull(acceptor, "acceptor must not be null");

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebSocketTransportIntegrationTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebSocketTransportIntegrationTest.java
@@ -1,0 +1,60 @@
+package io.rsocket.transport.netty;
+
+import java.net.URI;
+import java.time.Duration;
+
+import io.rsocket.AbstractRSocket;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.RSocketFactory;
+import io.rsocket.transport.ServerTransport;
+import io.rsocket.transport.netty.client.WebsocketClientTransport;
+import io.rsocket.transport.netty.server.WebsocketRouteTransport;
+import io.rsocket.util.DefaultPayload;
+import io.rsocket.util.EmptyPayload;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+import reactor.test.StepVerifier;
+
+public class WebSocketTransportIntegrationTest {
+
+
+    @Test
+    public void sendStreamOfDataWithExternalHttpServerTest() {
+        ServerTransport.ConnectionAcceptor acceptor =
+            RSocketFactory.receive()
+                          .acceptor((setupPayload, sendingRSocket) -> {
+                              return Mono.just(new AbstractRSocket() {
+                                  @Override
+                                  public Flux<Payload> requestStream(Payload payload) {
+                                      return Flux.range(0, 10)
+                                                 .map(i -> DefaultPayload.create(String.valueOf(i)));
+                                  }
+                              });
+                          })
+                          .toConnectionAcceptor();
+
+        DisposableServer server = HttpServer.create()
+                                            .host("localhost")
+                                            .route(router -> router.ws("/test",
+                                                WebsocketRouteTransport.newHandler(
+                                                    acceptor)))
+                                            .bindNow();
+
+        RSocket rsocket = RSocketFactory.connect()
+                                        .transport(WebsocketClientTransport.create(
+                                            URI.create("ws://" + server.host() + ":" + server.port() + "/test")
+                                        ))
+                                        .start()
+                                        .block();
+
+        StepVerifier.create(rsocket.requestStream(EmptyPayload.INSTANCE))
+                    .expectSubscription()
+                    .expectNextCount(10)
+                    .expectComplete()
+                    .verify(Duration.ofMillis(1000));
+    }
+}


### PR DESCRIPTION
This PR provides access to `ServerTransport.ConnectionAcceptor` which
simplifies integration with existing `HttpServer` and does not mandate
to start HttpServer with RSocketServer. In addition,
`WebSocketRouteTransport` exposes api which shares common functionality
for WS BiFunction setup

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>