### PR TITLE
Resume cleanup round

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.java
@@ -433,9 +433,6 @@ class RSocketClient implements RSocket {
   protected void terminate() {
     lifecycle.setTerminationError(new ClosedChannelException());
 
-    if (keepAliveFramesAcceptor != null) {
-      keepAliveFramesAcceptor.dispose();
-    }
     try {
       receivers.values().forEach(this::cleanUpSubscriber);
       senders.values().forEach(this::cleanUpLimitableRequestPublisher);

--- a/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketServer.java
@@ -280,9 +280,6 @@ class RSocketServer implements ResponderRSocket {
   }
 
   private void cleanup() {
-    if (keepAliveFramesAcceptor != null) {
-      keepAliveFramesAcceptor.dispose();
-    }
     cleanUpSendingSubscriptions();
     cleanUpChannelProcessors();
 

--- a/rsocket-core/src/main/java/io/rsocket/internal/ClientSetup.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/ClientSetup.java
@@ -53,7 +53,7 @@ public interface ClientSetup {
 
     @Override
     public KeepAliveHandler keepAliveHandler() {
-      return new DefaultKeepAliveHandler();
+      return new DefaultKeepAliveHandler(connection);
     }
 
     @Override

--- a/rsocket-core/src/main/java/io/rsocket/internal/ServerSetup.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/ServerSetup.java
@@ -64,7 +64,7 @@ public interface ServerSetup {
                   multiplexer.dispose();
                 });
       } else {
-        return then.apply(new DefaultKeepAliveHandler(), multiplexer);
+        return then.apply(new DefaultKeepAliveHandler(multiplexer), multiplexer);
       }
     }
 
@@ -132,7 +132,7 @@ public interface ServerSetup {
             new ResumableKeepAliveHandler(connection),
             new ClientServerInputMultiplexer(connection));
       } else {
-        return then.apply(new DefaultKeepAliveHandler(), multiplexer);
+        return then.apply(new DefaultKeepAliveHandler(multiplexer), multiplexer);
       }
     }
 

--- a/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAliveFramesAcceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAliveFramesAcceptor.java
@@ -5,6 +5,4 @@ import io.netty.buffer.ByteBuf;
 public interface KeepAliveFramesAcceptor {
 
   void receive(ByteBuf keepAliveFrame);
-
-  void dispose();
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/SendPublisher.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/SendPublisher.java
@@ -2,6 +2,7 @@ package io.rsocket.transport.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
@@ -84,22 +85,26 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<ByteBuf> {
     fuse = queue instanceof Fuseable.QueueSubscription;
   }
 
-  @SuppressWarnings("unchecked")
-  private void writeCleanup(V poll) {
-    if (requested != Long.MAX_VALUE) {
-      requested--;
-    }
-    requestedUpstream--;
-    pending--;
+  private ChannelPromise writeCleanupPromise(V poll) {
+    return channel
+        .newPromise()
+        .addListener(
+            future -> {
+              if (requested != Long.MAX_VALUE) {
+                requested--;
+              }
+              requestedUpstream--;
+              pending--;
 
-    InnerSubscriber is = (InnerSubscriber) INNER_SUBSCRIBER.get(SendPublisher.this);
-    if (is != null) {
-      is.tryRequestMoreUpstream();
-      tryComplete(is);
-    }
-    if (poll.refCnt() > 0) {
-      ReferenceCountUtil.safeRelease(poll);
-    }
+              InnerSubscriber is = (InnerSubscriber) INNER_SUBSCRIBER.get(SendPublisher.this);
+              if (is != null) {
+                is.tryRequestMoreUpstream();
+                tryComplete(is);
+              }
+              if (poll.refCnt() > 0) {
+                ReferenceCountUtil.safeRelease(poll);
+              }
+            });
   }
 
   private void tryComplete(InnerSubscriber is) {
@@ -202,7 +207,7 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<ByteBuf> {
     }
 
     private void tryDrain() {
-      if (terminated == 0 && WIP.getAndIncrement(SendPublisher.this) == 0) {
+      if (wip == 0 && terminated == 0 && WIP.getAndIncrement(SendPublisher.this) == 0) {
         try {
           if (eventLoop.inEventLoop()) {
             drain();
@@ -230,29 +235,11 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<ByteBuf> {
               int readableBytes = sizeOf.size(poll);
               pending++;
               if (channel.isWritable() && readableBytes <= channel.bytesBeforeUnwritable()) {
-                channel
-                    .write(poll)
-                    .addListener(
-                        future -> {
-                          if (future.cause() != null) {
-                            onError(future.cause());
-                          } else {
-                            writeCleanup(poll);
-                          }
-                        });
+                channel.write(poll, writeCleanupPromise(poll));
                 scheduleFlush = true;
               } else {
                 scheduleFlush = false;
-                channel
-                    .writeAndFlush(poll)
-                    .addListener(
-                        future -> {
-                          if (future.cause() != null) {
-                            onError(future.cause());
-                          } else {
-                            writeCleanup(poll);
-                          }
-                        });
+                channel.writeAndFlush(poll, writeCleanupPromise(poll));
               }
 
               tryRequestMoreUpstream();

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/SendPublisher.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/SendPublisher.java
@@ -207,7 +207,7 @@ class SendPublisher<V extends ReferenceCounted> extends Flux<ByteBuf> {
     }
 
     private void tryDrain() {
-      if (wip == 0 && terminated == 0 && WIP.getAndIncrement(SendPublisher.this) == 0) {
+      if (terminated == 0 && WIP.getAndIncrement(SendPublisher.this) == 0) {
         try {
           if (eventLoop.inEventLoop()) {
             drain();


### PR DESCRIPTION
Use `Flux.generate` for resume stream of in-memory store.

Add `KeepAliveHandler` tests for resumable case.

Replace bugfix in https://github.com/rsocket/rsocket-java/pull/618 as It caused frames leak on resumption

