### PR TITLE
stream id wrap fix

### DIFF
--- a/rsocket-core/src/jmh/java/io/rsocket/StreamIdSupplierPerf.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/StreamIdSupplierPerf.java
@@ -1,0 +1,35 @@
+package io.rsocket;
+
+import io.netty.util.collection.IntObjectMap;
+import io.rsocket.internal.SynchronizedIntObjectHashMap;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@Fork(
+    value = 1 // , jvmArgsAppend = {"-Dio.netty.leakDetection.level=advanced"}
+    )
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@State(Scope.Thread)
+public class StreamIdSupplierPerf {
+  @Benchmark
+  public void benchmarkStreamId(Input input) {
+    int i = input.supplier.nextStreamId(input.map);
+    input.bh.consume(i);
+  }
+
+  @State(Scope.Benchmark)
+  public static class Input {
+    Blackhole bh;
+    IntObjectMap map;
+    StreamIdSupplier supplier;
+
+    @Setup
+    public void setup(Blackhole bh) {
+      this.supplier = StreamIdSupplier.clientSupplier();
+      this.bh = bh;
+      this.map = new SynchronizedIntObjectHashMap();
+    }
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
@@ -205,7 +205,7 @@ class RSocketRequester implements RSocket {
       return Mono.error(err);
     }
 
-    final int streamId = streamIdSupplier.nextStreamId();
+    final int streamId = streamIdSupplier.nextStreamId(receivers);
 
     return emptyUnicastMono()
         .doOnSubscribe(
@@ -233,7 +233,7 @@ class RSocketRequester implements RSocket {
       return Mono.error(err);
     }
 
-    int streamId = streamIdSupplier.nextStreamId();
+    int streamId = streamIdSupplier.nextStreamId(receivers);
     final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
 
     UnicastMonoProcessor<Payload> receiver = UnicastMonoProcessor.create();
@@ -274,7 +274,7 @@ class RSocketRequester implements RSocket {
       return Flux.error(err);
     }
 
-    int streamId = streamIdSupplier.nextStreamId();
+    int streamId = streamIdSupplier.nextStreamId(receivers);
 
     final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
     final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
@@ -328,7 +328,7 @@ class RSocketRequester implements RSocket {
 
     final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
     final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
-    final int streamId = streamIdSupplier.nextStreamId();
+    final int streamId = streamIdSupplier.nextStreamId(receivers);
 
     return receiver
         .doOnRequest(

--- a/rsocket-core/src/main/java/io/rsocket/StreamIdSupplier.java
+++ b/rsocket-core/src/main/java/io/rsocket/StreamIdSupplier.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.rsocket;
 
 import io.netty.util.collection.IntObjectMap;
@@ -43,7 +42,7 @@ final class StreamIdSupplier {
     int streamId;
     do {
       streamId = (int) STREAM_ID.addAndGet(this, 2) & MASK;
-    } while (streamIds.containsKey(streamId));
+    } while (streamId == 0 || streamIds.containsKey(streamId));
     return streamId;
   }
 

--- a/rsocket-core/src/main/java/io/rsocket/StreamIdSupplier.java
+++ b/rsocket-core/src/main/java/io/rsocket/StreamIdSupplier.java
@@ -16,15 +16,18 @@
 
 package io.rsocket;
 
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import io.netty.util.collection.IntObjectMap;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 final class StreamIdSupplier {
+  private static final int MASK = 0x7FFFFFFF;
 
-  private static final AtomicIntegerFieldUpdater<StreamIdSupplier> STREAM_ID =
-      AtomicIntegerFieldUpdater.newUpdater(StreamIdSupplier.class, "streamId");
-  private volatile int streamId;
+  private static final AtomicLongFieldUpdater<StreamIdSupplier> STREAM_ID =
+      AtomicLongFieldUpdater.newUpdater(StreamIdSupplier.class, "streamId");
+  private volatile long streamId;
 
-  private StreamIdSupplier(int streamId) {
+  // Visible for testing
+  StreamIdSupplier(int streamId) {
     this.streamId = streamId;
   }
 
@@ -36,8 +39,12 @@ final class StreamIdSupplier {
     return new StreamIdSupplier(0);
   }
 
-  int nextStreamId() {
-    return STREAM_ID.addAndGet(this, 2);
+  int nextStreamId(IntObjectMap<?> streamIds) {
+    int streamId;
+    do {
+      streamId = (int) STREAM_ID.addAndGet(this, 2) & MASK;
+    } while (streamIds.containsKey(streamId));
+    return streamId;
   }
 
   boolean isBeforeOrCurrent(int streamId) {

--- a/rsocket-core/src/test/java/io/rsocket/StreamIdSupplierTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/StreamIdSupplierTest.java
@@ -95,8 +95,8 @@ public class StreamIdSupplierTest {
     StreamIdSupplier s = new StreamIdSupplier(Integer.MAX_VALUE - 3);
 
     assertEquals(2147483646, s.nextStreamId(map));
-    assertEquals(0, s.nextStreamId(map));
     assertEquals(2, s.nextStreamId(map));
+    assertEquals(4, s.nextStreamId(map));
 
     s = new StreamIdSupplier(Integer.MAX_VALUE - 2);
 


### PR DESCRIPTION
wraps the stream id when it reaches 2^31 - it also checks for active streams and increments the id if it finds a collision