### PR TITLE
fixes bug with incorrect WS framesize setup.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,13 +103,13 @@ subprojects {
             options.compilerArgs << '-Xlint:all,-overloads,-rawtypes,-unchecked'
         }
 
-//        javadoc {
-//            options.with {
-//                links 'https://docs.oracle.com/javase/8/docs/api/'
-//                links 'https://projectreactor.io/docs/core/release/api/'
-//                links 'https://netty.io/4.1/api/'
-//            }
-//        }
+        javadoc {
+            options.with {
+                links 'https://docs.oracle.com/javase/8/docs/api/'
+                links 'https://projectreactor.io/docs/core/release/api/'
+                links 'https://netty.io/4.1/api/'
+            }
+        }
 
         test {
             useJUnitPlatform()

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
     ext['netty.version'] = '4.1.31.Final'
     ext['netty-boringssl.version'] = '2.0.18.Final'
     ext['hdrhistogram.version'] = '2.1.10'
-    ext['mockito.version'] = '2.23.0'
+    ext['mockito.version'] = '2.25.1'
     ext['slf4j.version'] = '1.7.25'
     ext['jmh.version'] = '1.21'
     ext['junit.version'] = '5.1.0'
@@ -60,8 +60,12 @@ subprojects {
             dependency "io.micrometer:micrometer-core:${ext['micrometer.version']}"
             dependency "org.assertj:assertj-core:${ext['assertj.version']}"
             dependency "org.hdrhistogram:HdrHistogram:${ext['hdrhistogram.version']}"
-            dependency "org.mockito:mockito-core:${ ext['mockito.version']}"
             dependency "org.slf4j:slf4j-api:${ext['slf4j.version']}"
+            
+            dependencySet(group: 'org.mockito', version: ext['mockito.version']) {
+                entry 'mockito-junit-jupiter'
+                entry 'mockito-core'
+            }
 
             dependencySet(group: 'org.junit.jupiter', version: ext['junit.version']) {
                 entry 'junit-jupiter-api'
@@ -99,13 +103,13 @@ subprojects {
             options.compilerArgs << '-Xlint:all,-overloads,-rawtypes,-unchecked'
         }
 
-        javadoc {
-            options.with {
-                links 'https://docs.oracle.com/javase/8/docs/api/'
-                links 'https://projectreactor.io/docs/core/release/api/'
-                links 'https://netty.io/4.1/api/'
-            }
-        }
+//        javadoc {
+//            options.with {
+//                links 'https://docs.oracle.com/javase/8/docs/api/'
+//                links 'https://projectreactor.io/docs/core/release/api/'
+//                links 'https://netty.io/4.1/api/'
+//            }
+//        }
 
         test {
             useJUnitPlatform()

--- a/rsocket-core/src/main/java/io/rsocket/frame/FrameUtil.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/FrameUtil.java
@@ -5,7 +5,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 
 public class FrameUtil {
-  public static final int FRAME_MAX_SIZE = 16_777_215;
 
   private FrameUtil() {}
 

--- a/rsocket-core/src/main/java/io/rsocket/frame/FrameUtil.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/FrameUtil.java
@@ -5,6 +5,8 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 
 public class FrameUtil {
+  public static final int FRAME_MAX_SIZE = 16_777_215;
+
   private FrameUtil() {}
 
   public static String toString(ByteBuf frame) {

--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     testImplementation project(':rsocket-test')
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
 

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.transport.netty.client;
 
-import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 import static io.rsocket.transport.netty.UriUtils.getPort;
 import static io.rsocket.transport.netty.UriUtils.isSecure;
 
@@ -153,7 +153,7 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
   public Mono<DuplexConnection> connect(int mtu) {
     return client
         .headers(headers -> transportHeaders.get().forEach(headers::set))
-        .websocket(Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_MAX_SIZE : mtu))
+        .websocket(FRAME_LENGTH_MASK)
         .uri(path)
         .connect()
         .map(

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.transport.netty.client;
 
+import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
 import static io.rsocket.transport.netty.UriUtils.getPort;
 import static io.rsocket.transport.netty.UriUtils.isSecure;
 
@@ -42,6 +43,7 @@ import reactor.netty.tcp.TcpClient;
  */
 public final class WebsocketClientTransport implements ClientTransport, TransportHeaderAware {
 
+  private static final int DEFAULT_FRAME_SIZE = 65536;
   private static final String DEFAULT_PATH = "/";
 
   private final HttpClient client;
@@ -151,7 +153,7 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
   public Mono<DuplexConnection> connect(int mtu) {
     return client
         .headers(headers -> transportHeaders.get().forEach(headers::set))
-        .websocket()
+        .websocket(Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_MAX_SIZE : mtu))
         .uri(path)
         .connect()
         .map(

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.transport.netty.server;
 
-import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.HttpMethod;
@@ -87,7 +87,7 @@ public final class WebsocketRouteTransport implements ServerTransport<Closeable>
                     return acceptor.apply(connection).then(out.neverComplete());
                   },
                   null,
-                  Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_MAX_SIZE : mtu));
+                  Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_LENGTH_MASK : mtu));
             })
         .bind()
         .map(CloseableChannel::new);
@@ -99,14 +99,10 @@ public final class WebsocketRouteTransport implements ServerTransport<Closeable>
     private static final String FULL_SPLAT_REPLACEMENT = ".*";
 
     private static final Pattern NAME_SPLAT_PATTERN = Pattern.compile("\\{([^/]+?)\\}[\\*][\\*]");
-    // JDK 6 doesn't support named capture groups
     private static final String NAME_SPLAT_REPLACEMENT = "(?<%NAME%>.*)";
-    // private static final String  NAME_SPLAT_REPLACEMENT = "(.*)";
 
     private static final Pattern NAME_PATTERN = Pattern.compile("\\{([^/]+?)\\}");
-    // JDK 6 doesn't support named capture groups
     private static final String NAME_REPLACEMENT = "(?<%NAME%>[^\\/]*)";
-    // private static final String  NAME_REPLACEMENT = "([^\\/]*)";
 
     private final List<String> pathVariables = new ArrayList<>();
     private final HashMap<String, Matcher> matchers = new HashMap<>();

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -44,8 +44,6 @@ import reactor.netty.http.server.HttpServerRoutes;
  */
 public final class WebsocketRouteTransport implements ServerTransport<Closeable> {
 
-  private static final int DEFAULT_FRAME_SIZE = 65536;
-
   private final UriPathTemplate template;
 
   private final Consumer<? super HttpServerRoutes> routesBuilder;
@@ -87,7 +85,7 @@ public final class WebsocketRouteTransport implements ServerTransport<Closeable>
                     return acceptor.apply(connection).then(out.neverComplete());
                   },
                   null,
-                  Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_LENGTH_MASK : mtu));
+                  FRAME_LENGTH_MASK);
             })
         .bind()
         .map(CloseableChannel::new);

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -16,14 +16,23 @@
 
 package io.rsocket.transport.netty.server;
 
