### PR TITLE
[#588] Add OpenJDK 11 and 12 build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,13 @@
 ---
 language: java
 
-jdk:
-- oraclejdk8
-# - oraclejdk9
+matrix:
+  include:
+    - jdk: oraclejdk8
+    - jdk: openjdk11
+      env: SKIP_RELEASE=true
+    - jdk: openjdk12
+      env: SKIP_RELEASE=true
 
 env:
   global:
@@ -37,4 +41,3 @@ cache:
   directories:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
-

--- a/artifactory.gradle
+++ b/artifactory.gradle
@@ -35,6 +35,9 @@ if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey')) {
                     }
                 }
             }
+            tasks.named("artifactoryPublish").configure {
+                onlyIf { System.getenv('SKIP_RELEASE') != "true" }
+            }
         }
     }
 }

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -55,6 +55,9 @@ if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey') &&
                     }
                 }
             }
+            tasks.named("bintrayUpload").configure {
+                onlyIf { System.getenv('SKIP_RELEASE') != "true" }
+            }
         }
     }
 }


### PR DESCRIPTION
To know if the project builds well with newer Java versions. Publishing to artifactory/bintray has been disabled for Java != 8.

Fixes #588.