### PR TITLE
Feature/mono processor rework

### DIFF
--- a/benchmarks/src/main/java/io/rsocket/MaxPerfSubscriber.java
+++ b/benchmarks/src/main/java/io/rsocket/MaxPerfSubscriber.java
@@ -5,12 +5,12 @@ import org.openjdk.jmh.infra.Blackhole;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 
-public class MaxPerfSubscriber implements CoreSubscriber<Payload> {
+public class MaxPerfSubscriber<T> extends CountDownLatch implements CoreSubscriber<T> {
 
-  final CountDownLatch latch = new CountDownLatch(1);
   final Blackhole blackhole;
 
   public MaxPerfSubscriber(Blackhole blackhole) {
+    super(1);
     this.blackhole = blackhole;
   }
 
@@ -20,19 +20,18 @@ public class MaxPerfSubscriber implements CoreSubscriber<Payload> {
   }
 
   @Override
-  public void onNext(Payload payload) {
-    payload.release();
+  public void onNext(T payload) {
     blackhole.consume(payload);
   }
 
   @Override
   public void onError(Throwable t) {
     blackhole.consume(t);
-    latch.countDown();
+    countDown();
   }
 
   @Override
   public void onComplete() {
-    latch.countDown();
+    countDown();
   }
 }

--- a/benchmarks/src/main/java/io/rsocket/PayloadsMaxPerfSubscriber.java
+++ b/benchmarks/src/main/java/io/rsocket/PayloadsMaxPerfSubscriber.java
@@ -1,10 +1,6 @@
 package io.rsocket;
 
 import org.openjdk.jmh.infra.Blackhole;
-import org.reactivestreams.Subscription;
-import reactor.core.CoreSubscriber;
-
-import java.util.concurrent.CountDownLatch;
 
 public class PayloadsMaxPerfSubscriber extends MaxPerfSubscriber<Payload> {
 

--- a/benchmarks/src/main/java/io/rsocket/PayloadsMaxPerfSubscriber.java
+++ b/benchmarks/src/main/java/io/rsocket/PayloadsMaxPerfSubscriber.java
@@ -1,0 +1,20 @@
+package io.rsocket;
+
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+
+import java.util.concurrent.CountDownLatch;
+
+public class PayloadsMaxPerfSubscriber extends MaxPerfSubscriber<Payload> {
+
+  public PayloadsMaxPerfSubscriber(Blackhole blackhole) {
+    super(blackhole);
+  }
+
+  @Override
+  public void onNext(Payload payload) {
+    payload.release();
+    super.onNext(payload);
+  }
+}

--- a/benchmarks/src/main/java/io/rsocket/PerfSubscriber.java
+++ b/benchmarks/src/main/java/io/rsocket/PerfSubscriber.java
@@ -5,14 +5,14 @@ import org.openjdk.jmh.infra.Blackhole;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 
-public class PerfSubscriber<T> implements CoreSubscriber<T> {
+public class PerfSubscriber<T> extends CountDownLatch implements CoreSubscriber<T> {
 
-  public final CountDownLatch latch = new CountDownLatch(1);
   final Blackhole blackhole;
 
   Subscription s;
 
   public PerfSubscriber(Blackhole blackhole) {
+    super(1);
     this.blackhole = blackhole;
   }
 
@@ -31,11 +31,11 @@ public class PerfSubscriber<T> implements CoreSubscriber<T> {
   @Override
   public void onError(Throwable t) {
     blackhole.consume(t);
-    latch.countDown();
+    countDown();
   }
 
   @Override
   public void onComplete() {
-    latch.countDown();
+    countDown();
   }
 }

--- a/benchmarks/src/main/java/io/rsocket/RSocketPerf.java
+++ b/benchmarks/src/main/java/io/rsocket/RSocketPerf.java
@@ -112,7 +112,7 @@ public class RSocketPerf {
   public PayloadsPerfSubscriber fireAndForget(Blackhole blackhole) throws InterruptedException {
     PayloadsPerfSubscriber subscriber = new PayloadsPerfSubscriber(blackhole);
     client.fireAndForget(PAYLOAD).subscribe((CoreSubscriber) subscriber);
-    subscriber.latch.await();
+    subscriber.await();
 
     return subscriber;
   }
@@ -121,7 +121,7 @@ public class RSocketPerf {
   public PayloadsPerfSubscriber requestResponse(Blackhole blackhole) throws InterruptedException {
     PayloadsPerfSubscriber subscriber = new PayloadsPerfSubscriber(blackhole);
     client.requestResponse(PAYLOAD).subscribe(subscriber);
-    subscriber.latch.await();
+    subscriber.await();
 
     return subscriber;
   }
@@ -131,17 +131,17 @@ public class RSocketPerf {
       throws InterruptedException {
     PayloadsPerfSubscriber subscriber = new PayloadsPerfSubscriber(blackhole);
     client.requestStream(PAYLOAD).subscribe(subscriber);
-    subscriber.latch.await();
+    subscriber.await();
 
     return subscriber;
   }
 
   @Benchmark
-  public MaxPerfSubscriber requestStreamWithRequestAllStrategy(Blackhole blackhole)
+  public PayloadsMaxPerfSubscriber requestStreamWithRequestAllStrategy(Blackhole blackhole)
       throws InterruptedException {
-    MaxPerfSubscriber subscriber = new MaxPerfSubscriber(blackhole);
+    PayloadsMaxPerfSubscriber subscriber = new PayloadsMaxPerfSubscriber(blackhole);
     client.requestStream(PAYLOAD).subscribe(subscriber);
-    subscriber.latch.await();
+    subscriber.await();
 
     return subscriber;
   }
@@ -151,17 +151,17 @@ public class RSocketPerf {
       throws InterruptedException {
     PayloadsPerfSubscriber subscriber = new PayloadsPerfSubscriber(blackhole);
     client.requestChannel(PAYLOAD_FLUX).subscribe(subscriber);
-    subscriber.latch.await();
+    subscriber.await();
 
     return subscriber;
   }
 
   @Benchmark
-  public MaxPerfSubscriber requestChannelWithRequestAllStrategy(Blackhole blackhole)
+  public PayloadsMaxPerfSubscriber requestChannelWithRequestAllStrategy(Blackhole blackhole)
       throws InterruptedException {
-    MaxPerfSubscriber subscriber = new MaxPerfSubscriber(blackhole);
+    PayloadsMaxPerfSubscriber subscriber = new PayloadsMaxPerfSubscriber(blackhole);
     client.requestChannel(PAYLOAD_FLUX).subscribe(subscriber);
-    subscriber.latch.await();
+    subscriber.await();
 
     return subscriber;
   }

--- a/benchmarks/src/main/java/io/rsocket/internal/UnicastVsDefaultMonoProcessorPerf.java
+++ b/benchmarks/src/main/java/io/rsocket/internal/UnicastVsDefaultMonoProcessorPerf.java
@@ -1,0 +1,48 @@
+package io.rsocket.internal;
+
+
+import io.rsocket.MaxPerfSubscriber;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import reactor.core.publisher.MonoProcessor;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+@Fork(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10, time = 20)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class UnicastVsDefaultMonoProcessorPerf {
+
+    @Benchmark
+    public void monoProcessorPerf(Blackhole bh) {
+        MaxPerfSubscriber<Integer> subscriber = new MaxPerfSubscriber<>(bh);
+        MonoProcessor<Integer> monoProcessor = MonoProcessor.create();
+        monoProcessor.onNext(1);
+        monoProcessor.subscribe(subscriber);
+
+        bh.consume(monoProcessor);
+        bh.consume(subscriber);
+    }
+
+    @Benchmark
+    public void unicastMonoProcessorPerf(Blackhole bh) {
+        MaxPerfSubscriber<Integer> subscriber = new MaxPerfSubscriber<>(bh);
+        UnicastMonoProcessor<Integer> monoProcessor = UnicastMonoProcessor.create();
+        monoProcessor.onNext(1);
+        monoProcessor.subscribe(subscriber);
+
+        bh.consume(monoProcessor);
+        bh.consume(subscriber);
+    }
+}

--- a/benchmarks/src/main/java/io/rsocket/internal/UnicastVsDefaultMonoProcessorPerf.java
+++ b/benchmarks/src/main/java/io/rsocket/internal/UnicastVsDefaultMonoProcessorPerf.java
@@ -1,7 +1,7 @@
 package io.rsocket.internal;
 
-
 import io.rsocket.MaxPerfSubscriber;
+import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -14,8 +14,6 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import reactor.core.publisher.MonoProcessor;
 
-import java.util.concurrent.TimeUnit;
-
 @BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 @Fork(1)
 @Warmup(iterations = 10)
@@ -24,25 +22,25 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class UnicastVsDefaultMonoProcessorPerf {
 
-    @Benchmark
-    public void monoProcessorPerf(Blackhole bh) {
-        MaxPerfSubscriber<Integer> subscriber = new MaxPerfSubscriber<>(bh);
-        MonoProcessor<Integer> monoProcessor = MonoProcessor.create();
-        monoProcessor.onNext(1);
-        monoProcessor.subscribe(subscriber);
+  @Benchmark
+  public void monoProcessorPerf(Blackhole bh) {
+    MaxPerfSubscriber<Integer> subscriber = new MaxPerfSubscriber<>(bh);
+    MonoProcessor<Integer> monoProcessor = MonoProcessor.create();
+    monoProcessor.onNext(1);
+    monoProcessor.subscribe(subscriber);
 
-        bh.consume(monoProcessor);
-        bh.consume(subscriber);
-    }
+    bh.consume(monoProcessor);
+    bh.consume(subscriber);
+  }
 
-    @Benchmark
-    public void unicastMonoProcessorPerf(Blackhole bh) {
-        MaxPerfSubscriber<Integer> subscriber = new MaxPerfSubscriber<>(bh);
-        UnicastMonoProcessor<Integer> monoProcessor = UnicastMonoProcessor.create();
-        monoProcessor.onNext(1);
-        monoProcessor.subscribe(subscriber);
+  @Benchmark
+  public void unicastMonoProcessorPerf(Blackhole bh) {
+    MaxPerfSubscriber<Integer> subscriber = new MaxPerfSubscriber<>(bh);
+    UnicastMonoProcessor<Integer> monoProcessor = UnicastMonoProcessor.create();
+    monoProcessor.onNext(1);
+    monoProcessor.subscribe(subscriber);
 
-        bh.consume(monoProcessor);
-        bh.consume(subscriber);
-    }
+    bh.consume(monoProcessor);
+    bh.consume(subscriber);
+  }
 }

--- a/rsocket-core/src/main/java/io/rsocket/internal/UnicastMonoProcessor.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/UnicastMonoProcessor.java
@@ -1,179 +1,587 @@
 package io.rsocket.internal;
 
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.stream.Stream;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.Operators;
+import reactor.util.annotation.NonNull;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
-import reactor.util.function.Tuple2;
 
 public class UnicastMonoProcessor<O> extends Mono<O>
-    implements Processor<O, O>, CoreSubscriber<O>, Disposable, Subscription, Scannable {
+    implements Processor<O, O>, CoreSubscriber<O>, Fuseable, Disposable, Fuseable.QueueSubscription<O>, Scannable {
 
-  @SuppressWarnings("rawtypes")
-  static final AtomicIntegerFieldUpdater<UnicastMonoProcessor> ONCE =
-      AtomicIntegerFieldUpdater.newUpdater(UnicastMonoProcessor.class, "once");
-
-  private final MonoProcessor<O> processor;
-
-  @SuppressWarnings("unused")
-  private volatile int once;
-
-  private UnicastMonoProcessor() {
-    this.processor = MonoProcessor.create();
-  }
-
-  public static <O> UnicastMonoProcessor<O> create() {
+  /**
+   * Create a {@link UnicastMonoProcessor} that will eagerly request 1 on {@link
+   * #onSubscribe(Subscription)}, cache and emit the eventual result for 1 or N subscribers.
+   *
+   * @param <T> type of the expected value
+   * @return A {@link UnicastMonoProcessor}.
+   */
+  public static <T> UnicastMonoProcessor<T> create() {
     return new UnicastMonoProcessor<>();
   }
 
-  @Override
-  public Stream<? extends Scannable> actuals() {
-    return processor.actuals();
+  /**
+   * Indicates this Subscription has no value and not requested yet.
+   */
+  static final int NO_SUBSCRIBER_NO_RESULT  = 0;
+  /**
+   * Indicates this Subscription has no value and not requested yet.
+   */
+  static final int NO_SUBSCRIBER_HAS_RESULT = 1;
+  /**
+   * Indicates this Subscription has no value and not requested yet.
+   */
+  static final int NO_REQUEST_NO_RESULT     = 4;
+  /**
+   * Indicates this Subscription has a value but not requested yet.
+   */
+  static final int NO_REQUEST_HAS_RESULT    = 5;
+  /**
+   * Indicates this Subscription has been requested but there is no value yet.
+   */
+  static final int HAS_REQUEST_NO_RESULT    = 6;
+  /**
+   * Indicates this Subscription has both request and value.
+   */
+  static final int HAS_REQUEST_HAS_RESULT   = 7;
+  /**
+   * Indicates the Subscription has been cancelled.
+   */
+  static final int CANCELLED                = 8;
+  /**
+   * Indicates this Subscription is in fusion mode and is currently empty.
+   */
+  static final int FUSED_EMPTY              = 16;
+  /**
+   * Indicates this Subscription is in fusion mode and has an undelivered notification about present result.
+   */
+  static final int FUSED_HAS_RESULT         = 32;
+  /**
+   * Indicates this Subscription is in fusion mode and has a result.
+   */
+  static final int FUSED_READY              = 64;
+  /**
+   * Indicates this Subscription is in fusion mode and its value has been consumed.
+   */
+  static final int FUSED_CONSUMED           = 128;
+
+  volatile int state;
+  @SuppressWarnings("rawtypes")
+  static final AtomicIntegerFieldUpdater<UnicastMonoProcessor> STATE =
+      AtomicIntegerFieldUpdater.newUpdater(UnicastMonoProcessor.class, "state");
+
+  volatile int once;
+  @SuppressWarnings("rawtypes")
+  static final AtomicIntegerFieldUpdater<UnicastMonoProcessor> ONCE =
+          AtomicIntegerFieldUpdater.newUpdater(UnicastMonoProcessor.class, "once");
+
+  volatile Subscription subscription;
+  @SuppressWarnings("rawtypes")
+  static final AtomicReferenceFieldUpdater<UnicastMonoProcessor, Subscription> UPSTREAM =
+          AtomicReferenceFieldUpdater.newUpdater(
+                  UnicastMonoProcessor.class, Subscription.class, "subscription");
+
+  CoreSubscriber<? super O> actual;
+
+  Throwable error;
+  O value;
+
+  UnicastMonoProcessor() {
   }
 
   @Override
-  public boolean isScanAvailable() {
-    return processor.isScanAvailable();
-  }
-
-  @Override
-  public String name() {
-    return processor.name();
-  }
-
-  @Override
-  public String stepName() {
-    return processor.stepName();
-  }
-
-  @Override
-  public Stream<String> steps() {
-    return processor.steps();
-  }
-
-  @Override
-  public Stream<? extends Scannable> parents() {
-    return processor.parents();
-  }
-
-  @Override
-  @Nullable
-  public <T> T scan(Attr<T> key) {
-    return processor.scan(key);
-  }
-
-  @Override
-  public <T> T scanOrDefault(Attr<T> key, T defaultValue) {
-    return processor.scanOrDefault(key, defaultValue);
-  }
-
-  @Override
-  public Stream<Tuple2<String, String>> tags() {
-    return processor.tags();
-  }
-
-  @Override
-  public void onSubscribe(Subscription s) {
-    processor.onSubscribe(s);
-  }
-
-  @Override
-  public void onNext(O o) {
-    processor.onNext(o);
-  }
-
-  @Override
-  public void onError(Throwable t) {
-    processor.onError(t);
-  }
-
-  @Nullable
-  public Throwable getError() {
-    return processor.getError();
-  }
-
-  public boolean isCancelled() {
-    return processor.isCancelled();
-  }
-
-  public boolean isError() {
-    return processor.isError();
-  }
-
-  public boolean isSuccess() {
-    return processor.isSuccess();
-  }
-
-  public boolean isTerminated() {
-    return processor.isTerminated();
-  }
-
-  @Nullable
-  public O peek() {
-    return processor.peek();
-  }
-
-  public long downstreamCount() {
-    return processor.downstreamCount();
-  }
-
-  public boolean hasDownstreams() {
-    return processor.hasDownstreams();
-  }
-
-  @Override
-  public void onComplete() {
-    processor.onComplete();
-  }
-
-  @Override
-  public void request(long n) {
-    processor.request(n);
-  }
-
-  @Override
-  public void cancel() {
-    processor.cancel();
-  }
-
-  @Override
-  public void dispose() {
-    processor.dispose();
-  }
-
-  @Override
+  @NonNull
   public Context currentContext() {
-    return processor.currentContext();
+    final CoreSubscriber<? super O> a = this.actual;
+    return a != null ? a.currentContext() : Context.empty();
   }
 
   @Override
-  public boolean isDisposed() {
-    return processor.isDisposed();
+  public final void onSubscribe(Subscription subscription) {
+    if (Operators.setOnce(UPSTREAM, this, subscription)) {
+      subscription.request(Long.MAX_VALUE);
+    }
   }
 
   @Override
-  public Object scanUnsafe(Attr key) {
-    return processor.scanUnsafe(key);
+  public final void onComplete() {
+    onNext(null);
+  }
+
+  @Override
+  public final void onError(Throwable cause) {
+    Objects.requireNonNull(cause, "onError cannot be null");
+
+    if (UPSTREAM.getAndSet(this, Operators.cancelledSubscription())
+        == Operators.cancelledSubscription()) {
+      Operators.onErrorDropped(cause, currentContext());
+      return;
+    }
+
+    complete(cause);
+  }
+
+  @Override
+  public final void onNext(@Nullable O value) {
+    final Subscription s;
+    if ((s = UPSTREAM.getAndSet(this, Operators.cancelledSubscription()))
+        == Operators.cancelledSubscription()) {
+      if (value != null) {
+        Operators.onNextDropped(value, currentContext());
+      }
+      return;
+    }
+
+    if (value == null) {
+      complete();
+    } else {
+      if (s != null) {
+        s.cancel();
+      }
+
+      complete(value);
+    }
+  }
+
+  /**
+   * Tries to emit the value and complete the underlying subscriber or
+   * stores the value away until there is a request for it.
+   * <p>
+   * Make sure this method is called at most once
+   * @param v the value to emit
+   */
+  private void complete(O v) {
+    for (;;) {
+      int state = this.state;
+
+      if (state == FUSED_EMPTY) {
+        setValue(v);
+        //sync memory since setValue is non volatile
+        if (STATE.compareAndSet(this, FUSED_EMPTY, FUSED_READY)) {
+          Subscriber<? super O> a = actual;
+          a.onNext(v);
+          a.onComplete();
+          return;
+        }
+        //refresh state if race occurred so we test if cancelled in the next comparison
+        state = this.state;
+      }
+
+      // if state is >= HAS_CANCELLED or bit zero is set (*_HAS_VALUE) case, return
+      if ((state & ~HAS_REQUEST_NO_RESULT) != 0) {
+        this.value = null;
+        Operators.onDiscard(v, currentContext());
+        return;
+      }
+
+      if (state == HAS_REQUEST_NO_RESULT && STATE.compareAndSet(this, HAS_REQUEST_NO_RESULT, HAS_REQUEST_HAS_RESULT)) {
+        this.value = null;
+        Subscriber<? super O> a = actual;
+        a.onNext(v);
+        a.onComplete();
+        return;
+      }
+      setValue(v);
+      if (state == NO_REQUEST_NO_RESULT && STATE.compareAndSet(this, NO_REQUEST_NO_RESULT, NO_REQUEST_HAS_RESULT)) {
+        return;
+      }
+      if (state == NO_SUBSCRIBER_NO_RESULT && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Tries to emit completion the underlying subscriber
+   * <p>
+   * Make sure this method is called at most once
+   */
+  private void complete() {
+    for (;;) {
+      int state = this.state;
+
+      if (state == FUSED_EMPTY) {
+        if (STATE.compareAndSet(this, FUSED_EMPTY, FUSED_CONSUMED)) {
+          Subscriber<? super O> a = actual;
+          a.onComplete();
+          return;
+        }
+        //refresh state if race occurred so we test if cancelled in the next comparison
+        state = this.state;
+      }
+
+      // if state is >= HAS_CANCELLED or bit zero is set (*_HAS_VALUE) case, return
+      if ((state & ~HAS_REQUEST_NO_RESULT) != 0) {
+        return;
+      }
+
+      if ((state == HAS_REQUEST_NO_RESULT || state == NO_REQUEST_NO_RESULT) && STATE.compareAndSet(this, state, HAS_REQUEST_HAS_RESULT)) {
+        Subscriber<? super O> a = actual;
+        a.onComplete();
+        return;
+      }
+      if (state == NO_SUBSCRIBER_NO_RESULT && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Tries to emit error the underlying subscriber or
+   * stores the value away until there is a request for it.
+   * <p>
+   * Make sure this method is called at most once
+   * @param e the error to emit
+   */
+  private void complete(Throwable e) {
+    for (;;) {
+      int state = this.state;
+
+      if (state == FUSED_EMPTY) {
+        setError(e);
+        //sync memory since setValue is non volatile
+        if (STATE.compareAndSet(this, FUSED_EMPTY, FUSED_CONSUMED)) {
+          Subscriber<? super O> a = actual;
+          a.onError(e);
+          return;
+        }
+        //refresh state if race occurred so we test if cancelled in the next comparison
+        state = this.state;
+      }
+
+      // if state is >= HAS_CANCELLED or bit zero is set (*_HAS_VALUE) case, return
+      if ((state & ~HAS_REQUEST_NO_RESULT) != 0) {
+        return;
+      }
+
+      setError(e);
+      if ((state == HAS_REQUEST_NO_RESULT || state == NO_REQUEST_NO_RESULT) && STATE.compareAndSet(this, state, HAS_REQUEST_HAS_RESULT)) {
+        Subscriber<? super O> a = actual;
+        a.onError(e);
+        return;
+      }
+      if (state == NO_SUBSCRIBER_NO_RESULT && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
+        return;
+      }
+    }
   }
 
   @Override
   public void subscribe(CoreSubscriber<? super O> actual) {
     Objects.requireNonNull(actual, "subscribe");
+
     if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
-      processor.subscribe(actual);
+      this.actual = actual;
+
+      // CAS LOOP since there is a racing with [onNext / onComplete / onError / dispose] which can appear at any moment
+
+      int state = this.state;
+
+      // possible states within the racing between [onNext / onComplete / onError / dispose] and setting subscriber
+      // are NO_SUBSCRIBER_[NO_RESULT or HAS_RESULT]
+      if (state == NO_SUBSCRIBER_NO_RESULT) {
+        if (STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_REQUEST_NO_RESULT)) {
+          state = NO_REQUEST_NO_RESULT;
+        } else {
+          // the possible false position is racing with [onNext / onError / onComplete / dispose]
+          // which are going to put the state in the NO_REQUEST_HAS_RESULT
+          STATE.set(this, NO_REQUEST_HAS_RESULT);
+          state = NO_REQUEST_HAS_RESULT;
+        }
+      } else {
+        STATE.set(this, NO_REQUEST_HAS_RESULT);
+        state = NO_REQUEST_HAS_RESULT;
+      }
+
+
+      // check if state is with a result then there is a chance of immediate termination if there is no value
+      // e.g. [onError / onComplete / dispose] only
+      if (state == NO_REQUEST_HAS_RESULT && this.value == null) {
+        this.actual = null;
+        Throwable e = this.error;
+        // barrier to flush changes
+        STATE.set(this, HAS_REQUEST_HAS_RESULT);
+        if (e == null) {
+          Operators.complete(actual);
+        } else {
+          Operators.error(actual, e);
+        }
+        return;
+      }
+
+      // call onSubscribe if has value in the result or no result delivered so far
+      actual.onSubscribe(this);
+
+      // update state to ensure we observe what happened after onSubscribe appeared
+      state = this.state;
+      // if FUSED_HAS_RESULT appeared then we have to notify Subscriber that there is a result which MUST be consumed
+      if (state == FUSED_HAS_RESULT) {
+        this.actual = null;
+        Throwable e = this.error;
+        if (e != null) {
+          // racing between cancel / dispose / complete
+          if (STATE.compareAndSet(this, FUSED_HAS_RESULT, FUSED_CONSUMED)) {
+            actual.onError(e);
+          }
+        } else {
+          O v = this.value;
+
+          if (v == null) {
+            if (STATE.compareAndSet(this, FUSED_HAS_RESULT, FUSED_CONSUMED)) {
+              actual.onComplete();
+            }
+          } else {
+            if (STATE.compareAndSet(this, FUSED_HAS_RESULT, FUSED_READY)) {
+              actual.onNext(v);
+              actual.onComplete();
+            }
+          }
+        }
+      }
     } else {
       Operators.error(
-          actual,
-          new IllegalStateException("UnicastMonoProcessor allows only a single Subscriber"));
+              actual,
+              new IllegalStateException("UnicastMonoProcessor allows only a single Subscriber"));
     }
+  }
+
+  @Override
+  public int requestFusion(int mode) {
+    if ((mode & ASYNC) != 0) {
+      int state = this.state;
+
+      // CAS LOOP since there is a racing with [onNext / onComplete / onError / dispose] which can appear at any moment
+      for (;;) {
+        if (state == NO_REQUEST_NO_RESULT && STATE.compareAndSet(this, NO_REQUEST_NO_RESULT, FUSED_EMPTY)) {
+          break;
+        }
+        if (state == NO_REQUEST_HAS_RESULT && STATE.compareAndSet(this, NO_REQUEST_HAS_RESULT, FUSED_HAS_RESULT)) {
+          break;
+        }
+
+        state = this.state;
+      }
+      return ASYNC;
+    }
+    return NONE;
+  }
+
+  @Override
+  public final void request(long n) {
+    if (Operators.validate(n)) {
+      for (;;) {
+        int s = state;
+        // if the any bits 1-31 are set, we are either in fusion mode (FUSED_*)
+        // or request has been called (HAS_REQUEST_*)
+        if ((s & ~NO_REQUEST_HAS_RESULT) != 0) {
+          return;
+        }
+        if (s == NO_REQUEST_HAS_RESULT && STATE.compareAndSet(this, NO_REQUEST_HAS_RESULT, HAS_REQUEST_HAS_RESULT)) {
+          O v = value;
+          if (v != null) {
+            value = null;
+            Subscriber<? super O> a = actual;
+            a.onNext(v);
+            a.onComplete();
+          }
+          return;
+        }
+        if (STATE.compareAndSet(this, NO_REQUEST_NO_RESULT, HAS_REQUEST_NO_RESULT)) {
+          return;
+        }
+      }
+    }
+  }
+
+  @Override
+  public final void cancel() {
+    if (STATE.getAndSet(this, CANCELLED) <= HAS_REQUEST_NO_RESULT) {
+      Operators.onDiscard(value, currentContext());
+    }
+
+    final Subscription s = UPSTREAM.getAndSet(this, Operators.cancelledSubscription());
+    if (s != null) {
+      s.cancel();
+    }
+
+    value = null;
+    actual = null;
+  }
+
+  @Override
+  public void dispose() {
+    final Subscription s = UPSTREAM.getAndSet(this, Operators.cancelledSubscription());
+    if (s == Operators.cancelledSubscription()) {
+      return;
+    }
+
+    if (s != null) {
+      s.cancel();
+    }
+
+    complete(new CancellationException("Disposed"));
+  }
+
+  @Override
+  public O poll() {
+    if (STATE.compareAndSet(this, FUSED_READY, FUSED_CONSUMED)) {
+      O v = value;
+      value = null;
+      actual = null;
+      return v;
+    }
+    return null;
+  }
+
+  /**
+   * Returns the value that completed this {@link UnicastMonoProcessor}. Returns {@code null} if the
+   * {@link UnicastMonoProcessor} has not been completed. If the {@link UnicastMonoProcessor} is
+   * completed with an error a RuntimeException that wraps the error is thrown.
+   *
+   * @return the value that completed the {@link UnicastMonoProcessor}, or {@code null} if it has
+   *     not been completed
+   * @throws RuntimeException if the {@link UnicastMonoProcessor} was completed with an error
+   */
+  @Nullable
+  public O peek() {
+    if (!isDisposed()) {
+      return null;
+    }
+
+    if (value != null) {
+      return value;
+    }
+
+    if (error != null) {
+      RuntimeException re = Exceptions.propagate(error);
+      re = Exceptions.addSuppressed(re, new Exception("Mono#peek terminated with an error"));
+      throw re;
+    }
+
+    return null;
+  }
+
+  @Override
+  public int size() {
+    int state = this.state;
+
+    if (state < FUSED_EMPTY && state % 2 == 1 && this.value != null) {
+      return 1;
+    } else if (this.value != null) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return size() == 0;
+  }
+
+  @Override
+  public void clear() {
+    this.value = null;
+  }
+
+  /**
+   * Set the value internally, without impacting request tracking state.
+   *
+   * @param value the new value.
+   * @see #complete(Object)
+   */
+  private void setValue(O value) {
+    this.value = value;
+  }
+
+  /**
+   * Set the error internally, without impacting request tracking state.
+   *
+   * @param throwable the error.
+   * @see #complete(Object)
+   */
+  private void setError(Throwable throwable) {
+    this.error = throwable;
+  }
+
+  /**
+   * Return the produced {@link Throwable} error if any or null
+   *
+   * @return the produced {@link Throwable} error if any or null
+   */
+  @Nullable
+  public final Throwable getError() {
+    return isDisposed() ? error : null;
+  }
+
+  /**
+   * Indicates whether this {@code UnicastMonoProcessor} has been interrupted via cancellation.
+   *
+   * @return {@code true} if this {@code UnicastMonoProcessor} is cancelled, {@code false}
+   *     otherwise.
+   */
+  public boolean isCancelled() {
+    return state == CANCELLED;
+  }
+
+  /**
+   * Indicates whether this {@code UnicastMonoProcessor} has been completed with an error.
+   *
+   * @return {@code true} if this {@code UnicastMonoProcessor} was completed with an error, {@code
+   *     false} otherwise.
+   */
+  public final boolean isError() {
+    return getError() != null;
+  }
+
+  @Override
+  public boolean isDisposed() {
+    int state = this.state;
+    return state == HAS_REQUEST_HAS_RESULT || state == CANCELLED || state == FUSED_CONSUMED;
+  }
+
+  @Override
+  @Nullable
+  public Object scanUnsafe(Attr key) {
+    // touch guard
+    int state = this.state;
+
+    if (key == Attr.TERMINATED) {
+      return state == HAS_REQUEST_HAS_RESULT || state == FUSED_CONSUMED;
+    }
+    if (key == Attr.PARENT) {
+      return subscription;
+    }
+    if (key == Attr.ERROR) {
+      return error;
+    }
+    if (key == Attr.PREFETCH) {
+      return Integer.MAX_VALUE;
+    }
+    if (key == Attr.CANCELLED) {
+      return state == CANCELLED;
+    }
+    return null;
+  }
+
+  /**
+   * Return true if any {@link Subscriber} is actively subscribed
+   *
+   * @return true if any {@link Subscriber} is actively subscribed
+   */
+  public final boolean hasDownstream() {
+    return state > NO_SUBSCRIBER_HAS_RESULT && actual != null;
   }
 }

--- a/rsocket-core/src/main/java/io/rsocket/internal/UnicastMonoProcessor.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/UnicastMonoProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.rsocket.internal;
 
 import java.util.Objects;
@@ -10,7 +26,6 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
-import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
@@ -19,7 +34,7 @@ import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
 public class UnicastMonoProcessor<O> extends Mono<O>
-    implements Processor<O, O>, CoreSubscriber<O>, Fuseable, Disposable, Fuseable.QueueSubscription<O>, Scannable {
+    implements Processor<O, O>, CoreSubscriber<O>, Disposable, Subscription, Scannable {
 
   /**
    * Create a {@link UnicastMonoProcessor} that will eagerly request 1 on {@link
@@ -32,74 +47,46 @@ public class UnicastMonoProcessor<O> extends Mono<O>
     return new UnicastMonoProcessor<>();
   }
 
-  /**
-   * Indicates this Subscription has no value and not requested yet.
-   */
-  static final int NO_SUBSCRIBER_NO_RESULT  = 0;
-  /**
-   * Indicates this Subscription has no value and not requested yet.
-   */
+  /** Indicates this Subscription has no value and not requested yet. */
+  static final int NO_SUBSCRIBER_NO_RESULT = 0;
+  /** Indicates this Subscription has no value and not requested yet. */
   static final int NO_SUBSCRIBER_HAS_RESULT = 1;
-  /**
-   * Indicates this Subscription has no value and not requested yet.
-   */
-  static final int NO_REQUEST_NO_RESULT     = 4;
-  /**
-   * Indicates this Subscription has a value but not requested yet.
-   */
-  static final int NO_REQUEST_HAS_RESULT    = 5;
-  /**
-   * Indicates this Subscription has been requested but there is no value yet.
-   */
-  static final int HAS_REQUEST_NO_RESULT    = 6;
-  /**
-   * Indicates this Subscription has both request and value.
-   */
-  static final int HAS_REQUEST_HAS_RESULT   = 7;
-  /**
-   * Indicates the Subscription has been cancelled.
-   */
-  static final int CANCELLED                = 8;
-  /**
-   * Indicates this Subscription is in fusion mode and is currently empty.
-   */
-  static final int FUSED_EMPTY              = 16;
-  /**
-   * Indicates this Subscription is in fusion mode and has an undelivered notification about present result.
-   */
-  static final int FUSED_HAS_RESULT         = 32;
-  /**
-   * Indicates this Subscription is in fusion mode and has a result.
-   */
-  static final int FUSED_READY              = 64;
-  /**
-   * Indicates this Subscription is in fusion mode and its value has been consumed.
-   */
-  static final int FUSED_CONSUMED           = 128;
+  /** Indicates this Subscription has no value and not requested yet. */
+  static final int NO_REQUEST_NO_RESULT = 4;
+  /** Indicates this Subscription has a value but not requested yet. */
+  static final int NO_REQUEST_HAS_RESULT = 5;
+  /** Indicates this Subscription has been requested but there is no value yet. */
+  static final int HAS_REQUEST_NO_RESULT = 6;
+  /** Indicates this Subscription has both request and value. */
+  static final int HAS_REQUEST_HAS_RESULT = 7;
+  /** Indicates the Subscription has been cancelled. */
+  static final int CANCELLED = 8;
 
   volatile int state;
+
   @SuppressWarnings("rawtypes")
   static final AtomicIntegerFieldUpdater<UnicastMonoProcessor> STATE =
       AtomicIntegerFieldUpdater.newUpdater(UnicastMonoProcessor.class, "state");
 
   volatile int once;
+
   @SuppressWarnings("rawtypes")
   static final AtomicIntegerFieldUpdater<UnicastMonoProcessor> ONCE =
-          AtomicIntegerFieldUpdater.newUpdater(UnicastMonoProcessor.class, "once");
+      AtomicIntegerFieldUpdater.newUpdater(UnicastMonoProcessor.class, "once");
 
   volatile Subscription subscription;
+
   @SuppressWarnings("rawtypes")
   static final AtomicReferenceFieldUpdater<UnicastMonoProcessor, Subscription> UPSTREAM =
-          AtomicReferenceFieldUpdater.newUpdater(
-                  UnicastMonoProcessor.class, Subscription.class, "subscription");
+      AtomicReferenceFieldUpdater.newUpdater(
+          UnicastMonoProcessor.class, Subscription.class, "subscription");
 
   CoreSubscriber<? super O> actual;
 
   Throwable error;
   O value;
 
-  UnicastMonoProcessor() {
-  }
+  UnicastMonoProcessor() {}
 
   @Override
   @NonNull
@@ -156,28 +143,16 @@ public class UnicastMonoProcessor<O> extends Mono<O>
   }
 
   /**
-   * Tries to emit the value and complete the underlying subscriber or
-   * stores the value away until there is a request for it.
-   * <p>
-   * Make sure this method is called at most once
+   * Tries to emit the value and complete the underlying subscriber or stores the value away until
+   * there is a request for it.
+   *
+   * <p>Make sure this method is called at most once
+   *
    * @param v the value to emit
    */
   private void complete(O v) {
-    for (;;) {
+    for (; ; ) {
       int state = this.state;
-
-      if (state == FUSED_EMPTY) {
-        setValue(v);
-        //sync memory since setValue is non volatile
-        if (STATE.compareAndSet(this, FUSED_EMPTY, FUSED_READY)) {
-          Subscriber<? super O> a = actual;
-          a.onNext(v);
-          a.onComplete();
-          return;
-        }
-        //refresh state if race occurred so we test if cancelled in the next comparison
-        state = this.state;
-      }
 
       // if state is >= HAS_CANCELLED or bit zero is set (*_HAS_VALUE) case, return
       if ((state & ~HAS_REQUEST_NO_RESULT) != 0) {
@@ -186,18 +161,22 @@ public class UnicastMonoProcessor<O> extends Mono<O>
         return;
       }
 
-      if (state == HAS_REQUEST_NO_RESULT && STATE.compareAndSet(this, HAS_REQUEST_NO_RESULT, HAS_REQUEST_HAS_RESULT)) {
-        this.value = null;
-        Subscriber<? super O> a = actual;
-        a.onNext(v);
-        a.onComplete();
-        return;
+      if (state == HAS_REQUEST_NO_RESULT) {
+        final Subscriber<? super O> a = actual;
+        if (STATE.compareAndSet(this, HAS_REQUEST_NO_RESULT, HAS_REQUEST_HAS_RESULT)) {
+          this.value = null;
+          a.onNext(v);
+          a.onComplete();
+          return;
+        }
       }
       setValue(v);
-      if (state == NO_REQUEST_NO_RESULT && STATE.compareAndSet(this, NO_REQUEST_NO_RESULT, NO_REQUEST_HAS_RESULT)) {
+      if (state == NO_REQUEST_NO_RESULT
+          && STATE.compareAndSet(this, NO_REQUEST_NO_RESULT, NO_REQUEST_HAS_RESULT)) {
         return;
       }
-      if (state == NO_SUBSCRIBER_NO_RESULT && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
+      if (state == NO_SUBSCRIBER_NO_RESULT
+          && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
         return;
       }
     }
@@ -205,61 +184,43 @@ public class UnicastMonoProcessor<O> extends Mono<O>
 
   /**
    * Tries to emit completion the underlying subscriber
-   * <p>
-   * Make sure this method is called at most once
+   *
+   * <p>Make sure this method is called at most once
    */
   private void complete() {
-    for (;;) {
+    for (; ; ) {
       int state = this.state;
-
-      if (state == FUSED_EMPTY) {
-        if (STATE.compareAndSet(this, FUSED_EMPTY, FUSED_CONSUMED)) {
-          Subscriber<? super O> a = actual;
-          a.onComplete();
-          return;
-        }
-        //refresh state if race occurred so we test if cancelled in the next comparison
-        state = this.state;
-      }
 
       // if state is >= HAS_CANCELLED or bit zero is set (*_HAS_VALUE) case, return
       if ((state & ~HAS_REQUEST_NO_RESULT) != 0) {
         return;
       }
 
-      if ((state == HAS_REQUEST_NO_RESULT || state == NO_REQUEST_NO_RESULT) && STATE.compareAndSet(this, state, HAS_REQUEST_HAS_RESULT)) {
-        Subscriber<? super O> a = actual;
-        a.onComplete();
-        return;
+      if (state == HAS_REQUEST_NO_RESULT || state == NO_REQUEST_NO_RESULT) {
+        final Subscriber<? super O> a = actual;
+        if (STATE.compareAndSet(this, state, HAS_REQUEST_HAS_RESULT)) {
+          a.onComplete();
+          return;
+        }
       }
-      if (state == NO_SUBSCRIBER_NO_RESULT && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
+      if (state == NO_SUBSCRIBER_NO_RESULT
+          && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
         return;
       }
     }
   }
 
   /**
-   * Tries to emit error the underlying subscriber or
-   * stores the value away until there is a request for it.
-   * <p>
-   * Make sure this method is called at most once
+   * Tries to emit error the underlying subscriber or stores the value away until there is a request
+   * for it.
+   *
+   * <p>Make sure this method is called at most once
+   *
    * @param e the error to emit
    */
   private void complete(Throwable e) {
-    for (;;) {
+    for (; ; ) {
       int state = this.state;
-
-      if (state == FUSED_EMPTY) {
-        setError(e);
-        //sync memory since setValue is non volatile
-        if (STATE.compareAndSet(this, FUSED_EMPTY, FUSED_CONSUMED)) {
-          Subscriber<? super O> a = actual;
-          a.onError(e);
-          return;
-        }
-        //refresh state if race occurred so we test if cancelled in the next comparison
-        state = this.state;
-      }
 
       // if state is >= HAS_CANCELLED or bit zero is set (*_HAS_VALUE) case, return
       if ((state & ~HAS_REQUEST_NO_RESULT) != 0) {
@@ -267,12 +228,15 @@ public class UnicastMonoProcessor<O> extends Mono<O>
       }
 
       setError(e);
-      if ((state == HAS_REQUEST_NO_RESULT || state == NO_REQUEST_NO_RESULT) && STATE.compareAndSet(this, state, HAS_REQUEST_HAS_RESULT)) {
-        Subscriber<? super O> a = actual;
-        a.onError(e);
-        return;
+      if (state == HAS_REQUEST_NO_RESULT || state == NO_REQUEST_NO_RESULT) {
+        final Subscriber<? super O> a = actual;
+        if (STATE.compareAndSet(this, state, HAS_REQUEST_HAS_RESULT)) {
+          a.onError(e);
+          return;
+        }
       }
-      if (state == NO_SUBSCRIBER_NO_RESULT && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
+      if (state == NO_SUBSCRIBER_NO_RESULT
+          && STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_SUBSCRIBER_HAS_RESULT)) {
         return;
       }
     }
@@ -285,11 +249,13 @@ public class UnicastMonoProcessor<O> extends Mono<O>
     if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
       this.actual = actual;
 
-      // CAS LOOP since there is a racing with [onNext / onComplete / onError / dispose] which can appear at any moment
+      // CAS LOOP since there is a racing with [onNext / onComplete / onError / dispose] which can
+      // appear at any moment
 
       int state = this.state;
 
-      // possible states within the racing between [onNext / onComplete / onError / dispose] and setting subscriber
+      // possible states within the racing between [onNext / onComplete / onError / dispose] and
+      // setting subscriber
       // are NO_SUBSCRIBER_[NO_RESULT or HAS_RESULT]
       if (state == NO_SUBSCRIBER_NO_RESULT) {
         if (STATE.compareAndSet(this, NO_SUBSCRIBER_NO_RESULT, NO_REQUEST_NO_RESULT)) {
@@ -305,8 +271,8 @@ public class UnicastMonoProcessor<O> extends Mono<O>
         state = NO_REQUEST_HAS_RESULT;
       }
 
-
-      // check if state is with a result then there is a chance of immediate termination if there is no value
+      // check if state is with a result then there is a chance of immediate termination if there is
+      // no value
       // e.g. [onError / onComplete / dispose] only
       if (state == NO_REQUEST_HAS_RESULT && this.value == null) {
         this.actual = null;
@@ -323,72 +289,25 @@ public class UnicastMonoProcessor<O> extends Mono<O>
 
       // call onSubscribe if has value in the result or no result delivered so far
       actual.onSubscribe(this);
-
-      // update state to ensure we observe what happened after onSubscribe appeared
-      state = this.state;
-      // if FUSED_HAS_RESULT appeared then we have to notify Subscriber that there is a result which MUST be consumed
-      if (state == FUSED_HAS_RESULT) {
-        this.actual = null;
-        Throwable e = this.error;
-        if (e != null) {
-          // racing between cancel / dispose / complete
-          if (STATE.compareAndSet(this, FUSED_HAS_RESULT, FUSED_CONSUMED)) {
-            actual.onError(e);
-          }
-        } else {
-          O v = this.value;
-
-          if (v == null) {
-            if (STATE.compareAndSet(this, FUSED_HAS_RESULT, FUSED_CONSUMED)) {
-              actual.onComplete();
-            }
-          } else {
-            if (STATE.compareAndSet(this, FUSED_HAS_RESULT, FUSED_READY)) {
-              actual.onNext(v);
-              actual.onComplete();
-            }
-          }
-        }
-      }
     } else {
       Operators.error(
-              actual,
-              new IllegalStateException("UnicastMonoProcessor allows only a single Subscriber"));
+          actual,
+          new IllegalStateException("UnicastMonoProcessor allows only a single Subscriber"));
     }
-  }
-
-  @Override
-  public int requestFusion(int mode) {
-    if ((mode & ASYNC) != 0) {
-      int state = this.state;
-
-      // CAS LOOP since there is a racing with [onNext / onComplete / onError / dispose] which can appear at any moment
-      for (;;) {
-        if (state == NO_REQUEST_NO_RESULT && STATE.compareAndSet(this, NO_REQUEST_NO_RESULT, FUSED_EMPTY)) {
-          break;
-        }
-        if (state == NO_REQUEST_HAS_RESULT && STATE.compareAndSet(this, NO_REQUEST_HAS_RESULT, FUSED_HAS_RESULT)) {
-          break;
-        }
-
-        state = this.state;
-      }
-      return ASYNC;
-    }
-    return NONE;
   }
 
   @Override
   public final void request(long n) {
     if (Operators.validate(n)) {
-      for (;;) {
+      for (; ; ) {
         int s = state;
         // if the any bits 1-31 are set, we are either in fusion mode (FUSED_*)
         // or request has been called (HAS_REQUEST_*)
         if ((s & ~NO_REQUEST_HAS_RESULT) != 0) {
           return;
         }
-        if (s == NO_REQUEST_HAS_RESULT && STATE.compareAndSet(this, NO_REQUEST_HAS_RESULT, HAS_REQUEST_HAS_RESULT)) {
+        if (s == NO_REQUEST_HAS_RESULT
+            && STATE.compareAndSet(this, NO_REQUEST_HAS_RESULT, HAS_REQUEST_HAS_RESULT)) {
           O v = value;
           if (v != null) {
             value = null;
@@ -434,17 +353,6 @@ public class UnicastMonoProcessor<O> extends Mono<O>
     complete(new CancellationException("Disposed"));
   }
 
-  @Override
-  public O poll() {
-    if (STATE.compareAndSet(this, FUSED_READY, FUSED_CONSUMED)) {
-      O v = value;
-      value = null;
-      actual = null;
-      return v;
-    }
-    return null;
-  }
-
   /**
    * Returns the value that completed this {@link UnicastMonoProcessor}. Returns {@code null} if the
    * {@link UnicastMonoProcessor} has not been completed. If the {@link UnicastMonoProcessor} is
@@ -456,7 +364,7 @@ public class UnicastMonoProcessor<O> extends Mono<O>
    */
   @Nullable
   public O peek() {
-    if (!isDisposed()) {
+    if (isCancelled()) {
       return null;
     }
 
@@ -471,29 +379,6 @@ public class UnicastMonoProcessor<O> extends Mono<O>
     }
 
     return null;
-  }
-
-  @Override
-  public int size() {
-    int state = this.state;
-
-    if (state < FUSED_EMPTY && state % 2 == 1 && this.value != null) {
-      return 1;
-    } else if (this.value != null) {
-      return 1;
-    }
-
-    return 0;
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return size() == 0;
-  }
-
-  @Override
-  public void clear() {
-    this.value = null;
   }
 
   /**
@@ -527,16 +412,6 @@ public class UnicastMonoProcessor<O> extends Mono<O>
   }
 
   /**
-   * Indicates whether this {@code UnicastMonoProcessor} has been interrupted via cancellation.
-   *
-   * @return {@code true} if this {@code UnicastMonoProcessor} is cancelled, {@code false}
-   *     otherwise.
-   */
-  public boolean isCancelled() {
-    return state == CANCELLED;
-  }
-
-  /**
    * Indicates whether this {@code UnicastMonoProcessor} has been completed with an error.
    *
    * @return {@code true} if this {@code UnicastMonoProcessor} was completed with an error, {@code
@@ -546,10 +421,25 @@ public class UnicastMonoProcessor<O> extends Mono<O>
     return getError() != null;
   }
 
+  /**
+   * Indicates whether this {@code UnicastMonoProcessor} has been interrupted via cancellation.
+   *
+   * @return {@code true} if this {@code UnicastMonoProcessor} is cancelled, {@code false}
+   *     otherwise.
+   */
+  public boolean isCancelled() {
+    return state == CANCELLED;
+  }
+
+  public final boolean isTerminated() {
+    int state = this.state;
+    return (state < CANCELLED && state % 2 == 1);
+  }
+
   @Override
   public boolean isDisposed() {
     int state = this.state;
-    return state == HAS_REQUEST_HAS_RESULT || state == CANCELLED || state == FUSED_CONSUMED;
+    return state == CANCELLED || (state < CANCELLED && state % 2 == 1);
   }
 
   @Override
@@ -559,7 +449,7 @@ public class UnicastMonoProcessor<O> extends Mono<O>
     int state = this.state;
 
     if (key == Attr.TERMINATED) {
-      return state == HAS_REQUEST_HAS_RESULT || state == FUSED_CONSUMED;
+      return (state < CANCELLED && state % 2 == 1);
     }
     if (key == Attr.PARENT) {
       return subscription;

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoProcessorTest.java
@@ -1,0 +1,661 @@
+package io.rsocket.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.lang.ref.WeakReference;
+import java.time.Duration;
+import java.util.Date;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Scannable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
+import reactor.core.publisher.Operators;
+import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
+import reactor.util.function.Tuple2;
+
+public class UnicastMonoProcessorTest {
+
+  @Test
+  public void noRetentionOnTermination() throws InterruptedException {
+    Date date = new Date();
+    CompletableFuture<Date> future = new CompletableFuture<>();
+
+    WeakReference<Date> refDate = new WeakReference<>(date);
+    WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
+
+    Mono<Date> source = Mono.fromFuture(future);
+    Mono<String> data =
+        source.map(Date::toString).log().subscribeWith(UnicastMonoProcessor.create()).log();
+
+    future.complete(date);
+    assertThat(data.block()).isEqualTo(date.toString());
+
+    date = null;
+    future = null;
+    source = null;
+    System.gc();
+
+    int cycles;
+    for (cycles = 10; cycles > 0; cycles--) {
+      if (refDate.get() == null && refFuture.get() == null) break;
+      Thread.sleep(100);
+    }
+
+    assumeThat(refFuture.get()).isNull();
+    assertThat(refDate.get()).isNull();
+    assertThat(cycles).isNotZero().isPositive();
+  }
+
+  @Test
+  public void noRetentionOnTerminationError() throws InterruptedException {
+    CompletableFuture<Date> future = new CompletableFuture<>();
+
+    WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
+    UnicastMonoProcessor<String> processor = UnicastMonoProcessor.create();
+
+    Mono<Date> source = Mono.fromFuture(future);
+    Mono<String> data = source.map(Date::toString).subscribeWith(processor);
+
+    future.completeExceptionally(new IllegalStateException());
+
+    assertThatExceptionOfType(IllegalStateException.class).isThrownBy(data::block);
+
+    future = null;
+    source = null;
+    System.gc();
+
+    int cycles;
+    for (cycles = 10; cycles > 0; cycles--) {
+      if (refFuture.get() == null) break;
+      Thread.sleep(100);
+    }
+
+    assumeThat(refFuture.get()).isNull();
+    assertThat(cycles).isNotZero().isPositive();
+  }
+
+  @Test
+  public void noRetentionOnTerminationCancel() throws InterruptedException {
+    CompletableFuture<Date> future = new CompletableFuture<>();
+
+    WeakReference<CompletableFuture<Date>> refFuture = new WeakReference<>(future);
+    UnicastMonoProcessor<String> processor = UnicastMonoProcessor.create();
+
+    Mono<Date> source = Mono.fromFuture(future);
+    Mono<String> data =
+        source.map(Date::toString).transformDeferred((s) -> s.subscribeWith(processor));
+
+    future = null;
+    source = null;
+
+    data.subscribe().dispose();
+    processor.dispose();
+
+    data = null;
+
+    System.gc();
+
+    int cycles;
+    for (cycles = 10; cycles > 0; cycles--) {
+      if (refFuture.get() == null) break;
+      Thread.sleep(100);
+    }
+
+    assumeThat(refFuture.get()).isNull();
+    assertThat(cycles).isNotZero().isPositive();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void MonoProcessorResultNotAvailable() {
+    MonoProcessor<String> mp = MonoProcessor.create();
+    mp.block(Duration.ofMillis(1));
+  }
+
+  @Test
+  public void MonoProcessorRejectedDoOnSuccessOrError() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    AtomicReference<Throwable> ref = new AtomicReference<>();
+
+    mp.doOnSuccessOrError((s, f) -> ref.set(f)).subscribe();
+    mp.onError(new Exception("test"));
+
+    assertThat(ref.get()).hasMessage("test");
+    assertThat(mp.isError()).isTrue();
+  }
+
+  @Test
+  public void MonoProcessorRejectedDoOnTerminate() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    AtomicInteger invoked = new AtomicInteger();
+
+    mp.doOnTerminate(invoked::incrementAndGet).subscribe();
+    mp.onError(new Exception("test"));
+
+    assertThat(invoked.get()).isEqualTo(1);
+    assertThat(mp.isError()).isTrue();
+  }
+
+  @Test
+  public void MonoProcessorRejectedSubscribeCallback() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    AtomicReference<Throwable> ref = new AtomicReference<>();
+
+    mp.subscribe(v -> {}, ref::set);
+    mp.onError(new Exception("test"));
+
+    assertThat(ref.get()).hasMessage("test");
+    assertThat(mp.isError()).isTrue();
+  }
+
+  @Test
+  public void MonoProcessorSuccessDoOnSuccessOrError() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    AtomicReference<String> ref = new AtomicReference<>();
+
+    mp.doOnSuccessOrError((s, f) -> ref.set(s)).subscribe();
+    mp.onNext("test");
+
+    assertThat(ref.get()).isEqualToIgnoringCase("test");
+    assertThat(mp.isDisposed()).isTrue();
+    assertThat(mp.isError()).isFalse();
+  }
+
+  @Test
+  public void MonoProcessorSuccessDoOnTerminate() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    AtomicInteger invoked = new AtomicInteger();
+
+    mp.doOnTerminate(invoked::incrementAndGet).subscribe();
+    mp.onNext("test");
+
+    assertThat(invoked.get()).isEqualTo(1);
+    assertThat(mp.isDisposed()).isTrue();
+    assertThat(mp.isError()).isFalse();
+  }
+
+  @Test
+  public void MonoProcessorSuccessSubscribeCallback() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    AtomicReference<String> ref = new AtomicReference<>();
+
+    mp.subscribe(ref::set);
+    mp.onNext("test");
+
+    assertThat(ref.get()).isEqualToIgnoringCase("test");
+    assertThat(mp.isDisposed()).isTrue();
+    assertThat(mp.isError()).isFalse();
+  }
+
+  @Test
+  public void MonoProcessorRejectedDoOnError() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    AtomicReference<Throwable> ref = new AtomicReference<>();
+
+    mp.doOnError(ref::set).subscribe();
+    mp.onError(new Exception("test"));
+
+    assertThat(ref.get()).hasMessage("test");
+    assertThat(mp.isError()).isTrue();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void MonoProcessorRejectedSubscribeCallbackNull() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+
+    mp.subscribe((Subscriber<String>) null);
+  }
+
+  @Test
+  public void MonoProcessorSuccessDoOnSuccess() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    AtomicReference<String> ref = new AtomicReference<>();
+
+    mp.doOnSuccess(ref::set).subscribe();
+    mp.onNext("test");
+
+    assertThat(ref.get()).isEqualToIgnoringCase("test");
+    assertThat(mp.isDisposed()).isTrue();
+    assertThat(mp.isError()).isFalse();
+  }
+
+  @Test
+  public void MonoProcessorSuccessChainTogether() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<String> mp2 = UnicastMonoProcessor.create();
+    mp.subscribe(mp2);
+
+    mp.onNext("test");
+
+    assertThat(mp2.peek()).isEqualToIgnoringCase("test");
+    assertThat(mp.isDisposed()).isTrue();
+    assertThat(mp.isError()).isFalse();
+  }
+
+  @Test
+  public void MonoProcessorRejectedChainTogether() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<String> mp2 = UnicastMonoProcessor.create();
+    mp.subscribe(mp2);
+
+    mp.onError(new Exception("test"));
+
+    assertThat(mp2.getError()).hasMessage("test");
+    assertThat(mp.isError()).isTrue();
+  }
+
+  @Test
+  public void MonoProcessorDoubleFulfill() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+
+    StepVerifier.create(mp)
+        .then(
+            () -> {
+              mp.onNext("test1");
+              mp.onNext("test2");
+            })
+        .expectNext("test1")
+        .expectComplete()
+        .verifyThenAssertThat()
+        .hasDroppedExactly("test2");
+  }
+
+  @Test
+  public void MonoProcessorNullFulfill() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+
+    mp.onNext(null);
+
+    assertThat(mp.isDisposed()).isTrue();
+    assertThat(mp.peek()).isNull();
+  }
+
+  @Test
+  public void MonoProcessorMapFulfill() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+
+    mp.onNext(1);
+
+    UnicastMonoProcessor<Integer> mp2 =
+        mp.map(s -> s * 2).subscribeWith(UnicastMonoProcessor.create());
+    assertThat(mp2.peek()).isEqualTo(2);
+
+    mp2.subscribe();
+    assertThat(mp2.isDisposed()).isTrue();
+    assertThat(mp2.peek()).isNull();
+  }
+
+  @Test
+  public void MonoProcessorThenFulfill() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+
+    mp.onNext(1);
+
+    UnicastMonoProcessor<Integer> mp2 =
+        mp.flatMap(s -> Mono.just(s * 2)).subscribeWith(UnicastMonoProcessor.create());
+    mp2.subscribe();
+
+    assertThat(mp2.isDisposed()).isTrue();
+    assertThat(mp2.peek()).isEqualTo(2);
+  }
+
+  @Test
+  public void MonoProcessorMapError() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+
+    mp.onNext(1);
+
+    UnicastMonoProcessor<Integer> mp2 = UnicastMonoProcessor.create();
+
+    StepVerifier.create(
+            mp.<Integer>map(
+                    s -> {
+                      throw new RuntimeException("test");
+                    })
+                .subscribeWith(mp2),
+            0)
+        .thenRequest(1)
+        .then(
+            () -> {
+              assertThat(mp2.isDisposed()).isTrue();
+              assertThat(mp2.getError()).hasMessage("test");
+            })
+        .verifyErrorMessage("test");
+  }
+
+  @Test(expected = Exception.class)
+  public void MonoProcessorDoubleError() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+
+    mp.onError(new Exception("test"));
+    mp.onError(new Exception("test"));
+  }
+
+  @Test(expected = Exception.class)
+  public void MonoProcessorDoubleSignal() {
+    UnicastMonoProcessor<String> mp = UnicastMonoProcessor.create();
+
+    mp.onNext("test");
+    mp.onError(new Exception("test"));
+  }
+
+  @Test
+  public void zipMonoProcessor() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Integer> mp2 = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Tuple2<Integer, Integer>> mp3 = UnicastMonoProcessor.create();
+
+    StepVerifier.create(Mono.zip(mp, mp2).subscribeWith(mp3))
+        .then(() -> assertThat(mp3.isDisposed()).isFalse())
+        .then(() -> mp.onNext(1))
+        .then(() -> assertThat(mp3.isDisposed()).isFalse())
+        .then(() -> mp2.onNext(2))
+        .then(
+            () -> {
+              assertThat(mp3.isDisposed()).isTrue();
+              assertThat(mp3.peek().getT1()).isEqualTo(1);
+              assertThat(mp3.peek().getT2()).isEqualTo(2);
+            })
+        .expectNextMatches(t -> t.getT1() == 1 && t.getT2() == 2)
+        .verifyComplete();
+  }
+
+  @Test
+  public void zipMonoProcessor2() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Integer> mp3 = UnicastMonoProcessor.create();
+
+    StepVerifier.create(Mono.zip(d -> (Integer) d[0], mp).subscribeWith(mp3))
+        .then(() -> assertThat(mp3.isDisposed()).isFalse())
+        .then(() -> mp.onNext(1))
+        .then(
+            () -> {
+              assertThat(mp3.isDisposed()).isTrue();
+              assertThat(mp3.peek()).isEqualTo(1);
+            })
+        .expectNext(1)
+        .verifyComplete();
+  }
+
+  @Test
+  public void zipMonoProcessorRejected() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Integer> mp2 = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Tuple2<Integer, Integer>> mp3 = UnicastMonoProcessor.create();
+
+    StepVerifier.create(Mono.zip(mp, mp2).subscribeWith(mp3))
+        .then(() -> assertThat(mp3.isDisposed()).isFalse())
+        .then(() -> mp.onError(new Exception("test")))
+        .then(
+            () -> {
+              assertThat(mp3.isDisposed()).isTrue();
+              assertThat(mp3.getError()).hasMessage("test");
+            })
+        .verifyErrorMessage("test");
+  }
+
+  @Test
+  public void filterMonoProcessor() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Integer> mp2 = UnicastMonoProcessor.create();
+    StepVerifier.create(mp.filter(s -> s % 2 == 0).subscribeWith(mp2))
+        .then(() -> mp.onNext(2))
+        .then(() -> assertThat(mp2.isError()).isFalse())
+        .then(() -> assertThat(mp2.isDisposed()).isTrue())
+        .then(() -> assertThat(mp2.peek()).isEqualTo(2))
+        .then(() -> assertThat(mp2.isDisposed()).isTrue())
+        .expectNext(2)
+        .verifyComplete();
+  }
+
+  @Test
+  public void filterMonoProcessorNot() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Integer> mp2 = UnicastMonoProcessor.create();
+    StepVerifier.create(mp.filter(s -> s % 2 == 0).subscribeWith(mp2))
+        .then(() -> mp.onNext(1))
+        .then(() -> assertThat(mp2.isError()).isFalse())
+        .then(() -> assertThat(mp2.isDisposed()).isTrue())
+        .then(() -> assertThat(mp2.peek()).isNull())
+        .then(() -> assertThat(mp2.isDisposed()).isTrue())
+        .verifyComplete();
+  }
+
+  @Test
+  public void filterMonoProcessorError() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Integer> mp2 = UnicastMonoProcessor.create();
+    StepVerifier.create(
+            mp.filter(
+                    s -> {
+                      throw new RuntimeException("test");
+                    })
+                .subscribeWith(mp2))
+        .then(() -> mp.onNext(2))
+        .then(() -> assertThat(mp2.isError()).isTrue())
+        .then(() -> assertThat(mp2.isDisposed()).isTrue())
+        .then(() -> assertThat(mp2.getError()).hasMessage("test"))
+        .then(() -> assertThat(mp2.isDisposed()).isTrue())
+        .verifyErrorMessage("test");
+  }
+
+  @Test
+  public void doOnSuccessMonoProcessorError() {
+    UnicastMonoProcessor<Integer> mp = UnicastMonoProcessor.create();
+    UnicastMonoProcessor<Integer> mp2 = UnicastMonoProcessor.create();
+    AtomicReference<Throwable> ref = new AtomicReference<>();
+
+    StepVerifier.create(
+            mp.doOnSuccess(
+                    s -> {
+                      throw new RuntimeException("test");
+                    })
+                .doOnError(ref::set)
+                .subscribeWith(mp2))
+        .then(() -> mp.onNext(2))
+        .then(() -> assertThat(mp2.isError()).isTrue())
+        .then(() -> assertThat(ref.get()).hasMessage("test"))
+        .then(() -> assertThat(mp2.isDisposed()).isTrue())
+        .then(() -> assertThat(mp2.getError()).hasMessage("test"))
+        .then(() -> assertThat(mp2.isDisposed()).isTrue())
+        .verifyErrorMessage("test");
+  }
+
+  @Test
+  public void fluxCancelledByMonoProcessor() {
+    AtomicLong cancelCounter = new AtomicLong();
+    Flux.range(1, 10)
+        .doOnCancel(cancelCounter::incrementAndGet)
+        .transformDeferred((s) -> s.subscribeWith(UnicastMonoProcessor.create()))
+        .subscribe();
+
+    assertThat(cancelCounter.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void cancelledByMonoProcessor() {
+    AtomicLong cancelCounter = new AtomicLong();
+    UnicastMonoProcessor<String> monoProcessor =
+        Mono.just("foo")
+            .doOnCancel(cancelCounter::incrementAndGet)
+            .subscribeWith(UnicastMonoProcessor.create());
+    monoProcessor.subscribe();
+
+    assertThat(cancelCounter.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void scanProcessor() {
+    UnicastMonoProcessor<String> test = UnicastMonoProcessor.create();
+    Subscription subscription = Operators.emptySubscription();
+    test.onSubscribe(subscription);
+
+    assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+    assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+
+    test.onComplete();
+    assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
+    assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+  }
+
+  @Test
+  public void scanProcessorCancelled() {
+    UnicastMonoProcessor<String> test = UnicastMonoProcessor.create();
+    Subscription subscription = Operators.emptySubscription();
+    test.onSubscribe(subscription);
+
+    assertThat(test.scan(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+    assertThat(test.scan(Scannable.Attr.CANCELLED)).isFalse();
+
+    test.cancel();
+    assertThat(test.scan(Scannable.Attr.TERMINATED)).isFalse();
+    assertThat(test.scan(Scannable.Attr.CANCELLED)).isTrue();
+  }
+
+  @Test
+  public void scanProcessorSubscription() {
+    UnicastMonoProcessor<String> test = UnicastMonoProcessor.create();
+    Subscription subscription = Operators.emptySubscription();
+    test.onSubscribe(subscription);
+
+    assertThat(test.scan(Scannable.Attr.ACTUAL)).isNull();
+    assertThat(test.scan(Scannable.Attr.PARENT)).isSameAs(subscription);
+  }
+
+  @Test
+  public void scanProcessorError() {
+    UnicastMonoProcessor<String> test = UnicastMonoProcessor.create();
+    Subscription subscription = Operators.emptySubscription();
+    test.onSubscribe(subscription);
+
+    test.onError(new IllegalStateException("boom"));
+
+    assertThat(test.scan(Scannable.Attr.ERROR)).hasMessage("boom");
+  }
+
+  @Test
+  public void monoToProcessorConnects() {
+    TestPublisher<String> tp = TestPublisher.create();
+    UnicastMonoProcessor<String> connectedProcessor =
+        tp.mono().subscribeWith(UnicastMonoProcessor.create());
+
+    assertThat(connectedProcessor.subscription).isNotNull();
+  }
+
+  @Test
+  public void monoToProcessorChain() {
+    StepVerifier.withVirtualTime(
+            () ->
+                Mono.just("foo")
+                    .subscribeWith(UnicastMonoProcessor.create())
+                    .delayElement(Duration.ofMillis(500)))
+        .expectSubscription()
+        .expectNoEvent(Duration.ofMillis(500))
+        .expectNext("foo")
+        .verifyComplete();
+  }
+
+  @Test
+  public void monoToProcessorChainColdToHot() {
+    AtomicInteger subscriptionCount = new AtomicInteger();
+    Mono<String> coldToHot =
+        Mono.just("foo")
+            .doOnSubscribe(sub -> subscriptionCount.incrementAndGet())
+            .transformDeferred(s -> s.subscribeWith(UnicastMonoProcessor.create()))
+            .subscribeWith(UnicastMonoProcessor.create()) // this actually subscribes
+            .filter(s -> s.length() < 4);
+
+    assertThat(subscriptionCount.get()).isEqualTo(1);
+
+    coldToHot.block();
+    assertThatThrownBy(coldToHot::block)
+        .hasMessage("UnicastMonoProcessor allows only a single Subscriber");
+    assertThatThrownBy(coldToHot::block)
+        .hasMessage("UnicastMonoProcessor allows only a single Subscriber");
+
+    assertThat(subscriptionCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void monoProcessorBlockIsUnbounded() {
+    long start = System.nanoTime();
+
+    String result =
+        Mono.just("foo")
+            .delayElement(Duration.ofMillis(500))
+            .subscribeWith(UnicastMonoProcessor.create())
+            .block();
+
+    assertThat(result).isEqualTo("foo");
+    assertThat(Duration.ofNanos(System.nanoTime() - start))
+        .isGreaterThanOrEqualTo(Duration.ofMillis(500));
+  }
+
+  @Test
+  public void monoProcessorBlockNegativeIsImmediateTimeout() {
+    long start = System.nanoTime();
+
+    assertThatExceptionOfType(IllegalStateException.class)
+        .isThrownBy(
+            () ->
+                Mono.just("foo")
+                    .delayElement(Duration.ofMillis(500))
+                    .subscribeWith(UnicastMonoProcessor.create())
+                    .block(Duration.ofSeconds(-1)))
+        .withMessage("Timeout on blocking read for -1000 MILLISECONDS");
+
+    assertThat(Duration.ofNanos(System.nanoTime() - start)).isLessThan(Duration.ofMillis(500));
+  }
+
+  @Test
+  public void monoProcessorBlockZeroIsImmediateTimeout() {
+    long start = System.nanoTime();
+
+    assertThatExceptionOfType(IllegalStateException.class)
+        .isThrownBy(
+            () ->
+                Mono.just("foo")
+                    .delayElement(Duration.ofMillis(500))
+                    .subscribeWith(UnicastMonoProcessor.create())
+                    .block(Duration.ZERO))
+        .withMessage("Timeout on blocking read for 0 MILLISECONDS");
+
+    assertThat(Duration.ofNanos(System.nanoTime() - start)).isLessThan(Duration.ofMillis(500));
+  }
+
+  @Test
+  public void disposeBeforeValueSendsCancellationException() {
+    UnicastMonoProcessor<String> processor = UnicastMonoProcessor.create();
+    AtomicReference<Throwable> e1 = new AtomicReference<>();
+    AtomicReference<Throwable> e2 = new AtomicReference<>();
+    AtomicReference<Throwable> e3 = new AtomicReference<>();
+    AtomicReference<Throwable> late = new AtomicReference<>();
+
+    processor.subscribe(v -> Assertions.fail("expected first subscriber to error"), e1::set);
+    processor.subscribe(v -> Assertions.fail("expected second subscriber to error"), e2::set);
+    processor.subscribe(v -> Assertions.fail("expected third subscriber to error"), e3::set);
+
+    processor.dispose();
+
+    assertThat(e1.get()).isInstanceOf(CancellationException.class);
+    assertThat(e2.get()).isInstanceOf(IllegalStateException.class);
+    assertThat(e3.get()).isInstanceOf(IllegalStateException.class);
+
+    processor.subscribe(v -> Assertions.fail("expected late subscriber to error"), late::set);
+    assertThat(late.get()).isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoProcessorTest.java
@@ -79,6 +79,7 @@ public class UnicastMonoProcessorTest {
 
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_HAS_RESULT);
 
+    assertSubscriber.assertNoEvents();
     assertSubscriber.request(1);
 
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
@@ -162,6 +163,7 @@ public class UnicastMonoProcessorTest {
 
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_HAS_RESULT);
 
+    assertSubscriber.assertNoEvents();
     assertSubscriber.request(1);
 
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
@@ -240,10 +242,12 @@ public class UnicastMonoProcessorTest {
 
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
+    assertSubscriber.assertNoEvents();
     assertSubscriber.request(1);
 
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
+    assertSubscriber.assertNoEvents();
     processor.onNext(1);
 
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
@@ -339,10 +343,12 @@ public class UnicastMonoProcessorTest {
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       assertSubscriber.request(1);
+      assertSubscriber.assertNoEvents();
 
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       assertSubscriber.cancel();
+      assertSubscriber.assertNoEvents();
 
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
@@ -374,10 +380,12 @@ public class UnicastMonoProcessorTest {
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       assertSubscriber.request(1);
+      assertSubscriber.assertNoEvents();
 
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       assertSubscriber.cancel();
+      assertSubscriber.assertNoEvents();
 
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
@@ -410,10 +418,12 @@ public class UnicastMonoProcessorTest {
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       assertSubscriber.request(1);
+      assertSubscriber.assertNoEvents();
 
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       assertSubscriber.cancel();
+      assertSubscriber.assertNoEvents();
 
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
@@ -444,10 +454,12 @@ public class UnicastMonoProcessorTest {
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       assertSubscriber.request(1);
+      assertSubscriber.assertNoEvents();
 
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       assertSubscriber.cancel();
+      assertSubscriber.assertNoEvents();
 
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 

--- a/rsocket-core/src/test/java/io/rsocket/internal/subscriber/AssertSubscriber.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/subscriber/AssertSubscriber.java
@@ -1,0 +1,1154 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.internal.subscriber;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.publisher.Operators;
+import reactor.util.annotation.NonNull;
+import reactor.util.context.Context;
+
+/**
+ * A Subscriber implementation that hosts assertion tests for its state and allows asynchronous
+ * cancellation and requesting.
+ *
+ * <p>To create a new instance of {@link AssertSubscriber}, you have the choice between these static
+ * methods:
+ *
+ * <ul>
+ *   <li>{@link AssertSubscriber#create()}: create a new {@link AssertSubscriber} and requests an
+ *       unbounded number of elements.
+ *   <li>{@link AssertSubscriber#create(long)}: create a new {@link AssertSubscriber} and requests
+ *       {@code n} elements (can be 0 if you want no initial demand).
+ * </ul>
+ *
+ * <p>If you are testing asynchronous publishers, don't forget to use one of the {@code await*()}
+ * methods to wait for the data to assert.
+ *
+ * <p>You can extend this class but only the onNext, onError and onComplete can be overridden. You
+ * can call {@link #request(long)} and {@link #cancel()} from any thread or from within the
+ * overridable methods but you should avoid calling the assertXXX methods asynchronously.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * AssertSubscriber
+ *   .subscribe(publisher)
+ *   .await()
+ *   .assertValues("ABC", "DEF");
+ * }</pre>
+ *
+ * @param <T> the value type.
+ * @author Sebastien Deleuze
+ * @author David Karnok
+ * @author Anatoly Kadyshev
+ * @author Stephane Maldini
+ * @author Brian Clozel
+ */
+public class AssertSubscriber<T> implements CoreSubscriber<T>, Subscription {
+
+  /** Default timeout for waiting next values to be received */
+  public static final Duration DEFAULT_VALUES_TIMEOUT = Duration.ofSeconds(3);
+
+  @SuppressWarnings("rawtypes")
+  private static final AtomicLongFieldUpdater<AssertSubscriber> REQUESTED =
+      AtomicLongFieldUpdater.newUpdater(AssertSubscriber.class, "requested");
+
+  @SuppressWarnings("rawtypes")
+  private static final AtomicReferenceFieldUpdater<AssertSubscriber, List> NEXT_VALUES =
+      AtomicReferenceFieldUpdater.newUpdater(AssertSubscriber.class, List.class, "values");
+
+  @SuppressWarnings("rawtypes")
+  private static final AtomicReferenceFieldUpdater<AssertSubscriber, Subscription> S =
+      AtomicReferenceFieldUpdater.newUpdater(AssertSubscriber.class, Subscription.class, "s");
+
+  private final Context context;
+
+  private final List<Throwable> errors = new LinkedList<>();
+
+  private final CountDownLatch cdl = new CountDownLatch(1);
+
+  volatile Subscription s;
+
+  volatile long requested;
+
+  volatile List<T> values = new LinkedList<>();
+
+  /** The fusion mode to request. */
+  private int requestedFusionMode = -1;
+
+  /** The established fusion mode. */
+  private volatile int establishedFusionMode = -1;
+
+  /** The fuseable QueueSubscription in case a fusion mode was specified. */
+  private Fuseable.QueueSubscription<T> qs;
+
+  private int subscriptionCount = 0;
+
+  private int completionCount = 0;
+
+  private volatile long valueCount = 0L;
+
+  private volatile long nextValueAssertedCount = 0L;
+
+  private Duration valuesTimeout = DEFAULT_VALUES_TIMEOUT;
+
+  private boolean valuesStorage = true;
+
+  //
+  // ==============================================================================================================
+  //	 Static methods
+  //
+  // ==============================================================================================================
+
+  /**
+   * Blocking method that waits until {@code conditionSupplier} returns true, or if it does not
+   * before the specified timeout, throws an {@link AssertionError} with the specified error message
+   * supplier.
+   *
+   * @param timeout the timeout duration
+   * @param errorMessageSupplier the error message supplier
+   * @param conditionSupplier condition to break out of the wait loop
+   * @throws AssertionError
+   */
+  public static void await(
+      Duration timeout, Supplier<String> errorMessageSupplier, BooleanSupplier conditionSupplier) {
+
+    Objects.requireNonNull(errorMessageSupplier);
+    Objects.requireNonNull(conditionSupplier);
+    Objects.requireNonNull(timeout);
+
+    long timeoutNs = timeout.toNanos();
+    long startTime = System.nanoTime();
+    do {
+      if (conditionSupplier.getAsBoolean()) {
+        return;
+      }
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    } while (System.nanoTime() - startTime < timeoutNs);
+    throw new AssertionError(errorMessageSupplier.get());
+  }
+
+  /**
+   * Blocking method that waits until {@code conditionSupplier} returns true, or if it does not
+   * before the specified timeout, throw an {@link AssertionError} with the specified error message.
+   *
+   * @param timeout the timeout duration
+   * @param errorMessage the error message
+   * @param conditionSupplier condition to break out of the wait loop
+   * @throws AssertionError
+   */
+  public static void await(
+      Duration timeout, final String errorMessage, BooleanSupplier conditionSupplier) {
+    await(
+        timeout,
+        new Supplier<String>() {
+          @Override
+          public String get() {
+            return errorMessage;
+          }
+        },
+        conditionSupplier);
+  }
+
+  /**
+   * Create a new {@link AssertSubscriber} that requests an unbounded number of elements.
+   *
+   * <p>Be sure at least a publisher has subscribed to it via {@link
+   * Publisher#subscribe(Subscriber)} before use assert methods.
+   *
+   * @param <T> the observed value type
+   * @return a fresh AssertSubscriber instance
+   */
+  public static <T> AssertSubscriber<T> create() {
+    return new AssertSubscriber<>();
+  }
+
+  /**
+   * Create a new {@link AssertSubscriber} that requests initially {@code n} elements. You can then
+   * manage the demand with {@link Subscription#request(long)}.
+   *
+   * <p>Be sure at least a publisher has subscribed to it via {@link
+   * Publisher#subscribe(Subscriber)} before use assert methods.
+   *
+   * @param n Number of elements to request (can be 0 if you want no initial demand).
+   * @param <T> the observed value type
+   * @return a fresh AssertSubscriber instance
+   */
+  public static <T> AssertSubscriber<T> create(long n) {
+    return new AssertSubscriber<>(n);
+  }
+
+  //
+  // ==============================================================================================================
+  //	 constructors
+  //
+  // ==============================================================================================================
+
+  public AssertSubscriber() {
+    this(Context.empty(), Long.MAX_VALUE);
+  }
+
+  public AssertSubscriber(long n) {
+    this(Context.empty(), n);
+  }
+
+  public AssertSubscriber(Context context) {
+    this(context, Long.MAX_VALUE);
+  }
+
+  public AssertSubscriber(Context context, long n) {
+    if (n < 0) {
+      throw new IllegalArgumentException("initialRequest >= required but it was " + n);
+    }
+    this.context = context;
+    REQUESTED.lazySet(this, n);
+  }
+
+  //
+  // ==============================================================================================================
+  //	 Configuration
+  //
+  // ==============================================================================================================
+
+  /**
+   * Enable or disabled the values storage. It is enabled by default, and can be disable in order to
+   * be able to perform performance benchmarks or tests with a huge amount values.
+   *
+   * @param enabled enable value storage?
+   * @return this
+   */
+  public final AssertSubscriber<T> configureValuesStorage(boolean enabled) {
+    this.valuesStorage = enabled;
+    return this;
+  }
+
+  /**
+   * Configure the timeout in seconds for waiting next values to be received (3 seconds by default).
+   *
+   * @param timeout the new default value timeout duration
+   * @return this
+   */
+  public final AssertSubscriber<T> configureValuesTimeout(Duration timeout) {
+    this.valuesTimeout = timeout;
+    return this;
+  }
+
+  /**
+   * Returns the established fusion mode or -1 if it was not enabled
+   *
+   * @return the fusion mode, see Fuseable constants
+   */
+  public final int establishedFusionMode() {
+    return establishedFusionMode;
+  }
+
+  //
+  // ==============================================================================================================
+  //	 Assertions
+  //
+  // ==============================================================================================================
+
+  /**
+   * Assert a complete successfully signal has been received.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertComplete() {
+    assertNoError();
+    int c = completionCount;
+    if (c == 0) {
+      throw new AssertionError("Not completed", null);
+    }
+    if (c > 1) {
+      throw new AssertionError("Multiple completions: " + c, null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert the specified values have been received. Values storage should be enabled to use this
+   * method.
+   *
+   * @param expectedValues the values to assert
+   * @see #configureValuesStorage(boolean)
+   * @return this
+   */
+  public final AssertSubscriber<T> assertContainValues(Set<? extends T> expectedValues) {
+    if (!valuesStorage) {
+      throw new IllegalStateException("Using assertNoValues() requires enabling values storage");
+    }
+    if (expectedValues.size() > values.size()) {
+      throw new AssertionError("Actual contains fewer elements" + values, null);
+    }
+
+    Iterator<? extends T> expected = expectedValues.iterator();
+
+    for (; ; ) {
+      boolean n2 = expected.hasNext();
+      if (n2) {
+        T t2 = expected.next();
+        if (!values.contains(t2)) {
+          throw new AssertionError(
+              "The element is not contained in the "
+                  + "received results"
+                  + " = "
+                  + valueAndClass(t2),
+              null);
+        }
+      } else {
+        break;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Assert an error signal has been received.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertError() {
+    assertNotComplete();
+    int s = errors.size();
+    if (s == 0) {
+      throw new AssertionError("No error", null);
+    }
+    if (s > 1) {
+      throw new AssertionError("Multiple errors: " + s, null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert an error signal has been received.
+   *
+   * @param clazz The class of the exception contained in the error signal
+   * @return this
+   */
+  public final AssertSubscriber<T> assertError(Class<? extends Throwable> clazz) {
+    assertNotComplete();
+    int s = errors.size();
+    if (s == 0) {
+      throw new AssertionError("No error", null);
+    }
+    if (s == 1) {
+      Throwable e = errors.get(0);
+      if (!clazz.isInstance(e)) {
+        throw new AssertionError(
+            "Error class incompatible: expected = " + clazz + ", actual = " + e, null);
+      }
+    }
+    if (s > 1) {
+      throw new AssertionError("Multiple errors: " + s, null);
+    }
+    return this;
+  }
+
+  public final AssertSubscriber<T> assertErrorMessage(String message) {
+    assertNotComplete();
+    int s = errors.size();
+    if (s == 0) {
+      assertionError("No error", null);
+    }
+    if (s == 1) {
+      if (!Objects.equals(message, errors.get(0).getMessage())) {
+        assertionError(
+            "Error class incompatible: expected = \""
+                + message
+                + "\", actual = \""
+                + errors.get(0).getMessage()
+                + "\"",
+            null);
+      }
+    }
+    if (s > 1) {
+      assertionError("Multiple errors: " + s, null);
+    }
+
+    return this;
+  }
+
+  /**
+   * Assert an error signal has been received.
+   *
+   * @param expectation A method that can verify the exception contained in the error signal and
+   *     throw an exception (like an {@link AssertionError}) if the exception is not valid.
+   * @return this
+   */
+  public final AssertSubscriber<T> assertErrorWith(Consumer<? super Throwable> expectation) {
+    assertNotComplete();
+    int s = errors.size();
+    if (s == 0) {
+      throw new AssertionError("No error", null);
+    }
+    if (s == 1) {
+      expectation.accept(errors.get(0));
+    }
+    if (s > 1) {
+      throw new AssertionError("Multiple errors: " + s, null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert that the upstream was a Fuseable source.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertFuseableSource() {
+    if (qs == null) {
+      throw new AssertionError("Upstream was not Fuseable");
+    }
+    return this;
+  }
+
+  /**
+   * Assert that the fusion mode was granted.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertFusionEnabled() {
+    if (establishedFusionMode != Fuseable.SYNC && establishedFusionMode != Fuseable.ASYNC) {
+      throw new AssertionError("Fusion was not enabled");
+    }
+    return this;
+  }
+
+  public final AssertSubscriber<T> assertFusionMode(int expectedMode) {
+    if (establishedFusionMode != expectedMode) {
+      throw new AssertionError(
+          "Wrong fusion mode: expected: "
+              + fusionModeName(expectedMode)
+              + ", actual: "
+              + fusionModeName(establishedFusionMode));
+    }
+    return this;
+  }
+
+  /**
+   * Assert that the fusion mode was granted.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertFusionRejected() {
+    if (establishedFusionMode != Fuseable.NONE) {
+      throw new AssertionError("Fusion was granted");
+    }
+    return this;
+  }
+
+  /**
+   * Assert no error signal has been received.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertNoError() {
+    int s = errors.size();
+    if (s == 1) {
+      Throwable e = errors.get(0);
+      String valueAndClass = e == null ? null : e + " (" + e.getClass().getSimpleName() + ")";
+      throw new AssertionError("Error present: " + valueAndClass, null);
+    }
+    if (s > 1) {
+      throw new AssertionError("Multiple errors: " + s, null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert no values have been received.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertNoValues() {
+    if (valueCount != 0) {
+      throw new AssertionError(
+          "No values expected but received: [length = " + values.size() + "] " + values, null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert that the upstream was not a Fuseable source.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertNonFuseableSource() {
+    if (qs != null) {
+      throw new AssertionError("Upstream was Fuseable");
+    }
+    return this;
+  }
+
+  /**
+   * Assert no complete successfully signal has been received.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertNotComplete() {
+    int c = completionCount;
+    if (c == 1) {
+      throw new AssertionError("Completed", null);
+    }
+    if (c > 1) {
+      throw new AssertionError("Multiple completions: " + c, null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert no subscription occurred.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertNotSubscribed() {
+    int s = subscriptionCount;
+
+    if (s == 1) {
+      throw new AssertionError("OnSubscribe called once", null);
+    }
+    if (s > 1) {
+      throw new AssertionError("OnSubscribe called multiple times: " + s, null);
+    }
+
+    return this;
+  }
+
+  /**
+   * Assert no complete successfully or error signal has been received.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertNotTerminated() {
+    if (cdl.getCount() == 0) {
+      throw new AssertionError("Terminated", null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert subscription occurred (once).
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertSubscribed() {
+    int s = subscriptionCount;
+
+    if (s == 0) {
+      throw new AssertionError("OnSubscribe not called", null);
+    }
+    if (s > 1) {
+      throw new AssertionError("OnSubscribe called multiple times: " + s, null);
+    }
+
+    return this;
+  }
+
+  /**
+   * Assert either complete successfully or error signal has been received.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> assertTerminated() {
+    if (cdl.getCount() != 0) {
+      throw new AssertionError("Not terminated", null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert {@code n} values has been received.
+   *
+   * @param n the expected value count
+   * @return this
+   */
+  public final AssertSubscriber<T> assertValueCount(long n) {
+    if (valueCount != n) {
+      throw new AssertionError(
+          "Different value count: expected = " + n + ", actual = " + valueCount, null);
+    }
+    return this;
+  }
+
+  /**
+   * Assert the specified values have been received in the same order read by the passed {@link
+   * Iterable}. Values storage should be enabled to use this method.
+   *
+   * @param expectedSequence the values to assert
+   * @see #configureValuesStorage(boolean)
+   * @return this
+   */
+  public final AssertSubscriber<T> assertValueSequence(Iterable<? extends T> expectedSequence) {
+    if (!valuesStorage) {
+      throw new IllegalStateException("Using assertNoValues() requires enabling values storage");
+    }
+    Iterator<T> actual = values.iterator();
+    Iterator<? extends T> expected = expectedSequence.iterator();
+    int i = 0;
+    for (; ; ) {
+      boolean n1 = actual.hasNext();
+      boolean n2 = expected.hasNext();
+      if (n1 && n2) {
+        T t1 = actual.next();
+        T t2 = expected.next();
+        if (!Objects.equals(t1, t2)) {
+          throw new AssertionError(
+              "The element with index "
+                  + i
+                  + " does not match: expected = "
+                  + valueAndClass(t2)
+                  + ", actual = "
+                  + valueAndClass(t1),
+              null);
+        }
+        i++;
+      } else if (n1 && !n2) {
+        throw new AssertionError("Actual contains more elements" + values, null);
+      } else if (!n1 && n2) {
+        throw new AssertionError("Actual contains fewer elements: " + values, null);
+      } else {
+        break;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Assert the specified values have been received in the declared order. Values storage should be
+   * enabled to use this method.
+   *
+   * @param expectedValues the values to assert
+   * @return this
+   * @see #configureValuesStorage(boolean)
+   */
+  @SafeVarargs
+  public final AssertSubscriber<T> assertValues(T... expectedValues) {
+    return assertValueSequence(Arrays.asList(expectedValues));
+  }
+
+  /**
+   * Assert the specified values have been received in the declared order. Values storage should be
+   * enabled to use this method.
+   *
+   * @param expectations One or more methods that can verify the values and throw a exception (like
+   *     an {@link AssertionError}) if the value is not valid.
+   * @return this
+   * @see #configureValuesStorage(boolean)
+   */
+  @SafeVarargs
+  public final AssertSubscriber<T> assertValuesWith(Consumer<T>... expectations) {
+    if (!valuesStorage) {
+      throw new IllegalStateException("Using assertNoValues() requires enabling values storage");
+    }
+    final int expectedValueCount = expectations.length;
+    if (expectedValueCount != values.size()) {
+      throw new AssertionError(
+          "Different value count: expected = " + expectedValueCount + ", actual = " + valueCount,
+          null);
+    }
+    for (int i = 0; i < expectedValueCount; i++) {
+      Consumer<T> consumer = expectations[i];
+      T actualValue = values.get(i);
+      consumer.accept(actualValue);
+    }
+    return this;
+  }
+
+  //
+  // ==============================================================================================================
+  //	 Await methods
+  //
+  // ==============================================================================================================
+
+  /**
+   * Blocking method that waits until a complete successfully or error signal is received.
+   *
+   * @return this
+   */
+  public final AssertSubscriber<T> await() {
+    if (cdl.getCount() == 0) {
+      return this;
+    }
+    try {
+      cdl.await();
+    } catch (InterruptedException ex) {
+      throw new AssertionError("Wait interrupted", ex);
+    }
+    return this;
+  }
+
+  /**
+   * Blocking method that waits until a complete successfully or error signal is received or until a
+   * timeout occurs.
+   *
+   * @param timeout The timeout value
+   * @return this
+   */
+  public final AssertSubscriber<T> await(Duration timeout) {
+    if (cdl.getCount() == 0) {
+      return this;
+    }
+    try {
+      if (!cdl.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        throw new AssertionError("No complete or error signal before timeout");
+      }
+      return this;
+    } catch (InterruptedException ex) {
+      throw new AssertionError("Wait interrupted", ex);
+    }
+  }
+
+  /**
+   * Blocking method that waits until {@code n} next values have been received.
+   *
+   * @param n the value count to assert
+   * @return this
+   */
+  public final AssertSubscriber<T> awaitAndAssertNextValueCount(final long n) {
+    await(
+        valuesTimeout,
+        () -> {
+          if (valuesStorage) {
+            return String.format(
+                "%d out of %d next values received within %d, " + "values : %s",
+                valueCount - nextValueAssertedCount,
+                n,
+                valuesTimeout.toMillis(),
+                values.toString());
+          }
+          return String.format(
+              "%d out of %d next values received within %d",
+              valueCount - nextValueAssertedCount, n, valuesTimeout.toMillis());
+        },
+        () -> valueCount >= (nextValueAssertedCount + n));
+    nextValueAssertedCount += n;
+    return this;
+  }
+
+  /**
+   * Blocking method that waits until {@code n} next values have been received (n is the number of
+   * values provided) to assert them.
+   *
+   * @param values the values to assert
+   * @return this
+   */
+  @SafeVarargs
+  @SuppressWarnings("unchecked")
+  public final AssertSubscriber<T> awaitAndAssertNextValues(T... values) {
+    final int expectedNum = values.length;
+    final List<Consumer<T>> expectations = new ArrayList<>();
+    for (int i = 0; i < expectedNum; i++) {
+      final T expectedValue = values[i];
+      expectations.add(
+          actualValue -> {
+            if (!actualValue.equals(expectedValue)) {
+              throw new AssertionError(
+                  String.format(
+                      "Expected Next signal: %s, but got: %s", expectedValue, actualValue));
+            }
+          });
+    }
+    awaitAndAssertNextValuesWith(expectations.toArray((Consumer<T>[]) new Consumer[0]));
+    return this;
+  }
+
+  /**
+   * Blocking method that waits until {@code n} next values have been received (n is the number of
+   * expectations provided) to assert them.
+   *
+   * @param expectations One or more methods that can verify the values and throw a exception (like
+   *     an {@link AssertionError}) if the value is not valid.
+   * @return this
+   */
+  @SafeVarargs
+  public final AssertSubscriber<T> awaitAndAssertNextValuesWith(Consumer<T>... expectations) {
+    valuesStorage = true;
+    final int expectedValueCount = expectations.length;
+    await(
+        valuesTimeout,
+        () -> {
+          if (valuesStorage) {
+            return String.format(
+                "%d out of %d next values received within %d, " + "values : %s",
+                valueCount - nextValueAssertedCount,
+                expectedValueCount,
+                valuesTimeout.toMillis(),
+                values.toString());
+          }
+          return String.format(
+              "%d out of %d next values received within %d ms",
+              valueCount - nextValueAssertedCount, expectedValueCount, valuesTimeout.toMillis());
+        },
+        () -> valueCount >= (nextValueAssertedCount + expectedValueCount));
+    List<T> nextValuesSnapshot;
+    List<T> empty = new ArrayList<>();
+    for (; ; ) {
+      nextValuesSnapshot = values;
+      if (NEXT_VALUES.compareAndSet(this, values, empty)) {
+        break;
+      }
+    }
+    if (nextValuesSnapshot.size() < expectedValueCount) {
+      throw new AssertionError(
+          String.format(
+              "Expected %d number of signals but received %d",
+              expectedValueCount, nextValuesSnapshot.size()));
+    }
+    for (int i = 0; i < expectedValueCount; i++) {
+      Consumer<T> consumer = expectations[i];
+      T actualValue = nextValuesSnapshot.get(i);
+      consumer.accept(actualValue);
+    }
+    nextValueAssertedCount += expectedValueCount;
+    return this;
+  }
+
+  //
+  // ==============================================================================================================
+  //	 Overrides
+  //
+  // ==============================================================================================================
+
+  @Override
+  public void cancel() {
+    Subscription a = s;
+    if (a != Operators.cancelledSubscription()) {
+      a = S.getAndSet(this, Operators.cancelledSubscription());
+      if (a != null && a != Operators.cancelledSubscription()) {
+        a.cancel();
+      }
+    }
+  }
+
+  final boolean isCancelled() {
+    return s == Operators.cancelledSubscription();
+  }
+
+  public final boolean isTerminated() {
+    return cdl.getCount() == 0;
+  }
+
+  @Override
+  public void onComplete() {
+    completionCount++;
+    cdl.countDown();
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    errors.add(t);
+    cdl.countDown();
+  }
+
+  @Override
+  public void onNext(T t) {
+    if (establishedFusionMode == Fuseable.ASYNC) {
+      for (; ; ) {
+        t = qs.poll();
+        if (t == null) {
+          break;
+        }
+        valueCount++;
+        if (valuesStorage) {
+          List<T> nextValuesSnapshot;
+          for (; ; ) {
+            nextValuesSnapshot = values;
+            nextValuesSnapshot.add(t);
+            if (NEXT_VALUES.compareAndSet(this, nextValuesSnapshot, nextValuesSnapshot)) {
+              break;
+            }
+          }
+        }
+      }
+    } else {
+      valueCount++;
+      if (valuesStorage) {
+        List<T> nextValuesSnapshot;
+        for (; ; ) {
+          nextValuesSnapshot = values;
+          nextValuesSnapshot.add(t);
+          if (NEXT_VALUES.compareAndSet(this, nextValuesSnapshot, nextValuesSnapshot)) {
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void onSubscribe(Subscription s) {
+    subscriptionCount++;
+    int requestMode = requestedFusionMode;
+    if (requestMode >= 0) {
+      if (!setWithoutRequesting(s)) {
+        if (!isCancelled()) {
+          errors.add(new IllegalStateException("Subscription already set: " + subscriptionCount));
+        }
+      } else {
+        if (s instanceof Fuseable.QueueSubscription) {
+          this.qs = (Fuseable.QueueSubscription<T>) s;
+
+          int m = qs.requestFusion(requestMode);
+          establishedFusionMode = m;
+
+          if (m == Fuseable.SYNC) {
+            for (; ; ) {
+              T v = qs.poll();
+              if (v == null) {
+                onComplete();
+                break;
+              }
+
+              onNext(v);
+            }
+          } else {
+            requestDeferred();
+          }
+        } else {
+          requestDeferred();
+        }
+      }
+    } else {
+      if (!set(s)) {
+        if (!isCancelled()) {
+          errors.add(new IllegalStateException("Subscription already set: " + subscriptionCount));
+        }
+      }
+    }
+  }
+
+  @Override
+  public void request(long n) {
+    if (Operators.validate(n)) {
+      if (establishedFusionMode != Fuseable.SYNC) {
+        normalRequest(n);
+      }
+    }
+  }
+
+  @Override
+  @NonNull
+  public Context currentContext() {
+    return context;
+  }
+
+  /**
+   * Setup what fusion mode should be requested from the incoming Subscription if it happens to be
+   * QueueSubscription
+   *
+   * @param requestMode the mode to request, see Fuseable constants
+   * @return this
+   */
+  public final AssertSubscriber<T> requestedFusionMode(int requestMode) {
+    this.requestedFusionMode = requestMode;
+    return this;
+  }
+
+  public Subscription upstream() {
+    return s;
+  }
+
+  //
+  // ==============================================================================================================
+  //	 Non public methods
+  //
+  // ==============================================================================================================
+
+  protected final void normalRequest(long n) {
+    Subscription a = s;
+    if (a != null) {
+      a.request(n);
+    } else {
+      Operators.addCap(REQUESTED, this, n);
+
+      a = s;
+
+      if (a != null) {
+        long r = REQUESTED.getAndSet(this, 0L);
+
+        if (r != 0L) {
+          a.request(r);
+        }
+      }
+    }
+  }
+
+  /** Requests the deferred amount if not zero. */
+  protected final void requestDeferred() {
+    long r = REQUESTED.getAndSet(this, 0L);
+
+    if (r != 0L) {
+      s.request(r);
+    }
+  }
+
+  /**
+   * Atomically sets the single subscription and requests the missed amount from it.
+   *
+   * @param s
+   * @return false if this arbiter is cancelled or there was a subscription already set
+   */
+  protected final boolean set(Subscription s) {
+    Objects.requireNonNull(s, "s");
+    Subscription a = this.s;
+    if (a == Operators.cancelledSubscription()) {
+      s.cancel();
+      return false;
+    }
+    if (a != null) {
+      s.cancel();
+      Operators.reportSubscriptionSet();
+      return false;
+    }
+
+    if (S.compareAndSet(this, null, s)) {
+
+      long r = REQUESTED.getAndSet(this, 0L);
+
+      if (r != 0L) {
+        s.request(r);
+      }
+
+      return true;
+    }
+
+    a = this.s;
+
+    if (a != Operators.cancelledSubscription()) {
+      s.cancel();
+      return false;
+    }
+
+    Operators.reportSubscriptionSet();
+    return false;
+  }
+
+  /**
+   * Sets the Subscription once but does not request anything.
+   *
+   * @param s the Subscription to set
+   * @return true if successful, false if the current subscription is not null
+   */
+  protected final boolean setWithoutRequesting(Subscription s) {
+    Objects.requireNonNull(s, "s");
+    for (; ; ) {
+      Subscription a = this.s;
+      if (a == Operators.cancelledSubscription()) {
+        s.cancel();
+        return false;
+      }
+      if (a != null) {
+        s.cancel();
+        Operators.reportSubscriptionSet();
+        return false;
+      }
+
+      if (S.compareAndSet(this, null, s)) {
+        return true;
+      }
+    }
+  }
+
+  /**
+   * Prepares and throws an AssertionError exception based on the message, cause, the active state
+   * and the potential errors so far.
+   *
+   * @param message the message
+   * @param cause the optional Throwable cause
+   * @throws AssertionError as expected
+   */
+  protected final void assertionError(String message, Throwable cause) {
+    StringBuilder b = new StringBuilder();
+
+    if (cdl.getCount() != 0) {
+      b.append("(active) ");
+    }
+    b.append(message);
+
+    List<Throwable> err = errors;
+    if (!err.isEmpty()) {
+      b.append(" (+ ").append(err.size()).append(" errors)");
+    }
+    AssertionError e = new AssertionError(b.toString(), cause);
+
+    for (Throwable t : err) {
+      e.addSuppressed(t);
+    }
+
+    throw e;
+  }
+
+  protected final String fusionModeName(int mode) {
+    switch (mode) {
+      case -1:
+        return "Disabled";
+      case Fuseable.NONE:
+        return "None";
+      case Fuseable.SYNC:
+        return "Sync";
+      case Fuseable.ASYNC:
+        return "Async";
+      default:
+        return "Unknown(" + mode + ")";
+    }
+  }
+
+  protected final String valueAndClass(Object o) {
+    if (o == null) {
+      return null;
+    }
+    return o + " (" + o.getClass().getSimpleName() + ")";
+  }
+
+  public List<T> values() {
+    return values;
+  }
+
+  public final AssertSubscriber<T> assertNoEvents() {
+    return assertNoValues().assertNoError().assertNotComplete();
+  }
+
+  @SafeVarargs
+  public final AssertSubscriber<T> assertIncomplete(T... values) {
+    return assertValues(values).assertNotComplete().assertNoError();
+  }
+}


### PR DESCRIPTION
This PR provides a reworked implementation of `UnicastMonoProcessor`.

In general, it provides from 3% up to 6% win in throughput and 4% in latency

## Benchmarks

```
Benchmark                                                                                      Mode      Cnt     Score   Error   Units
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf                                           thrpt       10    20.127 ± 0.191  ops/us
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf                                    thrpt       10    20.787 ± 0.144  ops/us
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf                                          sample  7254769     0.088 ± 0.001   us/op
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf:monoProcessorPerf·p0.00                  sample              0.023           us/op
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf:monoProcessorPerf·p0.50                  sample              0.076           us/op
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf:monoProcessorPerf·p0.90                  sample              0.079           us/op
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf:monoProcessorPerf·p0.95                  sample              0.081           us/op
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf:monoProcessorPerf·p0.99                  sample              0.106           us/op
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf:monoProcessorPerf·p0.999                 sample              1.108           us/op
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf:monoProcessorPerf·p0.9999                sample             22.176           us/op
UnicastVsDefaultMonoProcessorPerf.monoProcessorPerf:monoProcessorPerf·p1.00                  sample           1871.872           us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf                                   sample  7680326     0.084 ± 0.001   us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf:unicastMonoProcessorPerf·p0.00    sample              0.023           us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf:unicastMonoProcessorPerf·p0.50    sample              0.073           us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf:unicastMonoProcessorPerf·p0.90    sample              0.077           us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf:unicastMonoProcessorPerf·p0.95    sample              0.079           us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf:unicastMonoProcessorPerf·p0.99    sample              0.106           us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf:unicastMonoProcessorPerf·p0.999   sample              0.865           us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf:unicastMonoProcessorPerf·p0.9999  sample             21.760           us/op
UnicastVsDefaultMonoProcessorPerf.unicastMonoProcessorPerf:unicastMonoProcessorPerf·p1.00    sample           1970.176           us/op

```

## Benchmarks on RSocket `FnF` and `RequestResponse`

### BaseLine 

```
Benchmark                     Mode  Cnt        Score       Error  Units
RSocketPerf.fireAndForget    thrpt   10  1698013.876 ± 26873.363  ops/s
RSocketPerf.requestResponse  thrpt   10   725708.244 ±  4801.008  ops/s
```

### PR

```
Benchmark                     Mode  Cnt        Score       Error  Units
RSocketPerf.fireAndForget    thrpt   10  1804857.887 ± 23843.790  ops/s
RSocketPerf.requestResponse  thrpt   10   762976.869 ± 11604.598  ops/s
```