### PR TITLE
remove unnecessary synchronized from default decoder

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/frame/decoder/DefaultPayloadDecoder.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/decoder/DefaultPayloadDecoder.java
@@ -11,7 +11,7 @@ import java.nio.ByteBuffer;
 class DefaultPayloadDecoder implements PayloadDecoder {
 
   @Override
-  public synchronized Payload apply(ByteBuf byteBuf) {
+  public Payload apply(ByteBuf byteBuf) {
     ByteBuf m;
     ByteBuf d;
     FrameType type = FrameHeaderFlyweight.frameType(byteBuf);


### PR DESCRIPTION
This PR fixes https://github.com/rsocket/rsocket-java/pull/616#pullrequestreview-324559437