### PR TITLE
Fix artifacts groupId

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ subprojects {
     ext['micrometer.version'] = '1.0.6'
     ext['assertj.version'] = '3.11.1'
 
+    group = "io.rsocket"
+
     googleJavaFormat {
         toolVersion = '1.6'
     }


### PR DESCRIPTION
Prior to this change, the default groupId "rsocket-java" would be used
for all RSocket artifacts. This commit fixes the group name to
"io.rsocket" for all Gradle subprojects.

This change is reflected in the published POMs and BOM.