### PR TITLE
fixes array copy in Tuple3ByteBuf

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/buffer/Tuple3ByteBuf.java
+++ b/rsocket-core/src/main/java/io/rsocket/buffer/Tuple3ByteBuf.java
@@ -168,7 +168,7 @@ class Tuple3ByteBuf extends AbstractTupleByteBuf {
             threeBuffer = three.nioBuffers(threeReadIndex, length);
             ByteBuffer[] results = new ByteBuffer[twoBuffer.length + threeBuffer.length];
             System.arraycopy(twoBuffer, 0, results, 0, twoBuffer.length);
-            System.arraycopy(threeBuffer, 0, results, threeBuffer.length, twoBuffer.length);
+            System.arraycopy(threeBuffer, 0, results, twoBuffer.length, threeBuffer.length);
             return results;
           } else {
             return twoBuffer;

--- a/rsocket-core/src/main/java/io/rsocket/buffer/Tuple3ByteBuf.java
+++ b/rsocket-core/src/main/java/io/rsocket/buffer/Tuple3ByteBuf.java
@@ -144,7 +144,8 @@ class Tuple3ByteBuf extends AbstractTupleByteBuf {
                   new ByteBuffer[oneBuffer.length + twoBuffer.length + threeBuffer.length];
               System.arraycopy(oneBuffer, 0, results, 0, oneBuffer.length);
               System.arraycopy(twoBuffer, 0, results, oneBuffer.length, twoBuffer.length);
-              System.arraycopy(threeBuffer, 0, results, twoBuffer.length, threeBuffer.length);
+              System.arraycopy(
+                  threeBuffer, 0, results, oneBuffer.length + twoBuffer.length, threeBuffer.length);
               return results;
             } else {
               ByteBuffer[] results = new ByteBuffer[oneBuffer.length + twoBuffer.length];

--- a/rsocket-core/src/test/java/io/rsocket/buffer/Tuple3ByteBufTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/buffer/Tuple3ByteBufTest.java
@@ -2,8 +2,14 @@ package io.rsocket.buffer;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 class Tuple3ByteBufTest {
@@ -33,5 +39,62 @@ class Tuple3ByteBufTest {
     short aShort = tuple.getShort(8);
 
     int medium = tuple.getMedium(8);
+  }
+
+  @Test
+  void testTuple3BufferSlicing() {
+    ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+    ByteBuf one = allocator.directBuffer();
+    ByteBufUtil.writeUtf8(one, "foo");
+
+    ByteBuf two = allocator.directBuffer();
+    ByteBufUtil.writeUtf8(two, "bar");
+
+    ByteBuf three = allocator.directBuffer();
+    ByteBufUtil.writeUtf8(three, "bar");
+
+    ByteBuf buf = TupleByteBuf.of(one, two, three);
+
+    String s = buf.slice(0, 6).toString(Charset.defaultCharset());
+    Assert.assertEquals("foobar", s);
+
+    String s1 = buf.slice(3, 6).toString(Charset.defaultCharset());
+    Assert.assertEquals("barbar", s1);
+
+    String s2 = buf.slice(4, 4).toString(Charset.defaultCharset());
+    Assert.assertEquals("arba", s2);
+  }
+
+  @Test
+  void testTuple3ToNioBuffers() throws Exception {
+    ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+    ByteBuf one = allocator.directBuffer();
+    ByteBufUtil.writeUtf8(one, "one");
+
+    ByteBuf two = allocator.directBuffer();
+    ByteBufUtil.writeUtf8(two, "two");
+
+    ByteBuf three = allocator.directBuffer();
+    ByteBufUtil.writeUtf8(three, "three");
+
+    ByteBuf buf = TupleByteBuf.of(one, two, three);
+    ByteBuffer[] byteBuffers = buf.nioBuffers();
+
+    Assert.assertEquals(3, byteBuffers.length);
+
+    ByteBuffer bb = byteBuffers[0];
+    byte[] dst = new byte[bb.remaining()];
+    bb.get(dst);
+    Assert.assertEquals("one", new String(dst, "UTF-8"));
+
+    bb = byteBuffers[1];
+    dst = new byte[bb.remaining()];
+    bb.get(dst);
+    Assert.assertEquals("two", new String(dst, "UTF-8"));
+
+    bb = byteBuffers[2];
+    dst = new byte[bb.remaining()];
+    bb.get(dst);
+    Assert.assertEquals("three", new String(dst, "UTF-8"));
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/buffer/Tuple3ByteBufTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/buffer/Tuple3ByteBufTest.java
@@ -4,11 +4,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.concurrent.ThreadLocalRandom;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Fix for this issue: https://github.com/rsocket/rsocket-java/issues/663