### PR TITLE
ClientServerMultiplexer should properly route zero non-setup frames

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -300,7 +300,7 @@ public class RSocketFactory {
                   DuplexConnection wrappedConnection = clientSetup.connection();
 
                   ClientServerInputMultiplexer multiplexer =
-                      new ClientServerInputMultiplexer(wrappedConnection, plugins);
+                      new ClientServerInputMultiplexer(wrappedConnection, plugins, true);
 
                   RSocketRequester rSocketRequester =
                       new RSocketRequester(
@@ -500,7 +500,7 @@ public class RSocketFactory {
 
       private Mono<Void> acceptor(ServerSetup serverSetup, DuplexConnection connection) {
         ClientServerInputMultiplexer multiplexer =
-            new ClientServerInputMultiplexer(connection, plugins);
+            new ClientServerInputMultiplexer(connection, plugins, false);
 
         return multiplexer
             .asSetupConnection()

--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -553,7 +553,10 @@ public class RSocketFactory {
                       wrappedMultiplexer.asServerConnection(),
                       payloadDecoder,
                       errorConsumer,
-                      StreamIdSupplier.serverSupplier());
+                      StreamIdSupplier.serverSupplier(),
+                      setupPayload.keepAliveInterval(),
+                      setupPayload.keepAliveMaxLifetime(),
+                      keepAliveHandler);
 
               RSocket wrappedRSocketRequester = plugins.applyRequester(rSocketRequester);
 
@@ -571,10 +574,7 @@ public class RSocketFactory {
                                 wrappedMultiplexer.asClientConnection(),
                                 wrappedRSocketHandler,
                                 payloadDecoder,
-                                errorConsumer,
-                                setupPayload.keepAliveInterval(),
-                                setupPayload.keepAliveMaxLifetime(),
-                                keepAliveHandler);
+                                errorConsumer);
                       })
                   .doFinally(signalType -> setupPayload.release())
                   .then();