+import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.http.HttpMethod;
 import io.rsocket.Closeable;
 import io.rsocket.DuplexConnection;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
 import io.rsocket.transport.ServerTransport;
 import io.rsocket.transport.netty.WebsocketDuplexConnection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.http.server.HttpServer;
@@ -35,7 +44,9 @@ import reactor.netty.http.server.HttpServerRoutes;
  */
 public final class WebsocketRouteTransport implements ServerTransport<Closeable> {
 
-  private final String path;
+  private static final int DEFAULT_FRAME_SIZE = 65536;
+
+  private final UriPathTemplate template;
 
   private final Consumer<? super HttpServerRoutes> routesBuilder;
 
@@ -53,7 +64,7 @@ public final class WebsocketRouteTransport implements ServerTransport<Closeable>
 
     this.server = Objects.requireNonNull(server, "server must not be null");
     this.routesBuilder = Objects.requireNonNull(routesBuilder, "routesBuilder must not be null");
-    this.path = Objects.requireNonNull(path, "path must not be null");
+    this.template = new UriPathTemplate(Objects.requireNonNull(path, "path must not be null"));
   }
 
   @Override
@@ -65,7 +76,7 @@ public final class WebsocketRouteTransport implements ServerTransport<Closeable>
             routes -> {
               routesBuilder.accept(routes);
               routes.ws(
-                  path,
+                  hsr -> hsr.method().equals(HttpMethod.GET) && template.matches(hsr.uri()),
                   (in, out) -> {
                     DuplexConnection connection = new WebsocketDuplexConnection((Connection) in);
                     if (mtu > 0) {
@@ -74,9 +85,132 @@ public final class WebsocketRouteTransport implements ServerTransport<Closeable>
                               connection, ByteBufAllocator.DEFAULT, mtu, false);
                     }
                     return acceptor.apply(connection).then(out.neverComplete());
-                  });
+                  },
+                  null,
+                  Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_MAX_SIZE : mtu));
             })
         .bind()
         .map(CloseableChannel::new);
