### PR TITLE
fix: LoadBalancedRSocketMono and RSocketSupplierPool not in sync

### DIFF
--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
@@ -581,7 +581,8 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
               s -> {
                 pool.accept(factory);
                 activeSockets.remove(WeightedSocket.this);
-                logger.debug("Removed {} from factory {} from activeSockets", WeightedSocket.this, factory);
+                logger.debug(
+                    "Removed {} from factory {} from activeSockets", WeightedSocket.this, factory);
                 refreshSockets();
               })
           .subscribe();
@@ -591,7 +592,11 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
           .retryBackoff(weightedSocketRetries, weightedSocketBackOff, weightedSocketMaxBackOff)
           .doOnError(
               throwable -> {
-                logger.error("error while connecting {} from factory {}", WeightedSocket.this, factory, throwable);
+                logger.error(
+                    "error while connecting {} from factory {}",
+                    WeightedSocket.this,
+                    factory,
+                    throwable);
                 WeightedSocket.this.dispose();
               })
           .subscribe(
@@ -601,7 +606,8 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
                     .onClose()
                     .doFinally(
                         signalType -> {
-                          logger.info("RSocket {} from factory {} closed", WeightedSocket.this, factory);
+                          logger.info(
+                              "RSocket {} from factory {} closed", WeightedSocket.this, factory);
                           WeightedSocket.this.dispose();
                         })
                     .subscribe();
@@ -621,7 +627,10 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
                     .onClose()
                     .doFinally(
                         signalType -> {
-                          logger.info("WeightedSocket {} from factory {} closed", WeightedSocket.this, factory);
+                          logger.info(
+                              "WeightedSocket {} from factory {} closed",
+                              WeightedSocket.this,
+                              factory);
                           rSocket.dispose();
                         })
                     .subscribe();
@@ -634,9 +643,13 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
                 }*/
                 rSocketMono.onNext(rSocket);
                 availability = 1.0;
-                if (!WeightedSocket.this.isDisposed()) { // May be already disposed because of retryBackoff delay
+                if (!WeightedSocket.this
+                    .isDisposed()) { // May be already disposed because of retryBackoff delay
                   activeSockets.add(WeightedSocket.this);
-                  logger.debug("Added WeightedSocket {} from factory {} to activeSockets", WeightedSocket.this, factory);
+                  logger.debug(
+                      "Added WeightedSocket {} from factory {} to activeSockets",
+                      WeightedSocket.this,
+                      factory);
                 }
               });
     }

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
@@ -279,7 +279,6 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
       if (optional.isPresent()) {
         RSocketSupplier supplier = optional.get();
         WeightedSocket socket = new WeightedSocket(supplier, lowerQuantile, higherQuantile);
-        activeSockets.add(socket);
       } else {
         break;
       }
@@ -356,7 +355,8 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
     }
 
     if (slowest != null) {
-      activeSockets.remove(slowest);
+      logger.debug("Disposing slowest WeightedSocket {}", slowest);
+      slowest.dispose();
     }
   }
 
