### PR TITLE
Fix Gradle publication configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.gradle.build-scan' version '2.4.2'
 
     id 'com.github.sherter.google-java-format' version '0.8' apply false
-    id 'com.jfrog.artifactory' version '4.7.3' apply false
+    id 'com.jfrog.artifactory' version '4.9.10' apply false
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'me.champeau.gradle.jmh' version '0.4.8' apply false
     id 'io.spring.dependency-management' version '1.0.7.RELEASE' apply false
@@ -28,7 +28,6 @@ plugins {
 subprojects {
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'com.github.sherter.google-java-format'
-    apply from: "${rootDir}/gradle/publications.gradle"
     
     ext['reactor-bom.version'] = 'Dysprosium-RELEASE'
     ext['logback.version'] = '1.2.3'
@@ -132,18 +131,22 @@ subprojects {
             from javadoc.destinationDir
         }
 
-        publishing {
-            publications {
-                maven(MavenPublication) {
-                    from components.java
-                    artifact sourcesJar
-                    artifact javadocJar
+        plugins.withType(MavenPublishPlugin) {
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                        artifact sourcesJar
+                        artifact javadocJar
+                    }
                 }
             }
         }
     }
 
 }
+
+apply from: "${rootDir}/gradle/publications.gradle"
 
 buildScan {
     termsOfServiceUrl = 'https://gradle.com/terms-of-service'

--- a/gradle/artifactory.gradle
+++ b/gradle/artifactory.gradle
@@ -31,7 +31,7 @@ if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey')) {
                     }
 
                     defaults {
-                        publications('maven')
+                        publications(publishing.publications.maven)
                     }
                 }
             }

--- a/gradle/publications.gradle
+++ b/gradle/publications.gradle
@@ -1,61 +1,62 @@
-apply plugin: "maven-publish"
 apply from: "${rootDir}/gradle/artifactory.gradle"
 apply from: "${rootDir}/gradle/bintray.gradle"
 
-plugins.withType(MavenPublishPlugin) {
-    publishing {
-        publications {
-            maven(MavenPublication) {
-                pom {
-                    name = project.name
-                    groupId = 'io.rsocket'
-                    description = project.description
-                    url = 'http://rsocket.io'
-                    licenses {
-                        license {
-                            name = "The Apache Software License, Version 2.0"
-                            url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                            distribution = "repo"
+subprojects {
+    plugins.withType(MavenPublishPlugin) {
+        publishing {
+            publications {
+                maven(MavenPublication) {
+                    pom {
+                        name = project.name
+                        groupId = 'io.rsocket'
+                        description = project.description
+                        url = 'http://rsocket.io'
+                        licenses {
+                            license {
+                                name = "The Apache Software License, Version 2.0"
+                                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                                distribution = "repo"
+                            }
                         }
-                    }
-                    developers {
-                        developer {
-                            id = 'robertroeser'
-                            name = 'Robert Roeser'
-                            email = 'robert@netifi.com'
+                        developers {
+                            developer {
+                                id = 'robertroeser'
+                                name = 'Robert Roeser'
+                                email = 'robert@netifi.com'
+                            }
+                            developer {
+                                id = 'rdegnan'
+                                name = 'Ryland Degnan'
+                                email = 'ryland@netifi.com'
+                            }
+                            developer {
+                                id = 'yschimke'
+                                name = 'Yuri Schimke'
+                                email = 'yuri@schimke.ee'
+                            }
+                            developer {
+                                id = 'OlegDokuka'
+                                name = 'Oleh Dokuka'
+                                email = 'oleh@netifi.com'
+                            }
+                            developer {
+                                id = 'mostroverkhov'
+                                name = 'Maksym Ostroverkhov'
+                                email = 'm.ostroverkhov@gmail.com'
+                            }
                         }
-                        developer {
-                            id = 'rdegnan'
-                            name = 'Ryland Degnan'
-                            email = 'ryland@netifi.com'
+                        scm {
+                            connection = 'scm:git:https://github.com/rsocket/rsocket-java.git'
+                            developerConnection = 'scm:git:https://github.com/rsocket/rsocket-java.git'
+                            url = 'https://github.com/rsocket/rsocket-java'
                         }
-                        developer {
-                            id = 'yschimke'
-                            name = 'Yuri Schimke'
-                            email = 'yuri@schimke.ee'
-                        }
-                        developer {
-                            id = 'OlegDokuka'
-                            name = 'Oleh Dokuka'
-                            email = 'oleh@netifi.com'
-                        }
-                        developer {
-                            id = 'mostroverkhov'
-                            name = 'Maksym Ostroverkhov'
-                            email = 'm.ostroverkhov@gmail.com'
-                        }
-                    }
-                    scm {
-                        connection = 'scm:git:https://github.com/rsocket/rsocket-java.git'
-                        developerConnection = 'scm:git:https://github.com/rsocket/rsocket-java.git'
-                        url = 'https://github.com/rsocket/rsocket-java'
-                    }
-                    versionMapping {
-                        usage('java-api') {
-                            fromResolutionResult()
-                        }
-                        usage('java-runtime') {
-                            fromResolutionResult()
+                        versionMapping {
+                            usage('java-api') {
+                                fromResolutionResult()
+                            }
+                            usage('java-runtime') {
+                                fromResolutionResult()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Prior to this change, the Gradle publication configuration would be
applied to the wrong level of projects (subprojects of subprojects!),
resulting in no artifacts being published to the repository.

This commit updates the JFrog artifactory Gradle plugin version and
fixes the application of the publication configuration to align with
what's been done with artifactory and bintray configurations.

Signed-off-by: Brian Clozel <bclozel@pivotal.io>