### PR TITLE
do not refreshSockets after closing socket

### DIFF
--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
@@ -583,7 +583,6 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
                 activeSockets.remove(WeightedSocket.this);
                 logger.debug(
                     "Removed {} from factory {} from activeSockets", WeightedSocket.this, factory);
-                refreshSockets();
               })
           .subscribe();
 


### PR DESCRIPTION
If servers are intentionally rejecting connections, refreshSockets-after-closing-socket on client side may cause infinite loop of opening and closing (immediately reset on server side) connections.