### PR TITLE
Rename internal components to match their purpose

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -145,14 +145,14 @@ public class RSocketFactory {
       return this;
     }
 
-    /** Deprecated. Use {@link #addHandlerPlugin(RSocketInterceptor)} instead */
+    /** Deprecated. Use {@link #addResponderPlugin(RSocketInterceptor)} instead */
     @Deprecated
     public ClientRSocketFactory addServerPlugin(RSocketInterceptor interceptor) {
-      return addHandlerPlugin(interceptor);
+      return addResponderPlugin(interceptor);
     }
 
-    public ClientRSocketFactory addHandlerPlugin(RSocketInterceptor interceptor) {
-      plugins.addHandlerPlugin(interceptor);
+    public ClientRSocketFactory addResponderPlugin(RSocketInterceptor interceptor) {
+      plugins.addResponderPlugin(interceptor);
       return this;
     }
 
@@ -335,7 +335,7 @@ public class RSocketFactory {
                     rSocketHandler = acceptor.get().apply(wrappedRSocketRequester);
                   }
 
-                  RSocket wrappedRSocketHandler = plugins.applyHandler(rSocketHandler);
+                  RSocket wrappedRSocketHandler = plugins.applyResponder(rSocketHandler);
 
                   RSocketResponder rSocketResponder =
                       new RSocketResponder(
@@ -419,14 +419,14 @@ public class RSocketFactory {
       return this;
     }
 
-    /** Deprecated. Use {@link #addHandlerPlugin(RSocketInterceptor)} instead */
+    /** Deprecated. Use {@link #addResponderPlugin(RSocketInterceptor)} instead */
     @Deprecated
     public ServerRSocketFactory addServerPlugin(RSocketInterceptor interceptor) {
-      return addHandlerPlugin(interceptor);
+      return addResponderPlugin(interceptor);
     }
 
-    public ServerRSocketFactory addHandlerPlugin(RSocketInterceptor interceptor) {
-      plugins.addHandlerPlugin(interceptor);
+    public ServerRSocketFactory addResponderPlugin(RSocketInterceptor interceptor) {
+      plugins.addResponderPlugin(interceptor);
       return this;
     }
 
@@ -563,7 +563,7 @@ public class RSocketFactory {
                       err -> sendError(multiplexer, rejectedSetupError(err)).then(Mono.error(err)))
                   .doOnNext(
                       rSocketHandler -> {
-                        RSocket wrappedRSocketHandler = plugins.applyHandler(rSocketHandler);
+                        RSocket wrappedRSocketHandler = plugins.applyResponder(rSocketHandler);
 
                         RSocketResponder rSocketResponder =
                             new RSocketResponder(

--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -134,14 +134,25 @@ public class RSocketFactory {
       plugins.addConnectionPlugin(interceptor);
       return this;
     }
-
+    /** Deprecated. Use {@link #addRequesterPlugin(RSocketInterceptor)} instead */
+    @Deprecated
     public ClientRSocketFactory addClientPlugin(RSocketInterceptor interceptor) {
-      plugins.addClientPlugin(interceptor);
+      return addRequesterPlugin(interceptor);
+    }
+
+    public ClientRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor) {
+      plugins.addRequesterPlugin(interceptor);
       return this;
     }
 
+    /** Deprecated. Use {@link #addHandlerPlugin(RSocketInterceptor)} instead */
+    @Deprecated
     public ClientRSocketFactory addServerPlugin(RSocketInterceptor interceptor) {
-      plugins.addServerPlugin(interceptor);
+      return addHandlerPlugin(interceptor);
+    }
+
+    public ClientRSocketFactory addHandlerPlugin(RSocketInterceptor interceptor) {
+      plugins.addHandlerPlugin(interceptor);
       return this;
     }
 
@@ -291,8 +302,8 @@ public class RSocketFactory {
                   ClientServerInputMultiplexer multiplexer =
                       new ClientServerInputMultiplexer(wrappedConnection, plugins);
 
-                  RSocketClient rSocketClient =
-                      new RSocketClient(
+                  RSocketRequester rSocketRequester =
+                      new RSocketRequester(
                           allocator,
                           multiplexer.asClientConnection(),
                           payloadDecoder,
@@ -314,27 +325,27 @@ public class RSocketFactory {
                           setupPayload.sliceMetadata(),
                           setupPayload.sliceData());
 
-                  RSocket wrappedRSocketClient = plugins.applyClient(rSocketClient);
+                  RSocket wrappedRSocketRequester = plugins.applyRequester(rSocketRequester);
 
-                  RSocket unwrappedServerSocket;
+                  RSocket rSocketHandler;
                   if (biAcceptor != null) {
                     ConnectionSetupPayload setup = ConnectionSetupPayload.create(setupFrame);
-                    unwrappedServerSocket = biAcceptor.apply(setup, wrappedRSocketClient);
+                    rSocketHandler = biAcceptor.apply(setup, wrappedRSocketRequester);
                   } else {
-                    unwrappedServerSocket = acceptor.get().apply(wrappedRSocketClient);
+                    rSocketHandler = acceptor.get().apply(wrappedRSocketRequester);
                   }
 
-                  RSocket wrappedRSocketServer = plugins.applyServer(unwrappedServerSocket);
+                  RSocket wrappedRSocketHandler = plugins.applyHandler(rSocketHandler);
 
-                  RSocketServer rSocketServer =
-                      new RSocketServer(
+                  RSocketResponder rSocketResponder =
+                      new RSocketResponder(
                           allocator,
                           multiplexer.asServerConnection(),
-                          wrappedRSocketServer,
+                          wrappedRSocketHandler,
                           payloadDecoder,
                           errorConsumer);
 
-                  return wrappedConnection.sendOne(setupFrame).thenReturn(wrappedRSocketClient);
+                  return wrappedConnection.sendOne(setupFrame).thenReturn(wrappedRSocketRequester);
                 });
       }
 
@@ -397,14 +408,25 @@ public class RSocketFactory {
       plugins.addConnectionPlugin(interceptor);
       return this;
     }
-
+    /** Deprecated. Use {@link #addRequesterPlugin(RSocketInterceptor)} instead */
+    @Deprecated
     public ServerRSocketFactory addClientPlugin(RSocketInterceptor interceptor) {
-      plugins.addClientPlugin(interceptor);
+      return addRequesterPlugin(interceptor);
+    }
+
+    public ServerRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor) {
+      plugins.addRequesterPlugin(interceptor);
       return this;
     }
 
+    /** Deprecated. Use {@link #addHandlerPlugin(RSocketInterceptor)} instead */
+    @Deprecated
     public ServerRSocketFactory addServerPlugin(RSocketInterceptor interceptor) {
-      plugins.addServerPlugin(interceptor);
+      return addHandlerPlugin(interceptor);
+    }
+
+    public ServerRSocketFactory addHandlerPlugin(RSocketInterceptor interceptor) {
+      plugins.addHandlerPlugin(interceptor);
       return this;
     }
 
@@ -525,29 +547,29 @@ public class RSocketFactory {
             (keepAliveHandler, wrappedMultiplexer) -> {
               ConnectionSetupPayload setupPayload = ConnectionSetupPayload.create(setupFrame);
 
-              RSocketClient rSocketClient =
-                  new RSocketClient(
+              RSocketRequester rSocketRequester =
+                  new RSocketRequester(
                       allocator,
                       wrappedMultiplexer.asServerConnection(),
                       payloadDecoder,
                       errorConsumer,
                       StreamIdSupplier.serverSupplier());
 
-              RSocket wrappedRSocketClient = plugins.applyClient(rSocketClient);
+              RSocket wrappedRSocketRequester = plugins.applyRequester(rSocketRequester);
 
               return acceptor
-                  .accept(setupPayload, wrappedRSocketClient)
+                  .accept(setupPayload, wrappedRSocketRequester)
                   .onErrorResume(
                       err -> sendError(multiplexer, rejectedSetupError(err)).then(Mono.error(err)))
                   .doOnNext(
-                      unwrappedServerSocket -> {
-                        RSocket wrappedRSocketServer = plugins.applyServer(unwrappedServerSocket);
+                      rSocketHandler -> {
+                        RSocket wrappedRSocketHandler = plugins.applyHandler(rSocketHandler);
 
-                        RSocketServer rSocketServer =
-                            new RSocketServer(
+                        RSocketResponder rSocketResponder =
+                            new RSocketResponder(
                                 allocator,
                                 wrappedMultiplexer.asClientConnection(),
-                                wrappedRSocketServer,
+                                wrappedRSocketHandler,
                                 payloadDecoder,
                                 errorConsumer,
                                 setupPayload.keepAliveInterval(),

--- a/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
@@ -45,8 +45,10 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.*;
 
-/** Client Side of a RSocket socket. Sends {@link ByteBuf}s to a {@link RSocketServer} */
-class RSocketClient implements RSocket {
+/**
+ * Requester Side of a RSocket socket. Sends {@link ByteBuf}s to a {@link RSocketResponder} of peer
+ */
+class RSocketRequester implements RSocket {
 
   private final DuplexConnection connection;
   private final PayloadDecoder payloadDecoder;
@@ -60,7 +62,7 @@ class RSocketClient implements RSocket {
   private final KeepAliveFramesAcceptor keepAliveFramesAcceptor;
 
   /*client requester*/
-  RSocketClient(
+  RSocketRequester(
       ByteBufAllocator allocator,
       DuplexConnection connection,
       PayloadDecoder payloadDecoder,
@@ -99,7 +101,7 @@ class RSocketClient implements RSocket {
   }
 
   /*server requester*/
-  RSocketClient(
+  RSocketRequester(
       ByteBufAllocator allocator,
       DuplexConnection connection,
       PayloadDecoder payloadDecoder,

--- a/rsocket-core/src/main/java/io/rsocket/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketResponder.java
@@ -43,8 +43,8 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.publisher.*;
 
-/** Server side RSocket. Receives {@link ByteBuf}s from a {@link RSocketClient} */
-class RSocketServer implements ResponderRSocket {
+/** Responder side of RSocket. Receives {@link ByteBuf}s from a peer's {@link RSocketRequester} */
+class RSocketResponder implements ResponderRSocket {
 
   private final DuplexConnection connection;
   private final RSocket requestHandler;
@@ -61,7 +61,7 @@ class RSocketServer implements ResponderRSocket {
   private final KeepAliveFramesAcceptor keepAliveFramesAcceptor;
 
   /*client responder*/
-  RSocketServer(
+  RSocketResponder(
       ByteBufAllocator allocator,
       DuplexConnection connection,
       RSocket requestHandler,
@@ -71,7 +71,7 @@ class RSocketServer implements ResponderRSocket {
   }
 
   /*server responder*/
-  RSocketServer(
+  RSocketResponder(
       ByteBufAllocator allocator,
       DuplexConnection connection,
       RSocket requestHandler,

--- a/rsocket-core/src/main/java/io/rsocket/plugins/PluginRegistry.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/PluginRegistry.java
@@ -23,39 +23,63 @@ import java.util.List;
 
 public class PluginRegistry {
   private List<DuplexConnectionInterceptor> connections = new ArrayList<>();
-  private List<RSocketInterceptor> clients = new ArrayList<>();
-  private List<RSocketInterceptor> servers = new ArrayList<>();
+  private List<RSocketInterceptor> requesters = new ArrayList<>();
+  private List<RSocketInterceptor> handlers = new ArrayList<>();
 
   public PluginRegistry() {}
 
   public PluginRegistry(PluginRegistry defaults) {
     this.connections.addAll(defaults.connections);
-    this.clients.addAll(defaults.clients);
-    this.servers.addAll(defaults.servers);
+    this.requesters.addAll(defaults.requesters);
+    this.handlers.addAll(defaults.handlers);
   }
 
   public void addConnectionPlugin(DuplexConnectionInterceptor interceptor) {
     connections.add(interceptor);
   }
 
+  /** Deprecated. Use {@link #addRequesterPlugin(RSocketInterceptor)} instead */
+  @Deprecated
   public void addClientPlugin(RSocketInterceptor interceptor) {
-    clients.add(interceptor);
+    addRequesterPlugin(interceptor);
   }
 
+  public void addRequesterPlugin(RSocketInterceptor interceptor) {
+    requesters.add(interceptor);
+  }
+
+  /** Deprecated. Use {@link #addHandlerPlugin(RSocketInterceptor)} instead */
+  @Deprecated
   public void addServerPlugin(RSocketInterceptor interceptor) {
-    servers.add(interceptor);
+    addHandlerPlugin(interceptor);
   }
 
+  public void addHandlerPlugin(RSocketInterceptor interceptor) {
+    handlers.add(interceptor);
+  }
+
+  /** Deprecated. Use {@link #applyRequester(RSocket)} instead */
+  @Deprecated
   public RSocket applyClient(RSocket rSocket) {
-    for (RSocketInterceptor i : clients) {
+    return applyRequester(rSocket);
+  }
+
+  public RSocket applyRequester(RSocket rSocket) {
+    for (RSocketInterceptor i : requesters) {
       rSocket = i.apply(rSocket);
     }
 
     return rSocket;
   }
 
+  /** Deprecated. Use {@link #applyHandler(RSocket)} instead */
+  @Deprecated
   public RSocket applyServer(RSocket rSocket) {
-    for (RSocketInterceptor i : servers) {
+    return applyHandler(rSocket);
+  }
+
+  public RSocket applyHandler(RSocket rSocket) {
+    for (RSocketInterceptor i : handlers) {
       rSocket = i.apply(rSocket);
     }
 

--- a/rsocket-core/src/main/java/io/rsocket/plugins/PluginRegistry.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/PluginRegistry.java
@@ -24,14 +24,14 @@ import java.util.List;
 public class PluginRegistry {
   private List<DuplexConnectionInterceptor> connections = new ArrayList<>();
   private List<RSocketInterceptor> requesters = new ArrayList<>();
-  private List<RSocketInterceptor> handlers = new ArrayList<>();
+  private List<RSocketInterceptor> responders = new ArrayList<>();
 
   public PluginRegistry() {}
 
   public PluginRegistry(PluginRegistry defaults) {
     this.connections.addAll(defaults.connections);
     this.requesters.addAll(defaults.requesters);
-    this.handlers.addAll(defaults.handlers);
+    this.responders.addAll(defaults.responders);
   }
 
   public void addConnectionPlugin(DuplexConnectionInterceptor interceptor) {
@@ -48,14 +48,14 @@ public class PluginRegistry {
     requesters.add(interceptor);
   }
 
-  /** Deprecated. Use {@link #addHandlerPlugin(RSocketInterceptor)} instead */
+  /** Deprecated. Use {@link #addResponderPlugin(RSocketInterceptor)} instead */
   @Deprecated
   public void addServerPlugin(RSocketInterceptor interceptor) {
-    addHandlerPlugin(interceptor);
+    addResponderPlugin(interceptor);
   }
 
-  public void addHandlerPlugin(RSocketInterceptor interceptor) {
-    handlers.add(interceptor);
+  public void addResponderPlugin(RSocketInterceptor interceptor) {
+    responders.add(interceptor);
   }
 
   /** Deprecated. Use {@link #applyRequester(RSocket)} instead */
@@ -72,14 +72,14 @@ public class PluginRegistry {
     return rSocket;
   }
 
-  /** Deprecated. Use {@link #applyHandler(RSocket)} instead */
+  /** Deprecated. Use {@link #applyResponder(RSocket)} instead */
   @Deprecated
   public RSocket applyServer(RSocket rSocket) {
-    return applyHandler(rSocket);
+    return applyResponder(rSocket);
   }
 
-  public RSocket applyHandler(RSocket rSocket) {
-    for (RSocketInterceptor i : handlers) {
+  public RSocket applyResponder(RSocket rSocket) {
+    for (RSocketInterceptor i : responders) {
       rSocket = i.apply(rSocket);
     }
 

--- a/rsocket-core/src/test/java/io/rsocket/KeepAliveTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/KeepAliveTest.java
@@ -65,8 +65,8 @@ public class KeepAliveTest {
     return () -> {
       TestDuplexConnection connection = new TestDuplexConnection();
       Errors errors = new Errors();
-      RSocketClient rSocket =
-          new RSocketClient(
+      RSocketRequester rSocket =
+          new RSocketRequester(
               ByteBufAllocator.DEFAULT,
               connection,
               DefaultPayload::create,
@@ -84,8 +84,8 @@ public class KeepAliveTest {
       TestDuplexConnection connection = new TestDuplexConnection();
       AbstractRSocket handler = new AbstractRSocket() {};
       Errors errors = new Errors();
-      RSocketServer rSocket =
-          new RSocketServer(
+      RSocketResponder rSocket =
+          new RSocketResponder(
               ByteBufAllocator.DEFAULT,
               connection,
               handler,
@@ -110,8 +110,8 @@ public class KeepAliveTest {
               false);
 
       Errors errors = new Errors();
-      RSocketClient rSocket =
-          new RSocketClient(
+      RSocketRequester rSocket =
+          new RSocketRequester(
               ByteBufAllocator.DEFAULT,
               resumableConnection,
               DefaultPayload::create,
@@ -136,8 +136,8 @@ public class KeepAliveTest {
               Duration.ofSeconds(10),
               false);
       Errors errors = new Errors();
-      RSocketServer rSocket =
-          new RSocketServer(
+      RSocketResponder rSocket =
+          new RSocketResponder(
               ByteBufAllocator.DEFAULT,
               resumableConnection,
               handler,

--- a/rsocket-core/src/test/java/io/rsocket/RSocketRequesterTerminationTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketRequesterTerminationTest.java
@@ -1,6 +1,6 @@
 package io.rsocket;
 
-import io.rsocket.RSocketClientTest.ClientSocketRule;
+import io.rsocket.RSocketRequesterTest.ClientSocketRule;
 import io.rsocket.util.EmptyPayload;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
@@ -16,18 +16,18 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 @RunWith(Parameterized.class)
-public class RSocketClientTerminationTest {
+public class RSocketRequesterTerminationTest {
 
   @Rule public final ClientSocketRule rule = new ClientSocketRule();
   private Function<RSocket, ? extends Publisher<?>> interaction;
 
-  public RSocketClientTerminationTest(Function<RSocket, ? extends Publisher<?>> interaction) {
+  public RSocketRequesterTerminationTest(Function<RSocket, ? extends Publisher<?>> interaction) {
     this.interaction = interaction;
   }
 
   @Test
   public void testCurrentStreamIsTerminatedOnConnectionClose() {
-    RSocketClient rSocket = rule.socket;
+    RSocketRequester rSocket = rule.socket;
 
     Mono.delay(Duration.ofSeconds(1)).doOnNext(v -> rule.connection.dispose()).subscribe();
 
@@ -38,7 +38,7 @@ public class RSocketClientTerminationTest {
 
   @Test
   public void testSubsequentStreamIsTerminatedAfterConnectionClose() {
-    RSocketClient rSocket = rule.socket;
+    RSocketRequester rSocket = rule.socket;
 
     rule.connection.dispose();
     StepVerifier.create(interaction.apply(rSocket))

--- a/rsocket-core/src/test/java/io/rsocket/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketRequesterTest.java
@@ -47,7 +47,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.UnicastProcessor;
 
-public class RSocketClientTest {
+public class RSocketRequesterTest {
 
   @Rule public final ClientSocketRule rule = new ClientSocketRule();
 
@@ -223,10 +223,10 @@ public class RSocketClientTest {
     return streamId;
   }
 
-  public static class ClientSocketRule extends AbstractSocketRule<RSocketClient> {
+  public static class ClientSocketRule extends AbstractSocketRule<RSocketRequester> {
     @Override
-    protected RSocketClient newRSocket() {
-      return new RSocketClient(
+    protected RSocketRequester newRSocket() {
+      return new RSocketRequester(
           ByteBufAllocator.DEFAULT,
           connection,
           DefaultPayload::create,

--- a/rsocket-core/src/test/java/io/rsocket/RSocketResponderTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketResponderTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Mono;
 
-public class RSocketServerTest {
+public class RSocketResponderTest {
 
   @Rule public final ServerSocketRule rule = new ServerSocketRule();
 
@@ -106,7 +106,7 @@ public class RSocketServerTest {
     assertThat("Subscription not cancelled.", cancelled.get(), is(true));
   }
 
-  public static class ServerSocketRule extends AbstractSocketRule<RSocketServer> {
+  public static class ServerSocketRule extends AbstractSocketRule<RSocketResponder> {
 
     private RSocket acceptingSocket;
 
@@ -140,8 +140,8 @@ public class RSocketServerTest {
     }
 
     @Override
-    protected RSocketServer newRSocket() {
-      return new RSocketServer(
+    protected RSocketResponder newRSocket() {
+      return new RSocketResponder(
           ByteBufAllocator.DEFAULT,
           connection,
           acceptingSocket,

--- a/rsocket-core/src/test/java/io/rsocket/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketTest.java
@@ -102,10 +102,10 @@ public class RSocketTest {
 
     DirectProcessor<ByteBuf> serverProcessor;
     DirectProcessor<ByteBuf> clientProcessor;
-    private RSocketClient crs;
+    private RSocketRequester crs;
 
     @SuppressWarnings("unused")
-    private RSocketServer srs;
+    private RSocketResponder srs;
 
     private RSocket requestAcceptor;
     private ArrayList<Throwable> clientErrors = new ArrayList<>();
@@ -163,7 +163,7 @@ public class RSocketTest {
               };
 
       srs =
-          new RSocketServer(
+          new RSocketResponder(
               ByteBufAllocator.DEFAULT,
               serverConnection,
               requestAcceptor,
@@ -171,7 +171,7 @@ public class RSocketTest {
               throwable -> serverErrors.add(throwable));
 
       crs =
-          new RSocketClient(
+          new RSocketRequester(
               ByteBufAllocator.DEFAULT,
               clientConnection,
               DefaultPayload::create,

--- a/rsocket-core/src/test/java/io/rsocket/SetupRejectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/SetupRejectionTest.java
@@ -49,8 +49,8 @@ public class SetupRejectionTest {
   void requesterStreamsTerminatedOnZeroErrorFrame() {
     TestDuplexConnection conn = new TestDuplexConnection();
     List<Throwable> errors = new ArrayList<>();
-    RSocketClient rSocket =
-        new RSocketClient(
+    RSocketRequester rSocket =
+        new RSocketRequester(
             ByteBufAllocator.DEFAULT,
             conn,
             DefaultPayload::create,
@@ -79,8 +79,8 @@ public class SetupRejectionTest {
   @Test
   void requesterNewStreamsTerminatedAfterZeroErrorFrame() {
     TestDuplexConnection conn = new TestDuplexConnection();
-    RSocketClient rSocket =
-        new RSocketClient(
+    RSocketRequester rSocket =
+        new RSocketRequester(
             ByteBufAllocator.DEFAULT,
             conn,
             DefaultPayload::create,


### PR DESCRIPTION
`RSocketClient` and `RSocketServer` names for requester and responder are misleading because each side of connection has both, and they can be confused with client and server of `RSocketFactory`. Happened more than once already so It makes sense to rename them appropriately https://github.com/rsocket/rsocket-java/issues/640#issuecomment-494313461. 