--- a/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
@@ -61,7 +61,6 @@ class RSocketRequester implements RSocket {
   private final ByteBufAllocator allocator;
   private final KeepAliveFramesAcceptor keepAliveFramesAcceptor;
 
-  /*client requester*/
   RSocketRequester(
       ByteBufAllocator allocator,
       DuplexConnection connection,
@@ -100,7 +99,7 @@ class RSocketRequester implements RSocket {
     }
   }
 
-  /*server requester*/
+  /*for testing only*/
   RSocketRequester(
       ByteBufAllocator allocator,
       DuplexConnection connection,

--- a/rsocket-core/src/main/java/io/rsocket/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketResponder.java
@@ -16,22 +16,15 @@
 
 package io.rsocket;
 
-import static io.rsocket.keepalive.KeepAliveSupport.KeepAlive;
-import static io.rsocket.keepalive.KeepAliveSupport.ServerKeepAliveSupport;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.collection.IntObjectHashMap;
 import io.rsocket.exceptions.ApplicationErrorException;
-import io.rsocket.exceptions.ConnectionErrorException;
 import io.rsocket.frame.*;
 import io.rsocket.frame.decoder.PayloadDecoder;
 import io.rsocket.internal.LimitableRequestPublisher;
 import io.rsocket.internal.UnboundedProcessor;
-import io.rsocket.keepalive.KeepAliveFramesAcceptor;
-import io.rsocket.keepalive.KeepAliveHandler;
-import io.rsocket.keepalive.KeepAliveSupport;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -58,28 +51,13 @@ class RSocketResponder implements ResponderRSocket {
 
   private final UnboundedProcessor<ByteBuf> sendProcessor;
   private final ByteBufAllocator allocator;
-  private final KeepAliveFramesAcceptor keepAliveFramesAcceptor;
 
-  /*client responder*/
   RSocketResponder(
       ByteBufAllocator allocator,
       DuplexConnection connection,
       RSocket requestHandler,
       PayloadDecoder payloadDecoder,
       Consumer<Throwable> errorConsumer) {
-    this(allocator, connection, requestHandler, payloadDecoder, errorConsumer, 0, 0, null);
-  }
-
-  /*server responder*/
-  RSocketResponder(
-      ByteBufAllocator allocator,
-      DuplexConnection connection,
-      RSocket requestHandler,
-      PayloadDecoder payloadDecoder,
-      Consumer<Throwable> errorConsumer,
-      int keepAliveTickPeriod,
-      int keepAliveAckTimeout,
-      KeepAliveHandler keepAliveHandler) {
     this.allocator = allocator;
     this.connection = connection;
 
@@ -112,22 +90,6 @@ class RSocketResponder implements ResponderRSocket {
               receiveDisposable.dispose();
             })
         .subscribe(null, errorConsumer);
-
-    if (keepAliveTickPeriod != 0 && keepAliveHandler != null) {
-      KeepAliveSupport keepAliveSupport =
-          new ServerKeepAliveSupport(allocator, keepAliveTickPeriod, keepAliveAckTimeout);
-      keepAliveFramesAcceptor =
-          keepAliveHandler.start(keepAliveSupport, sendProcessor::onNext, this::terminate);
-    } else {
-      keepAliveFramesAcceptor = null;
-    }
-  }
-
-  private void terminate(KeepAlive keepAlive) {
-    String message =
-        String.format("No keep-alive acks for %d ms", keepAlive.getTimeout().toMillis());
-    errorConsumer.accept(new ConnectionErrorException(message));
-    connection.dispose();
   }
 
   private void handleSendProcessorError(Throwable t) {
@@ -308,9 +270,6 @@ class RSocketResponder implements ResponderRSocket {
           break;
         case CANCEL:
           handleCancelFrame(streamId);
-          break;
-        case KEEPALIVE:
-          handleKeepAliveFrame(frame);
           break;
         case REQUEST_N:
           handleRequestN(streamId, frame);
@@ -514,12 +473,6 @@ class RSocketResponder implements ResponderRSocket {
       handleStream(streamId, requestChannel(payload, payloads), initialRequestN);
     } else {
       handleStream(streamId, requestChannel(payloads), initialRequestN);
-    }
-  }
-
-  private void handleKeepAliveFrame(ByteBuf frame) {
-    if (keepAliveFramesAcceptor != null) {
-      keepAliveFramesAcceptor.receive(frame);
     }
   }
 

--- a/rsocket-core/src/test/java/io/rsocket/KeepAliveTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/KeepAliveTest.java
@@ -34,12 +34,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -49,112 +46,58 @@ public class KeepAliveTest {
   private static final int KEEP_ALIVE_TIMEOUT = 1000;
   private static final int RESUMABLE_KEEP_ALIVE_TIMEOUT = 200;
 
-  static Stream<Supplier<RSocketState>> rSocketStates() {
-    return Stream.of(
-        requester(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT),
-        responder(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT));
+  private RSocketState requesterState;
+  private ResumableRSocketState resumableRequesterState;
+
+  static RSocketState requester(int tickPeriod, int timeout) {
+    TestDuplexConnection connection = new TestDuplexConnection();
+    Errors errors = new Errors();
+    RSocketRequester rSocket =
+        new RSocketRequester(
+            ByteBufAllocator.DEFAULT,
+            connection,
+            DefaultPayload::create,
+            errors,
+            StreamIdSupplier.clientSupplier(),
+            tickPeriod,
+            timeout,
+            new DefaultKeepAliveHandler(connection));
+    return new RSocketState(rSocket, errors, connection);
   }
 
-  static Stream<Supplier<ResumableRSocketState>> resumableRSocketStates() {
-    return Stream.of(
-        resumableRequester(KEEP_ALIVE_INTERVAL, RESUMABLE_KEEP_ALIVE_TIMEOUT),
-        resumableResponder(KEEP_ALIVE_INTERVAL, RESUMABLE_KEEP_ALIVE_TIMEOUT));
+  static ResumableRSocketState resumableRequester(int tickPeriod, int timeout) {
+    TestDuplexConnection connection = new TestDuplexConnection();
+    ResumableDuplexConnection resumableConnection =
+        new ResumableDuplexConnection(
+            "test",
+            connection,
+            new InMemoryResumableFramesStore("test", 10_000),
+            Duration.ofSeconds(10),
+            false);
+
+    Errors errors = new Errors();
+    RSocketRequester rSocket =
+        new RSocketRequester(
+            ByteBufAllocator.DEFAULT,
+            resumableConnection,
+            DefaultPayload::create,
+            errors,
+            StreamIdSupplier.clientSupplier(),
+            tickPeriod,
+            timeout,
+            new ResumableKeepAliveHandler(resumableConnection));
+    return new ResumableRSocketState(rSocket, errors, connection, resumableConnection);
   }
 
-  static Supplier<RSocketState> requester(int tickPeriod, int timeout) {
-    return () -> {
-      TestDuplexConnection connection = new TestDuplexConnection();
-      Errors errors = new Errors();
-      RSocketRequester rSocket =
-          new RSocketRequester(
-              ByteBufAllocator.DEFAULT,
-              connection,
-              DefaultPayload::create,
-              errors,
-              StreamIdSupplier.clientSupplier(),
-              tickPeriod,
-              timeout,
-              new DefaultKeepAliveHandler(connection));
-      return new RSocketState(rSocket, errors, connection);
-    };
+  @BeforeEach
+  void setUp() {
+    requesterState = requester(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT);
+    resumableRequesterState = resumableRequester(KEEP_ALIVE_INTERVAL, RESUMABLE_KEEP_ALIVE_TIMEOUT);
   }
 
-  static Supplier<RSocketState> responder(int tickPeriod, int timeout) {
-    return () -> {
-      TestDuplexConnection connection = new TestDuplexConnection();
-      AbstractRSocket handler = new AbstractRSocket() {};
-      Errors errors = new Errors();
-      RSocketResponder rSocket =
-          new RSocketResponder(
-              ByteBufAllocator.DEFAULT,
-              connection,
-              handler,
-              DefaultPayload::create,
-              errors,
-              tickPeriod,
-              timeout,
-              new DefaultKeepAliveHandler(connection));
-      return new RSocketState(rSocket, errors, connection);
-    };
-  }
-
-  static Supplier<ResumableRSocketState> resumableRequester(int tickPeriod, int timeout) {
-    return () -> {
-      TestDuplexConnection connection = new TestDuplexConnection();
-      ResumableDuplexConnection resumableConnection =
-          new ResumableDuplexConnection(
-              "test",
-              connection,
-              new InMemoryResumableFramesStore("test", 10_000),
-              Duration.ofSeconds(10),
-              false);
-
-      Errors errors = new Errors();
-      RSocketRequester rSocket =
-          new RSocketRequester(
-              ByteBufAllocator.DEFAULT,
-              resumableConnection,
-              DefaultPayload::create,
-              errors,
-              StreamIdSupplier.clientSupplier(),
-              tickPeriod,
-              timeout,
-              new ResumableKeepAliveHandler(resumableConnection));
-      return new ResumableRSocketState(rSocket, errors, connection, resumableConnection);
-    };
-  }
-
-  static Supplier<ResumableRSocketState> resumableResponder(int tickPeriod, int timeout) {
-    return () -> {
-      AbstractRSocket handler = new AbstractRSocket() {};
-      TestDuplexConnection connection = new TestDuplexConnection();
-      ResumableDuplexConnection resumableConnection =
-          new ResumableDuplexConnection(
-              "test",
-              connection,
-              new InMemoryResumableFramesStore("test", 10_000),
-              Duration.ofSeconds(10),
-              false);
-      Errors errors = new Errors();
-      RSocketResponder rSocket =
-          new RSocketResponder(
-              ByteBufAllocator.DEFAULT,
-              resumableConnection,
-              handler,
-              DefaultPayload::create,
-              errors,
-              tickPeriod,
-              timeout,
-              new ResumableKeepAliveHandler(resumableConnection));
-      return new ResumableRSocketState(rSocket, errors, connection, resumableConnection);
-    };
-  }
-
-  @ParameterizedTest
-  @MethodSource("rSocketStates")
-  void rSocketNotDisposedOnPresentKeepAlives(Supplier<RSocketState> testDataSupplier) {
-    RSocketState RSocketState = testDataSupplier.get();
-    TestDuplexConnection connection = RSocketState.connection();
+  @Test
+  void rSocketNotDisposedOnPresentKeepAlives() {
+    TestDuplexConnection connection = requesterState.connection();
 
     Flux.interval(Duration.ofMillis(100))
         .subscribe(
@@ -165,33 +108,30 @@ public class KeepAliveTest {
 
     Mono.delay(Duration.ofMillis(1500)).block();
 
-    RSocket rSocket = RSocketState.rSocket();
-    List<Throwable> errors = RSocketState.errors().errors();
+    RSocket rSocket = requesterState.rSocket();
+    List<Throwable> errors = requesterState.errors().errors();
 
     Assertions.assertThat(rSocket.isDisposed()).isFalse();
     Assertions.assertThat(errors).isEmpty();
   }
 
-  @ParameterizedTest
-  @MethodSource("rSocketStates")
-  void noKeepAlivesSentAfterRSocketDispose(Supplier<RSocketState> testDataSupplier) {
-    RSocketState RSocketState = testDataSupplier.get();
-    RSocketState.rSocket().dispose();
+  @Test
+  void noKeepAlivesSentAfterRSocketDispose() {
+    requesterState.rSocket().dispose();
     StepVerifier.create(
-            Flux.from(RSocketState.connection().getSentAsPublisher()).take(Duration.ofMillis(500)))
+            Flux.from(requesterState.connection().getSentAsPublisher())
+                .take(Duration.ofMillis(500)))
         .expectComplete()
         .verify(Duration.ofSeconds(1));
   }
 
-  @ParameterizedTest
-  @MethodSource("rSocketStates")
-  void rSocketDisposedOnMissingKeepAlives(Supplier<RSocketState> testDataSupplier) {
-    RSocketState rSocketState = testDataSupplier.get();
-    RSocket rSocket = rSocketState.rSocket();
+  @Test
+  void rSocketDisposedOnMissingKeepAlives() {
+    RSocket rSocket = requesterState.rSocket();
 
     Mono.delay(Duration.ofMillis(1500)).block();
 
-    List<Throwable> errors = rSocketState.errors().errors();
+    List<Throwable> errors = requesterState.errors().errors();
     Assertions.assertThat(rSocket.isDisposed()).isTrue();
     Assertions.assertThat(errors).hasSize(1);
     Throwable throwable = errors.get(0);
@@ -200,7 +140,7 @@ public class KeepAliveTest {
 
   @Test
   void clientRequesterSendsKeepAlives() {
-    RSocketState RSocketState = requester(100, 1000).get();
+    RSocketState RSocketState = requester(100, 1000);
     TestDuplexConnection connection = RSocketState.connection();
 
     StepVerifier.create(Flux.from(connection.getSentAsPublisher()).take(3))
@@ -212,8 +152,8 @@ public class KeepAliveTest {
   }
 
   @Test
-  void serverResponderSendsKeepAlives() {
-    RSocketState RSocketState = responder(100, 1000).get();
+  void requesterRespondsToKeepAlives() {
+    RSocketState RSocketState = requester(100_000, 100_000);
     TestDuplexConnection connection = RSocketState.connection();
     Mono.delay(Duration.ofMillis(100))
         .subscribe(
@@ -231,7 +171,7 @@ public class KeepAliveTest {
   @Test
   void resumableRequesterNoKeepAlivesAfterDisconnect() {
     ResumableRSocketState rSocketState =
-        resumableRequester(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT).get();
+        resumableRequester(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT);
     TestDuplexConnection testConnection = rSocketState.connection();
     ResumableDuplexConnection resumableDuplexConnection = rSocketState.resumableDuplexConnection();
 
@@ -245,7 +185,7 @@ public class KeepAliveTest {
   @Test
   void resumableRequesterKeepAlivesAfterReconnect() {
     ResumableRSocketState rSocketState =
-        resumableRequester(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT).get();
+        resumableRequester(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT);
     ResumableDuplexConnection resumableDuplexConnection = rSocketState.resumableDuplexConnection();
     resumableDuplexConnection.disconnect();
     TestDuplexConnection newTestConnection = new TestDuplexConnection();
@@ -261,7 +201,7 @@ public class KeepAliveTest {
   @Test
   void resumableRequesterNoKeepAlivesAfterDispose() {
     ResumableRSocketState rSocketState =
-        resumableRequester(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT).get();
+        resumableRequester(KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT);
     rSocketState.rSocket().dispose();
     StepVerifier.create(
             Flux.from(rSocketState.connection().getSentAsPublisher()).take(Duration.ofMillis(500)))
@@ -269,14 +209,11 @@ public class KeepAliveTest {
         .verify(Duration.ofSeconds(5));
   }
 
-  @ParameterizedTest
-  @MethodSource("resumableRSocketStates")
-  void resumableRSocketsNotDisposedOnMissingKeepAlives(
-      Supplier<ResumableRSocketState> testDataSupplier) {
-    ResumableRSocketState rSocketState = testDataSupplier.get();
-    RSocket rSocket = rSocketState.rSocket();
-    List<Throwable> errors = rSocketState.errors().errors();
-    TestDuplexConnection connection = rSocketState.connection();
+  @Test
+  void resumableRSocketsNotDisposedOnMissingKeepAlives() {
+    RSocket rSocket = resumableRequesterState.rSocket();
+    List<Throwable> errors = resumableRequesterState.errors().errors();
+    TestDuplexConnection connection = resumableRequesterState.connection();
 
     Mono.delay(Duration.ofMillis(500)).block();
 

--- a/rsocket-core/src/test/java/io/rsocket/internal/ClientServerInputMultiplexerTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/ClientServerInputMultiplexerTest.java
@@ -18,8 +18,10 @@ package io.rsocket.internal;
 
 import static org.junit.Assert.assertEquals;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.rsocket.frame.ErrorFrameFlyweight;
+import io.netty.buffer.Unpooled;
+import io.rsocket.frame.*;
 import io.rsocket.plugins.PluginRegistry;
 import io.rsocket.test.util.TestDuplexConnection;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -28,50 +30,196 @@ import org.junit.Test;
 
 public class ClientServerInputMultiplexerTest {
   private TestDuplexConnection source;
-  private ClientServerInputMultiplexer multiplexer;
+  private ClientServerInputMultiplexer clientMultiplexer;
   private ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+  private ClientServerInputMultiplexer serverMultiplexer;
 
   @Before
   public void setup() {
     source = new TestDuplexConnection();
-    multiplexer = new ClientServerInputMultiplexer(source, new PluginRegistry());
+    clientMultiplexer = new ClientServerInputMultiplexer(source, new PluginRegistry(), true);
+    serverMultiplexer = new ClientServerInputMultiplexer(source, new PluginRegistry(), false);
   }
 
   @Test
-  public void testSplits() {
+  public void clientSplits() {
     AtomicInteger clientFrames = new AtomicInteger();
     AtomicInteger serverFrames = new AtomicInteger();
-    AtomicInteger connectionFrames = new AtomicInteger();
+    AtomicInteger setupFrames = new AtomicInteger();
 
-    multiplexer
+    clientMultiplexer
         .asClientConnection()
         .receive()
         .doOnNext(f -> clientFrames.incrementAndGet())
         .subscribe();
-    multiplexer
+    clientMultiplexer
         .asServerConnection()
         .receive()
         .doOnNext(f -> serverFrames.incrementAndGet())
         .subscribe();
-    multiplexer
+    clientMultiplexer
         .asSetupConnection()
         .receive()
-        .doOnNext(f -> connectionFrames.incrementAndGet())
+        .doOnNext(f -> setupFrames.incrementAndGet())
         .subscribe();
 
-    source.addToReceivedBuffer(ErrorFrameFlyweight.encode(allocator, 1, new Exception()));
+    source.addToReceivedBuffer(errorFrame(1));
     assertEquals(1, clientFrames.get());
     assertEquals(0, serverFrames.get());
-    assertEquals(0, connectionFrames.get());
+    assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(ErrorFrameFlyweight.encode(allocator, 2, new Exception()));
-    assertEquals(1, clientFrames.get());
+    source.addToReceivedBuffer(errorFrame(1));
+    assertEquals(2, clientFrames.get());
+    assertEquals(0, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(leaseFrame());
+    assertEquals(3, clientFrames.get());
+    assertEquals(0, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(keepAliveFrame());
+    assertEquals(4, clientFrames.get());
+    assertEquals(0, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(errorFrame(2));
+    assertEquals(4, clientFrames.get());
     assertEquals(1, serverFrames.get());
-    assertEquals(0, connectionFrames.get());
+    assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(ErrorFrameFlyweight.encode(allocator, 1, new Exception()));
+    source.addToReceivedBuffer(errorFrame(0));
+    assertEquals(5, clientFrames.get());
+    assertEquals(1, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(metadataPushFrame());
+    assertEquals(5, clientFrames.get());
+    assertEquals(2, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(setupFrame());
+    assertEquals(5, clientFrames.get());
+    assertEquals(2, serverFrames.get());
+    assertEquals(1, setupFrames.get());
+
+    source.addToReceivedBuffer(resumeFrame());
+    assertEquals(5, clientFrames.get());
+    assertEquals(2, serverFrames.get());
+    assertEquals(2, setupFrames.get());
+
+    source.addToReceivedBuffer(resumeOkFrame());
+    assertEquals(5, clientFrames.get());
+    assertEquals(2, serverFrames.get());
+    assertEquals(3, setupFrames.get());
+  }
+
+  @Test
+  public void serverSplits() {
+    AtomicInteger clientFrames = new AtomicInteger();
+    AtomicInteger serverFrames = new AtomicInteger();
+    AtomicInteger setupFrames = new AtomicInteger();
+
+    serverMultiplexer
+        .asClientConnection()
+        .receive()
+        .doOnNext(f -> clientFrames.incrementAndGet())
+        .subscribe();
+    serverMultiplexer
+        .asServerConnection()
+        .receive()
+        .doOnNext(f -> serverFrames.incrementAndGet())
+        .subscribe();
+    serverMultiplexer
+        .asSetupConnection()
+        .receive()
+        .doOnNext(f -> setupFrames.incrementAndGet())
+        .subscribe();
+
+    source.addToReceivedBuffer(errorFrame(1));
+    assertEquals(1, clientFrames.get());
+    assertEquals(0, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(errorFrame(1));
+    assertEquals(2, clientFrames.get());
+    assertEquals(0, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(leaseFrame());
     assertEquals(2, clientFrames.get());
     assertEquals(1, serverFrames.get());
-    assertEquals(0, connectionFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(keepAliveFrame());
+    assertEquals(2, clientFrames.get());
+    assertEquals(2, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(errorFrame(2));
+    assertEquals(2, clientFrames.get());
+    assertEquals(3, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(errorFrame(0));
+    assertEquals(2, clientFrames.get());
+    assertEquals(4, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(metadataPushFrame());
+    assertEquals(3, clientFrames.get());
+    assertEquals(4, serverFrames.get());
+    assertEquals(0, setupFrames.get());
+
+    source.addToReceivedBuffer(setupFrame());
+    assertEquals(3, clientFrames.get());
+    assertEquals(4, serverFrames.get());
+    assertEquals(1, setupFrames.get());
+
+    source.addToReceivedBuffer(resumeFrame());
+    assertEquals(3, clientFrames.get());
+    assertEquals(4, serverFrames.get());
+    assertEquals(2, setupFrames.get());
+
+    source.addToReceivedBuffer(resumeOkFrame());
+    assertEquals(3, clientFrames.get());
+    assertEquals(4, serverFrames.get());
+    assertEquals(3, setupFrames.get());
+  }
+
+  private ByteBuf resumeFrame() {
+    return ResumeFrameFlyweight.encode(allocator, Unpooled.EMPTY_BUFFER, 0, 0);
+  }
+
+  private ByteBuf setupFrame() {
+    return SetupFrameFlyweight.encode(
+        ByteBufAllocator.DEFAULT,
+        false,
+        0,
+        42,
+        "application/octet-stream",
+        "application/octet-stream",
+        Unpooled.EMPTY_BUFFER,
+        Unpooled.EMPTY_BUFFER);
+  }
+
+  private ByteBuf leaseFrame() {
+    return LeaseFlyweight.encode(allocator, 1_000, 1, Unpooled.EMPTY_BUFFER);
+  }
+
+  private ByteBuf errorFrame(int i) {
+    return ErrorFrameFlyweight.encode(allocator, i, new Exception());
+  }
+
+  private ByteBuf resumeOkFrame() {
+    return ResumeOkFrameFlyweight.encode(allocator, 0);
+  }
+
+  private ByteBuf keepAliveFrame() {
+    return KeepAliveFrameFlyweight.encode(allocator, false, 0, Unpooled.EMPTY_BUFFER);
+  }
+
+  private ByteBuf metadataPushFrame() {
+    return MetadataPushFrameFlyweight.encode(allocator, Unpooled.EMPTY_BUFFER);
   }
 }


### PR DESCRIPTION
to either requester or responder, regardless of connection side. This would simplify lease by removing coupling between requester and responder. Also fixes MetadaPush related issue https://github.com/rsocket/rsocket-java/issues/470 