### PR TITLE
Extra method for checking ByteBuf is a composite metadata

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/metadata/CompositeMetadataFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/metadata/CompositeMetadataFlyweight.java
@@ -306,7 +306,7 @@ public class CompositeMetadataFlyweight {
           int mimeLength = Byte.toUnsignedInt(mimeIdOrLength) + 1;
 
           if (compositeMetadata.isReadable(
-                  mimeLength)) { // need to be able to read an extra mimeLength bytes
+              mimeLength)) { // need to be able to read an extra mimeLength bytes
             // here we need a way for the returned ByteBuf to differentiate between a
             // 1-byte length mime type and a 1 byte encoded mime id, preferably without
             // re-applying the byte mask. The easiest way is to include the initial byte


### PR DESCRIPTION
This PR provides an additional utility method which allows checking that given bytebuf correspond to the structure of the composite metadata

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>