### PR TITLE
Fix logging formatting

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/resume/ClientRSocketSession.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ClientRSocketSession.java
@@ -78,7 +78,7 @@ public class ClientRSocketSession
                           errors
                               .doOnNext(
                                   retryErr ->
-                                      logger.debug("Resumption reconnection error: {}", retryErr))
+                                      logger.debug("Resumption reconnection error", retryErr))
                               .flatMap(
                                   retryErr ->
                                       Mono.from(reconnectOnError.apply(clientResume, retryErr))

--- a/rsocket-core/src/main/java/io/rsocket/resume/ServerRSocketSession.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ServerRSocketSession.java
@@ -68,7 +68,7 @@ public class ServerRSocketSession implements RSocketSession<ResumePositionsConne
             .connectionErrors()
             .flatMap(
                 err -> {
-                  logger.debug("Starting session timeout due to error: {}", err);
+                  logger.debug("Starting session timeout due to error", err);
                   return newConnections
                       .next()
                       .doOnNext(c -> logger.debug("Connection after error: {}", c))


### PR DESCRIPTION
The single arg form with a Throwable is a pre formatted message in slf4j

```
21:19:34.781	Starting session timeout due to error: {}
java.nio.channels.ClosedChannelException
	at io.rsocket.resume.ResumableDuplexConnection.disconnect(ResumableDuplexConnection.java:326)
```