@@ -461,7 +461,7 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
 
   @Override
   public void dispose() {
-    synchronized (this) {;
+    synchronized (this) {
       activeSockets.forEach(WeightedSocket::dispose);
       activeSockets.clear();
       onClose.onComplete();
@@ -573,12 +573,15 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
       this.interArrivalTime = new Ewma(1, TimeUnit.MINUTES, DEFAULT_INITIAL_INTER_ARRIVAL_TIME);
       this.pendingStreams = new AtomicLong();
 
+      logger.debug("Creating WeightedSocket {} from factory {}", WeightedSocket.this, factory);
+
       WeightedSocket.this
           .onClose()
           .doFinally(
               s -> {
                 pool.accept(factory);
                 activeSockets.remove(WeightedSocket.this);
+                logger.debug("Removed {} from factory {} from activeSockets", WeightedSocket.this, factory);
                 refreshSockets();
               })
           .subscribe();
@@ -588,7 +591,7 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
           .retryBackoff(weightedSocketRetries, weightedSocketBackOff, weightedSocketMaxBackOff)
           .doOnError(
               throwable -> {
-                logger.error("error while connecting {}", throwable);
+                logger.error("error while connecting {} from factory {}", WeightedSocket.this, factory, throwable);
                 WeightedSocket.this.dispose();
               })
           .subscribe(
@@ -598,7 +601,7 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
                     .onClose()
                     .doFinally(
                         signalType -> {
-                          System.out.println("RSocket closed");
+                          logger.info("RSocket {} from factory {} closed", WeightedSocket.this, factory);
                           WeightedSocket.this.dispose();
                         })
                     .subscribe();
@@ -608,7 +611,7 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
                     .onClose()
                     .doFinally(
                         signalType -> {
-                          System.out.println("Factory closed");
+                          logger.info("Factory {} closed", factory);
                           rSocket.dispose();
                         })
                     .subscribe();
@@ -618,20 +621,23 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
                     .onClose()
                     .doFinally(
                         signalType -> {
-                          System.out.println("WeightedSocket closed");
+                          logger.info("WeightedSocket {} from factory {} closed", WeightedSocket.this, factory);
                           rSocket.dispose();
                         })
                     .subscribe();
 
-                synchronized (LoadBalancedRSocketMono.this) {
+                /*synchronized (LoadBalancedRSocketMono.this) {
                   if (activeSockets.size() >= targetAperture) {
                     quickSlowestRS();
                     pendingSockets -= 1;
                   }
-                }
-
+                }*/
                 rSocketMono.onNext(rSocket);
                 availability = 1.0;
+                if (!WeightedSocket.this.isDisposed()) { // May be already disposed because of retryBackoff delay
+                  activeSockets.add(WeightedSocket.this);
+                  logger.debug("Added WeightedSocket {} from factory {} to activeSockets", WeightedSocket.this, factory);
+                }
               });
     }
 
@@ -829,11 +835,11 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
      */
     private class LatencySubscriber<U> implements Subscriber<U> {
       private final Subscriber<U> child;
-      private final LoadBalancedRSocketMono.WeightedSocket socket;
+      private final WeightedSocket socket;
       private final AtomicBoolean done;
       private long start;
 
-      LatencySubscriber(Subscriber<U> child, LoadBalancedRSocketMono.WeightedSocket socket) {
+      LatencySubscriber(Subscriber<U> child, WeightedSocket socket) {
         this.child = child;
         this.socket = socket;
         this.done = new AtomicBoolean(false);
@@ -893,9 +899,9 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
      */
     private class CountingSubscriber<U> implements Subscriber<U> {
       private final Subscriber<U> child;
-      private final LoadBalancedRSocketMono.WeightedSocket socket;
+      private final WeightedSocket socket;
 
-      CountingSubscriber(Subscriber<U> child, LoadBalancedRSocketMono.WeightedSocket socket) {
+      CountingSubscriber(Subscriber<U> child, WeightedSocket socket) {
         this.child = child;
         this.socket = socket;
       }
@@ -916,8 +922,8 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
         socket.pendingStreams.decrementAndGet();
         child.onError(t);
         if (t instanceof TransportException || t instanceof ClosedChannelException) {
-          activeSockets.remove(socket);
-          refreshSockets();
+          logger.debug("Disposing {} from activeSockets because of error {}", socket, t);
+          socket.dispose();
         }
       }
 

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/RSocketSupplierPool.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/RSocketSupplierPool.java
@@ -108,7 +108,9 @@ public class RSocketSupplierPool
   @Override
   public synchronized void accept(RSocketSupplier rSocketSupplier) {
     boolean contained = leasedSuppliers.remove(rSocketSupplier);
-    if (contained && !rSocketSupplier.isDisposed()) { // only added leasedSupplier back to factoryPool if it's still there
+    if (contained
+        && !rSocketSupplier
+            .isDisposed()) { // only added leasedSupplier back to factoryPool if it's still there
       factoryPool.add(rSocketSupplier);
     }
   }

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/RSocketSupplierPool.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/RSocketSupplierPool.java
@@ -84,6 +84,9 @@ public class RSocketSupplierPool
     }
 
     factoryPool.addAll(added);
+    if (!added.isEmpty()) {
+      changed = true;
+    }
 
     if (changed && logger.isDebugEnabled()) {
       StringBuilder msgBuilder = new StringBuilder();
@@ -104,8 +107,8 @@ public class RSocketSupplierPool
 
   @Override
   public synchronized void accept(RSocketSupplier rSocketSupplier) {
-    leasedSuppliers.remove(rSocketSupplier);
-    if (!rSocketSupplier.isDisposed()) {
+    boolean contained = leasedSuppliers.remove(rSocketSupplier);
+    if (contained && !rSocketSupplier.isDisposed()) { // only added leasedSupplier back to factoryPool if it's still there
       factoryPool.add(rSocketSupplier);
     }
   }
@@ -119,6 +122,7 @@ public class RSocketSupplierPool
       if (rSocketSupplier.availability() > 0.0) {
         factoryPool.remove(0);
         leasedSuppliers.add(rSocketSupplier);
+        logger.debug("Added {} to leasedSuppliers", rSocketSupplier);
         optional = Optional.of(rSocketSupplier);
       }
     } else if (poolSize > 1) {
@@ -143,10 +147,12 @@ public class RSocketSupplierPool
       if (factory0.availability() > factory1.availability()) {
         factoryPool.remove(i0);
         leasedSuppliers.add(factory0);
+        logger.debug("Added {} to leasedSuppliers", factory0);
         optional = Optional.of(factory0);
       } else {
         factoryPool.remove(i1);
         leasedSuppliers.add(factory1);
+        logger.debug("Added {} to leasedSuppliers", factory1);
         optional = Optional.of(factory1);
       }
     }


### PR DESCRIPTION
Mainly fix [issue](https://github.com/rsocket/rsocket-java/issues/652)

fix: LoadBalancedRSocketMono#activeSockets and RSocketSupplierPool#leasedSuppliers are not in sync
add: more logs to help debugging
fix: log when factoryPool has new items

