### PR TITLE
Add SocketAcceptorInterceptor

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/SocketAcceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/SocketAcceptor.java
@@ -20,20 +20,21 @@ import io.rsocket.exceptions.SetupException;
 import reactor.core.publisher.Mono;
 
 /**
- * {@code RSocket} is a full duplex protocol where a client and server are identical in terms of
- * both having the capability to initiate requests to their peer. This interface provides the
- * contract where a server accepts a new {@code RSocket} for sending requests to the peer and
- * returns a new {@code RSocket} that will be used to accept requests from it's peer.
+ * RSocket is a full duplex protocol where a client and server are identical in terms of both having
+ * the capability to initiate requests to their peer. This interface provides the contract where a
+ * client or server handles the {@code setup} for a new connection and creates a responder {@code
+ * RSocket} for accepting requests from the remote peer.
  */
 public interface SocketAcceptor {
 
   /**
-   * Accepts a new {@code RSocket} used to send requests to the peer and returns another {@code
-   * RSocket} that is used for accepting requests from the peer.
+   * Handle the {@code SETUP} frame for a new connection and create a responder {@code RSocket} for
+   * handling requests from the remote peer.
    *
-   * @param setup Setup as sent by the client.
-   * @param sendingSocket Socket used to send requests to the peer.
-   * @return Socket to accept requests from the peer.
+   * @param setup the {@code setup} received from a client in a server scenario, or in a client
+   *     scenario this is the setup about to be sent to the server.
+   * @param sendingSocket socket for sending requests to the remote peer.
+   * @return {@code RSocket} to accept requests with.
    * @throws SetupException If the acceptor needs to reject the setup of this socket.
    */
   Mono<RSocket> accept(ConnectionSetupPayload setup, RSocket sendingSocket);

--- a/rsocket-core/src/main/java/io/rsocket/plugins/PluginRegistry.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/PluginRegistry.java
@@ -18,6 +18,7 @@ package io.rsocket.plugins;
 
 import io.rsocket.DuplexConnection;
 import io.rsocket.RSocket;
+import io.rsocket.SocketAcceptor;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +26,7 @@ public class PluginRegistry {
   private List<DuplexConnectionInterceptor> connections = new ArrayList<>();
   private List<RSocketInterceptor> requesters = new ArrayList<>();
   private List<RSocketInterceptor> responders = new ArrayList<>();
+  private List<SocketAcceptorInterceptor> socketAcceptorInterceptors = new ArrayList<>();
 
   public PluginRegistry() {}
 
@@ -58,6 +60,10 @@ public class PluginRegistry {
     responders.add(interceptor);
   }
 
+  public void addSocketAcceptorPlugin(SocketAcceptorInterceptor interceptor) {
+    socketAcceptorInterceptors.add(interceptor);
+  }
+
   /** Deprecated. Use {@link #applyRequester(RSocket)} instead */
   @Deprecated
   public RSocket applyClient(RSocket rSocket) {
@@ -84,6 +90,14 @@ public class PluginRegistry {
     }
 
     return rSocket;
+  }
+
+  public SocketAcceptor applySocketAcceptorInterceptor(SocketAcceptor acceptor) {
+    for (SocketAcceptorInterceptor i : socketAcceptorInterceptors) {
+      acceptor = i.apply(acceptor);
+    }
+
+    return acceptor;
   }
 
   public DuplexConnection applyConnection(

--- a/rsocket-core/src/main/java/io/rsocket/plugins/SocketAcceptorInterceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/SocketAcceptorInterceptor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rsocket.plugins;
+
+import io.rsocket.SocketAcceptor;
+import java.util.function.Function;
+
+/**
+ * Contract to decorate a {@link SocketAcceptor}, providing access to connection {@code setup}
+ * information and the ability to also decorate the sockets for requesting and responding.
+ *
+ * <p>This can be used as an alternative to individual requester and responder {@link
+ * RSocketInterceptor} plugins.
+ */
+public @FunctionalInterface interface SocketAcceptorInterceptor
+    extends Function<SocketAcceptor, SocketAcceptor> {}

--- a/rsocket-examples/src/test/java/io/rsocket/integration/IntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/IntegrationTest.java
@@ -29,6 +29,7 @@ import io.rsocket.RSocket;
 import io.rsocket.RSocketFactory;
 import io.rsocket.plugins.DuplexConnectionInterceptor;
 import io.rsocket.plugins.RSocketInterceptor;
+import io.rsocket.plugins.SocketAcceptorInterceptor;
 import io.rsocket.test.TestSubscriber;
 import io.rsocket.transport.netty.client.TcpClientTransport;
 import io.rsocket.transport.netty.server.CloseableChannel;
@@ -48,32 +49,50 @@ import reactor.core.publisher.Mono;
 
 public class IntegrationTest {
 
-  private static final RSocketInterceptor clientPlugin;
-  private static final RSocketInterceptor serverPlugin;
+  private static final RSocketInterceptor requesterPlugin;
+  private static final RSocketInterceptor responderPlugin;
+  private static final SocketAcceptorInterceptor clientAcceptorPlugin;
+  private static final SocketAcceptorInterceptor serverAcceptorPlugin;
   private static final DuplexConnectionInterceptor connectionPlugin;
-  public static volatile boolean calledClient = false;
-  public static volatile boolean calledServer = false;
+  public static volatile boolean calledRequester = false;
+  public static volatile boolean calledResponder = false;
+  public static volatile boolean calledClientAcceptor = false;
+  public static volatile boolean calledServerAcceptor = false;
   public static volatile boolean calledFrame = false;
 
   static {
-    clientPlugin =
+    requesterPlugin =
         reactiveSocket ->
             new RSocketProxy(reactiveSocket) {
               @Override
               public Mono<Payload> requestResponse(Payload payload) {
-                calledClient = true;
+                calledRequester = true;
                 return reactiveSocket.requestResponse(payload);
               }
             };
 
-    serverPlugin =
+    responderPlugin =
         reactiveSocket ->
             new RSocketProxy(reactiveSocket) {
               @Override
               public Mono<Payload> requestResponse(Payload payload) {
-                calledServer = true;
+                calledResponder = true;
                 return reactiveSocket.requestResponse(payload);
               }
+            };
+
+    clientAcceptorPlugin =
+        acceptor ->
+            (setup, sendingSocket) -> {
+              calledClientAcceptor = true;
+              return acceptor.accept(setup, sendingSocket);
+            };
+
+    serverAcceptorPlugin =
+        acceptor ->
+            (setup, sendingSocket) -> {
+              calledServerAcceptor = true;
+              return acceptor.accept(setup, sendingSocket);
             };
 
     connectionPlugin =
@@ -99,7 +118,8 @@ public class IntegrationTest {
 
     server =
         RSocketFactory.receive()
-            .addServerPlugin(serverPlugin)
+            .addResponderPlugin(responderPlugin)
+            .addSocketAcceptorPlugin(serverAcceptorPlugin)
             .addConnectionPlugin(connectionPlugin)
             .errorConsumer(
                 t -> {
@@ -138,7 +158,8 @@ public class IntegrationTest {
 
     client =
         RSocketFactory.connect()
-            .addClientPlugin(clientPlugin)
+            .addRequesterPlugin(requesterPlugin)
+            .addSocketAcceptorPlugin(clientAcceptorPlugin)
             .addConnectionPlugin(connectionPlugin)
             .transport(TcpClientTransport.create(server.address()))
             .start()
@@ -154,8 +175,10 @@ public class IntegrationTest {
   public void testRequest() {
     client.requestResponse(DefaultPayload.create("REQUEST", "META")).block();
     assertThat("Server did not see the request.", requestCount.get(), is(1));
-    assertTrue(calledClient);
-    assertTrue(calledServer);
+    assertTrue(calledRequester);
+    assertTrue(calledResponder);
+    assertTrue(calledClientAcceptor);
+    assertTrue(calledServerAcceptor);
     assertTrue(calledFrame);
   }
 


### PR DESCRIPTION
Currently an `RSocketInterceptor` can only intercept requests, but has no visibility into connection setup like metadata  and data mime types, see https://github.com/rsocket/rsocket-java/issues/661#issuecomment-512067225. Especially on the server side there is no way for an interceptor to access this information which can be critical (e.g. for a security interceptor).

This pull request adds `SocketAcceptorInterceptor` and also updates support for `SocketAcceptor` so both are supported symmetrically.