+  }
+
+  static final class UriPathTemplate {
+
+    private static final Pattern FULL_SPLAT_PATTERN = Pattern.compile("[\\*][\\*]");
+    private static final String FULL_SPLAT_REPLACEMENT = ".*";
+
+    private static final Pattern NAME_SPLAT_PATTERN = Pattern.compile("\\{([^/]+?)\\}[\\*][\\*]");
+    // JDK 6 doesn't support named capture groups
+    private static final String NAME_SPLAT_REPLACEMENT = "(?<%NAME%>.*)";
+    // private static final String  NAME_SPLAT_REPLACEMENT = "(.*)";
+
+    private static final Pattern NAME_PATTERN = Pattern.compile("\\{([^/]+?)\\}");
+    // JDK 6 doesn't support named capture groups
+    private static final String NAME_REPLACEMENT = "(?<%NAME%>[^\\/]*)";
+    // private static final String  NAME_REPLACEMENT = "([^\\/]*)";
+
+    private final List<String> pathVariables = new ArrayList<>();
+    private final HashMap<String, Matcher> matchers = new HashMap<>();
+    private final HashMap<String, Map<String, String>> vars = new HashMap<>();
+
+    private final Pattern uriPattern;
+
+    static String filterQueryParams(String uri) {
+      int hasQuery = uri.lastIndexOf("?");
+      if (hasQuery != -1) {
+        return uri.substring(0, hasQuery);
+      } else {
+        return uri;
+      }
+    }
+
+    /**
+     * Creates a new {@code UriPathTemplate} from the given {@code uriPattern}.
+     *
+     * @param uriPattern The pattern to be used by the template
+     */
+    UriPathTemplate(String uriPattern) {
+      String s = "^" + filterQueryParams(uriPattern);
+
+      Matcher m = NAME_SPLAT_PATTERN.matcher(s);
+      while (m.find()) {
+        for (int i = 1; i <= m.groupCount(); i++) {
+          String name = m.group(i);
+          pathVariables.add(name);
+          s = m.replaceFirst(NAME_SPLAT_REPLACEMENT.replaceAll("%NAME%", name));
+          m.reset(s);
+        }
+      }
+
+      m = NAME_PATTERN.matcher(s);
+      while (m.find()) {
+        for (int i = 1; i <= m.groupCount(); i++) {
+          String name = m.group(i);
+          pathVariables.add(name);
+          s = m.replaceFirst(NAME_REPLACEMENT.replaceAll("%NAME%", name));
+          m.reset(s);
+        }
+      }
+
+      m = FULL_SPLAT_PATTERN.matcher(s);
+      while (m.find()) {
+        s = m.replaceAll(FULL_SPLAT_REPLACEMENT);
+        m.reset(s);
+      }
+
+      this.uriPattern = Pattern.compile(s + "$");
+    }
+
+    /**
+     * Tests the given {@code uri} against this template, returning {@code true} if the uri matches
+     * the template, {@code false} otherwise.
+     *
+     * @param uri The uri to match
+     * @return {@code true} if there's a match, {@code false} otherwise
+     */
+    public boolean matches(String uri) {
+      return matcher(uri).matches();
+    }
+
+    /**
+     * Matches the template against the given {@code uri} returning a map of path parameters
+     * extracted from the uri, keyed by the names in the template. If the uri does not match, or
+     * there are no path parameters, an empty map is returned.
+     *
+     * @param uri The uri to match
+     * @return the path parameters from the uri. Never {@code null}.
+     */
+    final Map<String, String> match(String uri) {
+      Map<String, String> pathParameters = vars.get(uri);
+      if (null != pathParameters) {
+        return pathParameters;
+      }
+
+      pathParameters = new HashMap<>();
+      Matcher m = matcher(uri);
+      if (m.matches()) {
+        int i = 1;
+        for (String name : pathVariables) {
+          String val = m.group(i++);
+          pathParameters.put(name, val);
+        }
+      }
+      synchronized (vars) {
+        vars.put(uri, pathParameters);
+      }
+
+      return pathParameters;
+    }
+
+    private Matcher matcher(String uri) {
+      uri = filterQueryParams(uri);
+      Matcher m = matchers.get(uri);
+      if (null == m) {
+        m = uriPattern.matcher(uri);
+        synchronized (matchers) {
+          matchers.put(uri, m);
+        }
+      }
+      return m;
+    }
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
@@ -16,6 +16,8 @@
 
 package io.rsocket.transport.netty.server;
 
+import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
@@ -38,6 +40,8 @@ import reactor.netty.http.server.HttpServer;
  */
 public final class WebsocketServerTransport
     implements ServerTransport<CloseableChannel>, TransportHeaderAware {
+
+  private static final int DEFAULT_FRAME_SIZE = 65536;
 
   private final HttpServer server;
 
@@ -114,6 +118,8 @@ public final class WebsocketServerTransport
             (request, response) -> {
               transportHeaders.get().forEach(response::addHeader);
               return response.sendWebsocket(
+                  null,
+                  Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_MAX_SIZE : mtu),
                   (in, out) -> {
                     DuplexConnection connection = new WebsocketDuplexConnection((Connection) in);
                     if (mtu > 0) {

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
@@ -41,8 +41,6 @@ import reactor.netty.http.server.HttpServer;
 public final class WebsocketServerTransport
     implements ServerTransport<CloseableChannel>, TransportHeaderAware {
 
-  private static final int DEFAULT_FRAME_SIZE = 65536;
-
   private final HttpServer server;
 
   private Supplier<Map<String, String>> transportHeaders = Collections::emptyMap;
@@ -119,7 +117,7 @@ public final class WebsocketServerTransport
               transportHeaders.get().forEach(response::addHeader);
               return response.sendWebsocket(
                   null,
-                  Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_LENGTH_MASK : mtu),
+                  FRAME_LENGTH_MASK,
                   (in, out) -> {
                     DuplexConnection connection = new WebsocketDuplexConnection((Connection) in);
                     if (mtu > 0) {

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.transport.netty.server;
 
-import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
@@ -119,7 +119,7 @@ public final class WebsocketServerTransport
               transportHeaders.get().forEach(response::addHeader);
               return response.sendWebsocket(
                   null,
-                  Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_MAX_SIZE : mtu),
+                  Math.max(DEFAULT_FRAME_SIZE, mtu == 0 ? FRAME_LENGTH_MASK : mtu),
                   (in, out) -> {
                     DuplexConnection connection = new WebsocketDuplexConnection((Connection) in);
                     if (mtu > 0) {

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/client/WebsocketClientTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/client/WebsocketClientTransportTest.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.transport.netty.client;
 
-import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
@@ -49,7 +49,7 @@ final class WebsocketClientTransportTest {
 
     clientTransport.connect(0).subscribe();
 
-    Assertions.assertThat(captor.getValue()).isEqualTo(FRAME_MAX_SIZE);
+    Assertions.assertThat(captor.getValue()).isEqualTo(FRAME_LENGTH_MASK);
   }
 
   @Test
@@ -63,7 +63,7 @@ final class WebsocketClientTransportTest {
 
     clientTransport.connect(65536 - 10000).subscribe();
 
-    Assertions.assertThat(captor.getValue()).isEqualTo(65536);
+    Assertions.assertThat(captor.getValue()).isEqualTo(FRAME_LENGTH_MASK);
   }
 
   @Test
@@ -78,7 +78,7 @@ final class WebsocketClientTransportTest {
 
     clientTransport.connect(65536 + 10000).subscribe();
 
-    Assertions.assertThat(captor.getValue()).isEqualTo(65536 + 10000);
+    Assertions.assertThat(captor.getValue()).isEqualTo(FRAME_LENGTH_MASK);
   }
 
   @DisplayName("connects to server")

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/client/WebsocketClientTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/client/WebsocketClientTransportTest.java
@@ -16,13 +16,14 @@
 
 package io.rsocket.transport.netty.client;
 
+import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import io.rsocket.transport.netty.server.WebsocketServerTransport;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Collections;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
-import io.rsocket.transport.netty.server.WebsocketServerTransport;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,23 +31,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.netty.ByteBufFlux;
-import reactor.netty.Connection;
 import reactor.netty.http.client.HttpClient;
-import reactor.netty.http.client.HttpClientRequest;
-import reactor.netty.http.server.HttpServer;
-import reactor.netty.http.server.HttpServerRequest;
-import reactor.netty.http.server.HttpServerResponse;
-import reactor.netty.http.websocket.WebsocketInbound;
-import reactor.netty.http.websocket.WebsocketOutbound;
 import reactor.test.StepVerifier;
-
-import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 @ExtendWith(MockitoExtension.class)
 final class WebsocketClientTransportTest {
@@ -60,11 +47,9 @@ final class WebsocketClientTransportTest {
 
     WebsocketClientTransport clientTransport = WebsocketClientTransport.create(httpClient, "");
 
-    clientTransport.connect(0)
-                   .subscribe();
+    clientTransport.connect(0).subscribe();
 
     Assertions.assertThat(captor.getValue()).isEqualTo(FRAME_MAX_SIZE);
-
   }
 
   @Test
@@ -76,15 +61,14 @@ final class WebsocketClientTransportTest {
 
     WebsocketClientTransport clientTransport = WebsocketClientTransport.create(httpClient, "");
 
-    clientTransport.connect(65536-10000)
-                   .subscribe();
+    clientTransport.connect(65536 - 10000).subscribe();
 
     Assertions.assertThat(captor.getValue()).isEqualTo(65536);
-
   }
 
   @Test
-  public void testThatSetupWithSpecifiedFrameSizeButHigherThanWsDefaultShouldSetToSpecifiedFrameSize() {
+  public void
+      testThatSetupWithSpecifiedFrameSizeButHigherThanWsDefaultShouldSetToSpecifiedFrameSize() {
     ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
     HttpClient httpClient = Mockito.spy(HttpClient.create());
     Mockito.doAnswer(a -> httpClient).when(httpClient).headers(Mockito.any());
@@ -92,10 +76,9 @@ final class WebsocketClientTransportTest {
 
     WebsocketClientTransport clientTransport = WebsocketClientTransport.create(httpClient, "");
 
-    clientTransport.connect(65536+10000)
-                   .subscribe();
+    clientTransport.connect(65536 + 10000).subscribe();
 
-    Assertions.assertThat(captor.getValue()).isEqualTo(65536+10000);
+    Assertions.assertThat(captor.getValue()).isEqualTo(65536 + 10000);
   }
 
   @DisplayName("connects to server")

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketRouteTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketRouteTransportTest.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.transport.netty.server;
 
-import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.util.function.BiFunction;
@@ -53,7 +53,7 @@ final class WebsocketRouteTransportTest {
             Mockito.any(Predicate.class),
             Mockito.any(BiFunction.class),
             Mockito.nullable(String.class),
-            Mockito.eq(FRAME_MAX_SIZE));
+            Mockito.eq(FRAME_LENGTH_MASK));
   }
 
   @Test
@@ -76,7 +76,7 @@ final class WebsocketRouteTransportTest {
             Mockito.any(Predicate.class),
             Mockito.any(BiFunction.class),
             Mockito.nullable(String.class),
-            Mockito.eq(65536));
+            Mockito.eq(FRAME_LENGTH_MASK));
   }
 
   @Test
@@ -100,7 +100,7 @@ final class WebsocketRouteTransportTest {
             Mockito.any(Predicate.class),
             Mockito.any(BiFunction.class),
             Mockito.nullable(String.class),
-            Mockito.eq(65536 + 1000));
+            Mockito.eq(FRAME_LENGTH_MASK));
   }
 
   @DisplayName("creates server")

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketRouteTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketRouteTransportTest.java
@@ -16,21 +16,18 @@
 
 package io.rsocket.transport.netty.server;
 
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-
 import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.server.HttpServer;
-import reactor.netty.http.server.HttpServerRequest;
-import reactor.netty.http.server.HttpServerResponse;
 import reactor.netty.http.server.HttpServerRoutes;
 import reactor.test.StepVerifier;
 
@@ -44,14 +41,19 @@ final class WebsocketRouteTransportTest {
     Mockito.doAnswer(a -> httpServer).when(httpServer).route(captor.capture());
     Mockito.doAnswer(a -> Mono.empty()).when(httpServer).bind();
 
-    WebsocketRouteTransport serverTransport = new WebsocketRouteTransport(httpServer, (r) -> {}, "");
+    WebsocketRouteTransport serverTransport =
+        new WebsocketRouteTransport(httpServer, (r) -> {}, "");
 
-    serverTransport.start(c -> Mono.empty(), 0)
-                   .subscribe();
+    serverTransport.start(c -> Mono.empty(), 0).subscribe();
 
     captor.getValue().accept(routes);
 
-    Mockito.verify(routes).ws(Mockito.any(Predicate.class), Mockito.any(BiFunction.class), Mockito.nullable(String.class), Mockito.eq(FRAME_MAX_SIZE));
+    Mockito.verify(routes)
+        .ws(
+            Mockito.any(Predicate.class),
+            Mockito.any(BiFunction.class),
+            Mockito.nullable(String.class),
+            Mockito.eq(FRAME_MAX_SIZE));
   }
 
   @Test
@@ -62,35 +64,43 @@ final class WebsocketRouteTransportTest {
     Mockito.doAnswer(a -> httpServer).when(httpServer).route(captor.capture());
     Mockito.doAnswer(a -> Mono.empty()).when(httpServer).bind();
 
-    WebsocketRouteTransport serverTransport = new WebsocketRouteTransport(httpServer, (r) -> {}, "");
+    WebsocketRouteTransport serverTransport =
+        new WebsocketRouteTransport(httpServer, (r) -> {}, "");
 
-    serverTransport.start(c -> Mono.empty(), 1000)
-                   .subscribe();
+    serverTransport.start(c -> Mono.empty(), 1000).subscribe();
 
     captor.getValue().accept(routes);
 
-    Mockito.verify(routes).ws(Mockito.any(Predicate.class), Mockito.any(BiFunction.class), Mockito.nullable(String.class), Mockito.eq(65536));
+    Mockito.verify(routes)
+        .ws(
+            Mockito.any(Predicate.class),
+            Mockito.any(BiFunction.class),
+            Mockito.nullable(String.class),
+            Mockito.eq(65536));
   }
 
   @Test
-  public void testThatSetupWithSpecifiedFrameSizeButHigherThanWsDefaultShouldSetToSpecifiedFrameSize() {
+  public void
+      testThatSetupWithSpecifiedFrameSizeButHigherThanWsDefaultShouldSetToSpecifiedFrameSize() {
     ArgumentCaptor<Consumer> captor = ArgumentCaptor.forClass(Consumer.class);
     HttpServer httpServer = Mockito.spy(HttpServer.create());
     HttpServerRoutes routes = Mockito.mock(HttpServerRoutes.class);
     Mockito.doAnswer(a -> httpServer).when(httpServer).route(captor.capture());
     Mockito.doAnswer(a -> Mono.empty()).when(httpServer).bind();
 
-    WebsocketRouteTransport serverTransport = new WebsocketRouteTransport(httpServer, (r) -> {}, "");
+    WebsocketRouteTransport serverTransport =
+        new WebsocketRouteTransport(httpServer, (r) -> {}, "");
 
-    serverTransport.start(c -> Mono.empty(), 65536 + 1000)
-                   .subscribe();
+    serverTransport.start(c -> Mono.empty(), 65536 + 1000).subscribe();
 
     captor.getValue().accept(routes);
 
-    Mockito.verify(routes).ws(Mockito.any(Predicate.class),
-        Mockito.any(BiFunction.class), Mockito.nullable(String.class),
-        Mockito.eq(65536 + 1000));
-
+    Mockito.verify(routes)
+        .ws(
+            Mockito.any(Predicate.class),
+            Mockito.any(BiFunction.class),
+            Mockito.nullable(String.class),
+            Mockito.eq(65536 + 1000));
   }
 
   @DisplayName("creates server")

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.transport.netty.server;
 
-import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
+import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
@@ -52,7 +52,7 @@ final class WebsocketServerTransportTest {
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
     Mockito.verify(httpServerResponse)
-        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(FRAME_MAX_SIZE), Mockito.any());
+        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
   }
 
   @Test
@@ -72,7 +72,7 @@ final class WebsocketServerTransportTest {
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
     Mockito.verify(httpServerResponse)
-        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(65536), Mockito.any());
+        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
   }
 
   @Test
@@ -93,7 +93,7 @@ final class WebsocketServerTransportTest {
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
     Mockito.verify(httpServerResponse)
-        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(65536 + 1000), Mockito.any());
+        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
   }
 
   @DisplayName("creates server with BindAddress")

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
@@ -16,18 +16,91 @@
 
 package io.rsocket.transport.netty.server;
 
+import static io.rsocket.frame.FrameUtil.FRAME_MAX_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.function.BiFunction;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.server.HttpServer;
+import reactor.netty.http.server.HttpServerRequest;
+import reactor.netty.http.server.HttpServerResponse;
 import reactor.test.StepVerifier;
 
 final class WebsocketServerTransportTest {
+
+  @Test
+  public void testThatSetupWithUnSpecifiedFrameSizeShouldSetMaxFrameSize() {
+    ArgumentCaptor<BiFunction> captor = ArgumentCaptor.forClass(BiFunction.class);
+    HttpServer httpServer = Mockito.spy(HttpServer.create());
+    Mockito.doAnswer(a -> httpServer).when(httpServer).handle(captor.capture());
+    Mockito.doAnswer(a -> Mono.empty()).when(httpServer).bind();
+
+    WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
+
+    serverTransport.start(c -> Mono.empty(), 0)
+                   .subscribe();
+
+    HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
+    HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
+
+    captor.getValue().apply(httpServerRequest, httpServerResponse);
+
+    Mockito.verify(httpServerResponse).sendWebsocket(Mockito.nullable(String.class),
+        Mockito.eq(FRAME_MAX_SIZE), Mockito.any());
+
+  }
+
+  @Test
+  public void testThatSetupWithSpecifiedFrameSizeButLowerThanWsDefaultShouldSetToWsDefault() {
+    ArgumentCaptor<BiFunction> captor = ArgumentCaptor.forClass(BiFunction.class);
+    HttpServer httpServer = Mockito.spy(HttpServer.create());
+    Mockito.doAnswer(a -> httpServer).when(httpServer).handle(captor.capture());
+    Mockito.doAnswer(a -> Mono.empty()).when(httpServer).bind();
+
+    WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
+
+    serverTransport.start(c -> Mono.empty(), 1000)
+                   .subscribe();
+
+    HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
+    HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
+
+    captor.getValue().apply(httpServerRequest, httpServerResponse);
+
+    Mockito.verify(httpServerResponse).sendWebsocket(Mockito.nullable(String.class),
+        Mockito.eq(65536), Mockito.any());
+
+  }
+
+  @Test
+  public void testThatSetupWithSpecifiedFrameSizeButHigherThanWsDefaultShouldSetToSpecifiedFrameSize() {
+    ArgumentCaptor<BiFunction> captor = ArgumentCaptor.forClass(BiFunction.class);
+    HttpServer httpServer = Mockito.spy(HttpServer.create());
+    Mockito.doAnswer(a -> httpServer).when(httpServer).handle(captor.capture());
+    Mockito.doAnswer(a -> Mono.empty()).when(httpServer).bind();
+
+    WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
+
+    serverTransport.start(c -> Mono.empty(), 65536 + 1000)
+                   .subscribe();
+
+    HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
+    HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
+
+    captor.getValue().apply(httpServerRequest, httpServerResponse);
+
+    Mockito.verify(httpServerResponse).sendWebsocket(Mockito.nullable(String.class),
+        Mockito.eq(65536 + 1000), Mockito.any());
+
+  }
 
   @DisplayName("creates server with BindAddress")
   @Test

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
@@ -52,7 +52,8 @@ final class WebsocketServerTransportTest {
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
     Mockito.verify(httpServerResponse)
-        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
+        .sendWebsocket(
+            Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
   }
 
   @Test
@@ -72,7 +73,8 @@ final class WebsocketServerTransportTest {
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
     Mockito.verify(httpServerResponse)
-        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
+        .sendWebsocket(
+            Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
   }
 
   @Test
@@ -93,7 +95,8 @@ final class WebsocketServerTransportTest {
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
     Mockito.verify(httpServerResponse)
-        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
+        .sendWebsocket(
+            Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
   }
 
   @DisplayName("creates server with BindAddress")

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.function.BiFunction;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -45,17 +44,15 @@ final class WebsocketServerTransportTest {
 
     WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
 
-    serverTransport.start(c -> Mono.empty(), 0)
-                   .subscribe();
+    serverTransport.start(c -> Mono.empty(), 0).subscribe();
 
     HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
     HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
 
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
-    Mockito.verify(httpServerResponse).sendWebsocket(Mockito.nullable(String.class),
-        Mockito.eq(FRAME_MAX_SIZE), Mockito.any());
-
+    Mockito.verify(httpServerResponse)
+        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(FRAME_MAX_SIZE), Mockito.any());
   }
 
   @Test
@@ -67,21 +64,20 @@ final class WebsocketServerTransportTest {
 
     WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
 
-    serverTransport.start(c -> Mono.empty(), 1000)
-                   .subscribe();
+    serverTransport.start(c -> Mono.empty(), 1000).subscribe();
 
     HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
     HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
 
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
-    Mockito.verify(httpServerResponse).sendWebsocket(Mockito.nullable(String.class),
-        Mockito.eq(65536), Mockito.any());
-
+    Mockito.verify(httpServerResponse)
+        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(65536), Mockito.any());
   }
 
   @Test
-  public void testThatSetupWithSpecifiedFrameSizeButHigherThanWsDefaultShouldSetToSpecifiedFrameSize() {
+  public void
+      testThatSetupWithSpecifiedFrameSizeButHigherThanWsDefaultShouldSetToSpecifiedFrameSize() {
     ArgumentCaptor<BiFunction> captor = ArgumentCaptor.forClass(BiFunction.class);
     HttpServer httpServer = Mockito.spy(HttpServer.create());
     Mockito.doAnswer(a -> httpServer).when(httpServer).handle(captor.capture());
@@ -89,17 +85,15 @@ final class WebsocketServerTransportTest {
 
     WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
 
-    serverTransport.start(c -> Mono.empty(), 65536 + 1000)
-                   .subscribe();
+    serverTransport.start(c -> Mono.empty(), 65536 + 1000).subscribe();
 
     HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
     HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
 
     captor.getValue().apply(httpServerRequest, httpServerResponse);
 
-    Mockito.verify(httpServerResponse).sendWebsocket(Mockito.nullable(String.class),
-        Mockito.eq(65536 + 1000), Mockito.any());
-
+    Mockito.verify(httpServerResponse)
+        .sendWebsocket(Mockito.nullable(String.class), Mockito.eq(65536 + 1000), Mockito.any());
   }
 
   @DisplayName("creates server with BindAddress")

--- a/rsocket-transport-netty/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/rsocket-transport-netty/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR provides a WebSocket transport's frame size setup with regards
of current RSocket fragment size.

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>