### PR TITLE
Feature/perf tunning 3

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/internal/UnicastMonoEmpty.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/UnicastMonoEmpty.java
@@ -1,0 +1,86 @@
+package io.rsocket.internal;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.util.annotation.Nullable;
+
+/**
+ * Represents an empty publisher which only calls onSubscribe and onComplete.
+ *
+ * <p>This Publisher is effectively stateless and only a single instance exists. Use the {@link
+ * #instance()} method to obtain a properly type-parametrized view of it.
+ *
+ * @see <a href="https://github.com/reactor/reactive-streams-commons">Reactive-Streams-Commons</a>
+ */
+public final class UnicastMonoEmpty extends Mono<Object> implements Scannable {
+
+  final Runnable onSubscribe;
+
+  volatile int once;
+
+  @SuppressWarnings("rawtypes")
+  static final AtomicIntegerFieldUpdater<UnicastMonoEmpty> ONCE =
+      AtomicIntegerFieldUpdater.newUpdater(UnicastMonoEmpty.class, "once");
+
+  UnicastMonoEmpty(Runnable onSubscribe) {
+    this.onSubscribe = onSubscribe;
+  }
+
+  @Override
+  public void subscribe(CoreSubscriber<? super Object> actual) {
+    if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
+      onSubscribe.run();
+      Operators.complete(actual);
+    } else {
+      Operators.error(
+          actual, new IllegalStateException("UnicastMonoEmpty allows only a single Subscriber"));
+    }
+  }
+
+  /**
+   * Returns a properly parametrized instance of this empty Publisher.
+   *
+   * @param <T> the output type
+   * @return a properly parametrized instance of this empty Publisher
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> Mono<T> newInstance(Runnable onSubscribe) {
+    return (Mono<T>) new UnicastMonoEmpty(onSubscribe);
+  }
+
+  @Override
+  @Nullable
+  public Object block(Duration m) {
+    if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
+      onSubscribe.run();
+      return null;
+    } else {
+      throw new IllegalStateException("UnicastMonoEmpty allows only a single Subscriber");
+    }
+  }
+
+  @Override
+  @Nullable
+  public Object block() {
+    if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
+      onSubscribe.run();
+      return null;
+    } else {
+      throw new IllegalStateException("UnicastMonoEmpty allows only a single Subscriber");
+    }
+  }
+
+  @Override
+  public Object scanUnsafe(Attr key) {
+    return null; // no particular key to be represented, still useful in hooks
+  }
+
+  @Override
+  public String stepName() {
+    return "source(UnicastMonoEmpty)";
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/util/MonoLifecycleHandler.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/MonoLifecycleHandler.java
@@ -1,0 +1,21 @@
+package io.rsocket.util;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import reactor.core.publisher.SignalType;
+
+public interface MonoLifecycleHandler<T> {
+
+  default void doOnSubscribe() {}
+
+  /**
+   * Handler which is invoked on the terminal activity within a given Monoø
+   *
+   * @param signalType a type of signal which explain what happened
+   * @param element an carried element. May not be present if stream is empty or cancelled or
+   *     errored
+   * @param e an carried error. May not be present if stream is cancelled or completed successfully
+   */
+  default void doOnTerminal(
+      @Nonnull SignalType signalType, @Nullable T element, @Nullable Throwable e) {}
+}

--- a/rsocket-core/src/test/java/io/rsocket/internal/SchedulerUtils.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/SchedulerUtils.java
@@ -1,0 +1,23 @@
+package io.rsocket.internal;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import reactor.core.scheduler.Scheduler;
+
+public class SchedulerUtils {
+
+  public static void warmup(Scheduler scheduler) throws InterruptedException {
+    warmup(scheduler, 10000);
+  }
+
+  public static void warmup(Scheduler scheduler, int times) throws InterruptedException {
+    scheduler.start();
+
+    // warm up
+    CountDownLatch latch = new CountDownLatch(times);
+    for (int i = 0; i < times; i++) {
+      scheduler.schedule(latch::countDown);
+    }
+    latch.await(5, TimeUnit.SECONDS);
+  }
+}

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoEmptyTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoEmptyTest.java
@@ -1,0 +1,97 @@
+package io.rsocket.internal;
+
+import static io.rsocket.internal.SchedulerUtils.warmup;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.util.RaceTestUtils;
+
+public class UnicastMonoEmptyTest {
+
+  @Test
+  public void shouldSupportASingleSubscriber() throws InterruptedException {
+    warmup(Schedulers.single());
+
+    for (int i = 0; i < 10000; i++) {
+      AtomicInteger times = new AtomicInteger();
+      Mono unicastMono = UnicastMonoEmpty.newInstance(times::incrementAndGet);
+
+      Assertions.assertThatThrownBy(
+              () ->
+                  RaceTestUtils.race(
+                      unicastMono::subscribe, unicastMono::subscribe, Schedulers.single()))
+          .hasCause(new IllegalStateException("UnicastMonoEmpty allows only a single Subscriber"));
+      Assertions.assertThat(times.get()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void shouldSupportASingleBlock() throws InterruptedException {
+    warmup(Schedulers.single());
+
+    for (int i = 0; i < 10000; i++) {
+      AtomicInteger times = new AtomicInteger();
+      Mono unicastMono = UnicastMonoEmpty.newInstance(times::incrementAndGet);
+
+      Assertions.assertThatThrownBy(
+              () -> RaceTestUtils.race(unicastMono::block, unicastMono::block, Schedulers.single()))
+          .hasMessage("UnicastMonoEmpty allows only a single Subscriber");
+      Assertions.assertThat(times.get()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void shouldSupportASingleBlockWithTimeout() throws InterruptedException {
+    warmup(Schedulers.single());
+
+    for (int i = 0; i < 10000; i++) {
+      AtomicInteger times = new AtomicInteger();
+      Mono unicastMono = UnicastMonoEmpty.newInstance(times::incrementAndGet);
+
+      Assertions.assertThatThrownBy(
+              () ->
+                  RaceTestUtils.race(
+                      () -> unicastMono.block(Duration.ofMinutes(1)),
+                      () -> unicastMono.block(Duration.ofMinutes(1)),
+                      Schedulers.single()))
+          .hasMessage("UnicastMonoEmpty allows only a single Subscriber");
+      Assertions.assertThat(times.get()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void shouldSupportASingleSubscribeOrBlock() throws InterruptedException {
+    warmup(Schedulers.parallel());
+
+    for (int i = 0; i < 10000; i++) {
+      AtomicInteger times = new AtomicInteger();
+      Mono unicastMono = UnicastMonoEmpty.newInstance(times::incrementAndGet);
+
+      Assertions.assertThatThrownBy(
+              () ->
+                  RaceTestUtils.race(
+                      unicastMono::subscribe,
+                      () ->
+                          RaceTestUtils.race(
+                              unicastMono::block,
+                              () -> unicastMono.block(Duration.ofMinutes(1)),
+                              Schedulers.parallel()),
+                      Schedulers.parallel()))
+          .matches(
+              t -> {
+                Assertions.assertThat(t.getSuppressed()).hasSize(2);
+                Assertions.assertThat(t.getSuppressed()[0])
+                    .hasMessageContaining("UnicastMonoEmpty allows only a single Subscriber");
+                Assertions.assertThat(t.getSuppressed()[1])
+                    .hasMessageContaining("UnicastMonoEmpty allows only a single Subscriber");
+
+                return true;
+              });
+      Assertions.assertThat(times.get()).isEqualTo(1);
+    }
+  }
+}

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoProcessorTest.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.internal;
 
+import static io.rsocket.internal.SchedulerUtils.warmup;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -27,8 +28,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -42,7 +41,6 @@ import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.Operators;
-import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
@@ -1436,16 +1434,5 @@ public class UnicastMonoProcessorTest {
 
     processor.subscribe(v -> Assertions.fail("expected late subscriber to error"), late::set);
     assertThat(late.get()).isInstanceOf(IllegalStateException.class);
-  }
-
-  static void warmup(Scheduler scheduler) throws InterruptedException {
-    scheduler.start();
-
-    // warm up
-    CountDownLatch latch = new CountDownLatch(10000);
-    for (int i = 0; i < 10000; i++) {
-      scheduler.schedule(latch::countDown);
-    }
-    latch.await(5, TimeUnit.SECONDS);
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnicastMonoProcessorTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.rsocket.internal.subscriber.AssertSubscriber;
+import io.rsocket.util.MonoLifecycleHandler;
 import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -41,6 +42,7 @@ import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.Operators;
+import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
@@ -50,36 +52,128 @@ import reactor.util.function.Tuple2;
 
 public class UnicastMonoProcessorTest {
 
+  static class VerifyMonoLifecycleHandler<T> implements MonoLifecycleHandler<T> {
+    private final AtomicInteger onSubscribeCounter = new AtomicInteger();
+    private final AtomicInteger onTerminalCounter = new AtomicInteger();
+    private final AtomicReference<T> valueReference = new AtomicReference<>();
+    private final AtomicReference<Throwable> errorReference = new AtomicReference<>();
+    private final AtomicReference<SignalType> signalTypeReference = new AtomicReference<>();
+
+    @Override
+    public void doOnSubscribe() {
+      onSubscribeCounter.incrementAndGet();
+    }
+
+    @Override
+    public void doOnTerminal(SignalType signalType, T element, Throwable e) {
+      onTerminalCounter.incrementAndGet();
+      signalTypeReference.set(signalType);
+      valueReference.set(element);
+      errorReference.set(e);
+    }
+
+    public VerifyMonoLifecycleHandler<T> assertSubscribed() {
+      assertThat(onSubscribeCounter.get()).isOne();
+      return this;
+    }
+
+    public VerifyMonoLifecycleHandler<T> assertNotSubscribed() {
+      assertThat(onSubscribeCounter.get()).isZero();
+      return this;
+    }
+
+    public VerifyMonoLifecycleHandler<T> assertTerminated() {
+      assertThat(onTerminalCounter.get()).describedAs("Expected a single terminal signal").isOne();
+      return this;
+    }
+
+    public VerifyMonoLifecycleHandler<T> assertNotTerminated() {
+      assertThat(onTerminalCounter.get()).describedAs("Expected zero terminal signals").isZero();
+      return this;
+    }
+
+    public VerifyMonoLifecycleHandler<T> assertCompleted() {
+      assertTerminated();
+      assertThat(signalTypeReference.get())
+          .describedAs("Expected ON_COMPLETE signal")
+          .isEqualTo(SignalType.ON_COMPLETE);
+      assertThat(errorReference.get()).describedAs("Expected error to be absent").isNull();
+      assertThat(valueReference.get()).isNull();
+      return this;
+    }
+
+    public VerifyMonoLifecycleHandler<T> assertCompleted(T value) {
+      assertTerminated();
+      assertThat(signalTypeReference.get())
+          .describedAs("Expected ON_COMPLETE signal")
+          .isEqualTo(SignalType.ON_COMPLETE);
+      assertThat(errorReference.get()).describedAs("Expected error to be absent").isNull();
+      assertThat(valueReference.get()).isEqualTo(value);
+      return this;
+    }
+
+    public VerifyMonoLifecycleHandler<T> assertErrored() {
+      assertTerminated();
+      assertThat(signalTypeReference.get())
+          .describedAs("Expected ON_ERROR signal")
+          .isEqualTo(SignalType.ON_ERROR);
+      assertThat(errorReference.get()).describedAs("Expected error to be present").isNotNull();
+      assertThat(valueReference.get()).isNull();
+      return this;
+    }
+
+    public VerifyMonoLifecycleHandler<T> assertCancelled() {
+      assertTerminated();
+      assertThat(signalTypeReference.get())
+          .describedAs("Expected ON_ERROR signal")
+          .isEqualTo(SignalType.CANCEL);
+      assertThat(errorReference.get()).describedAs("Expected error to be absent").isNull();
+      assertThat(valueReference.get()).isNull();
+      return this;
+    }
+  }
+
   @Test
   public void testUnicast() throws InterruptedException {
     warmup(Schedulers.single());
 
     for (int i = 0; i < 10000; i++) {
-      UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
+      verifyMonoLifecycleHandler.assertNotSubscribed();
       assertThatThrownBy(() -> RaceTestUtils.race(processor::subscribe, processor::subscribe))
           .hasCause(
               new IllegalStateException("UnicastMonoProcessor allows only a single Subscriber"));
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     }
   }
 
   @Test
   public void stateFlowTest1_Next() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.onNext(1);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_HAS_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoEvents();
     assertSubscriber.request(1);
 
+    verifyMonoLifecycleHandler.assertCompleted(1);
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertValues(1);
@@ -88,17 +182,23 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest1_Complete() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.onComplete();
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_HAS_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCompleted();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -107,18 +207,24 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest1_Error() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
     RuntimeException testError = new RuntimeException("test");
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.onError(testError);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_HAS_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -128,17 +234,23 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest1_Dispose() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.dispose();
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_HAS_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -148,22 +260,29 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest2_Next() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     processor.onNext(1);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoEvents();
     assertSubscriber.request(1);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCompleted(1);
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertValues(1);
@@ -172,17 +291,23 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest2_Complete() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     processor.onComplete();
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCompleted();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -191,17 +316,23 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest2_Error() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     processor.onError(new RuntimeException("Test"));
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -211,17 +342,23 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest2_Dispose() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     processor.dispose();
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -231,23 +368,30 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest3_Next() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     assertSubscriber.assertNoEvents();
     assertSubscriber.request(1);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
     assertSubscriber.assertNoEvents();
     processor.onNext(1);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCompleted(1);
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertValues(1);
@@ -256,21 +400,28 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest3_Complete() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     assertSubscriber.request(1);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
     processor.onComplete();
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCompleted();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -279,21 +430,28 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest3_Error() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     assertSubscriber.request(1);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
     processor.onError(new RuntimeException("Test"));
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -303,21 +461,28 @@ public class UnicastMonoProcessorTest {
 
   @Test
   public void stateFlowTest3_Dispose() {
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     AssertSubscriber<Integer> assertSubscriber = AssertSubscriber.create(0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     assertSubscriber.request(1);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
     processor.dispose();
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.assertNoValues();
@@ -328,30 +493,38 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest4_Next() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     //    Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     Hooks.onNextDropped(discarded::add);
     AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
 
     try {
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       assertSubscriber.request(1);
       assertSubscriber.assertNoEvents();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       assertSubscriber.cancel();
       assertSubscriber.assertNoEvents();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       processor.onNext(1);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       assertSubscriber.assertNoEvents();
@@ -364,32 +537,40 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest4_Error() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     //    Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     Hooks.onErrorDropped(discarded::add);
     AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
 
     try {
 
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       assertSubscriber.request(1);
       assertSubscriber.assertNoEvents();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       assertSubscriber.cancel();
       assertSubscriber.assertNoEvents();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       RuntimeException testError = new RuntimeException("test");
       processor.onError(testError);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       assertSubscriber.assertNoEvents();
@@ -403,30 +584,38 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest4_Dispose() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     //    Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     Hooks.onErrorDropped(discarded::add);
     try {
       AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
 
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       assertSubscriber.request(1);
       assertSubscriber.assertNoEvents();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       assertSubscriber.cancel();
       assertSubscriber.assertNoEvents();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       processor.dispose();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       assertSubscriber.assertNoEvents();
@@ -439,30 +628,38 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest4_Complete() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     //    Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     Hooks.onErrorDropped(discarded::add);
     AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
 
     try {
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       assertSubscriber.request(1);
       assertSubscriber.assertNoEvents();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       assertSubscriber.cancel();
       assertSubscriber.assertNoEvents();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       processor.onComplete();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       assertSubscriber.assertNoEvents();
@@ -475,22 +672,34 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest5_Next() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(discardingContext, 0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     processor.onNext(1);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_HAS_RESULT);
 
     assertSubscriber.cancel();
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
+    assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
+
+    assertSubscriber.request(1);
+
+    verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
     assertSubscriber.assertNoEvents();
@@ -500,22 +709,29 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest5_Complete() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(discardingContext, 0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
     processor.onComplete();
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCompleted();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
     assertSubscriber.cancel();
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCompleted();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
     assertSubscriber.assertComplete();
@@ -525,24 +741,31 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest5_Error() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     Hooks.onErrorDropped(discarded::add);
     AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(discardingContext, 0);
 
     try {
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       processor.onError(new RuntimeException("test"));
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
       assertSubscriber.cancel();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       assertSubscriber.assertError(RuntimeException.class);
@@ -556,24 +779,31 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest5_Dispose() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     Hooks.onErrorDropped(discarded::add);
     AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(discardingContext, 0);
 
     try {
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_NO_RESULT);
 
       processor.dispose();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
       assertSubscriber.cancel();
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       assertSubscriber.assertError(CancellationException.class);
@@ -587,22 +817,34 @@ public class UnicastMonoProcessorTest {
   @Test
   public void stateFlowTest6_Next() {
     ArrayList<Object> discarded = new ArrayList<>();
-    UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+    VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+        new VerifyMonoLifecycleHandler<>();
+    UnicastMonoProcessor<Integer> processor =
+        UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
     Context discardingContext = Operators.enableOnDiscard(null, discarded::add);
     AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(discardingContext, 0);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
     processor.onNext(1);
 
+    verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_HAS_RESULT);
 
     processor.subscribe(assertSubscriber);
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_REQUEST_HAS_RESULT);
 
     assertSubscriber.cancel();
 
+    verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
+    assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
+
+    assertSubscriber.request(1);
+
+    verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
     assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
     assertSubscriber.assertNoEvents();
@@ -614,9 +856,13 @@ public class UnicastMonoProcessorTest {
     warmup(Schedulers.single());
 
     for (int i = 0; i < 10000; i++) {
-      UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
       AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>();
 
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       RaceTestUtils.race(
@@ -624,6 +870,7 @@ public class UnicastMonoProcessorTest {
           () -> processor.subscribe(assertSubscriber),
           Schedulers.single());
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCompleted(1);
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
       assertSubscriber.assertValues(1);
@@ -679,14 +926,19 @@ public class UnicastMonoProcessorTest {
     warmup(Schedulers.single());
 
     for (int i = 0; i < 10000; i++) {
-      UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
       AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
 
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       RaceTestUtils.race(
           processor::dispose, () -> processor.subscribe(assertSubscriber), Schedulers.single());
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
       assertSubscriber.assertNoValues();
@@ -700,22 +952,30 @@ public class UnicastMonoProcessorTest {
     warmup(Schedulers.single());
 
     for (int i = 0; i < 10000; i++) {
-      UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
       AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>();
 
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       RaceTestUtils.race(() -> processor.onNext(1), assertSubscriber::cancel, Schedulers.single());
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
 
       if (assertSubscriber.values().isEmpty()) {
+        verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
         assertSubscriber.assertNoEvents();
       } else {
+        verifyMonoLifecycleHandler.assertSubscribed().assertCompleted(1);
         assertSubscriber.assertValues(1);
         assertSubscriber.assertComplete();
       }
@@ -727,23 +987,31 @@ public class UnicastMonoProcessorTest {
     warmup(Schedulers.single());
 
     for (int i = 0; i < 10000; i++) {
-      UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
       AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>();
 
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_NO_RESULT);
 
       RaceTestUtils.race(() -> processor.onNext(1), processor::dispose, Schedulers.single());
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
       if (processor.isError()) {
+        verifyMonoLifecycleHandler.assertSubscribed().assertErrored();
         assertSubscriber.assertNoValues();
         assertSubscriber.assertErrorMessage("Disposed");
       } else {
+        verifyMonoLifecycleHandler.assertSubscribed().assertCompleted(1);
         assertSubscriber.assertValues(1);
         assertSubscriber.assertComplete();
       }
@@ -755,19 +1023,26 @@ public class UnicastMonoProcessorTest {
     warmup(Schedulers.single());
 
     for (int i = 0; i < 10000; i++) {
-      UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
       AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
 
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.onNext(1);
       processor.subscribe(assertSubscriber);
+
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
 
       RaceTestUtils.race(
           () -> assertSubscriber.request(1),
           () -> assertSubscriber.request(1),
           Schedulers.single());
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCompleted(1);
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
       assertSubscriber.assertValues(1);
@@ -780,20 +1055,87 @@ public class UnicastMonoProcessorTest {
     warmup(Schedulers.single());
 
     for (int i = 0; i < 10000; i++) {
-      UnicastMonoProcessor<Integer> processor = UnicastMonoProcessor.create();
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
       AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
 
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
 
       processor.subscribe(assertSubscriber);
       assertSubscriber.request(1);
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
       RaceTestUtils.race(() -> processor.onNext(1), () -> processor.onNext(1), Schedulers.single());
 
+      verifyMonoLifecycleHandler.assertSubscribed().assertCompleted(1);
       assertThat(processor.state).isEqualTo(UnicastMonoProcessor.HAS_REQUEST_HAS_RESULT);
 
       assertSubscriber.assertValues(1);
       assertSubscriber.assertComplete();
+    }
+  }
+
+  @Test
+  public void stateFlowTest15_Next() throws InterruptedException {
+    warmup(Schedulers.single());
+
+    for (int i = 0; i < 10000; i++) {
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
+      AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
+
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
+      assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
+
+      processor.subscribe(assertSubscriber);
+      processor.onNext(1);
+
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
+      RaceTestUtils.race(
+          () -> assertSubscriber.request(1), assertSubscriber::cancel, Schedulers.single());
+
+      assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
+
+      if (assertSubscriber.values().isEmpty()) {
+        verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
+        assertSubscriber.assertNoEvents();
+      } else {
+        verifyMonoLifecycleHandler.assertSubscribed().assertCompleted(1);
+        assertSubscriber.assertValues(1);
+        assertSubscriber.assertComplete();
+      }
+    }
+  }
+
+  @Test
+  public void stateFlowTest16_Next() throws InterruptedException {
+    warmup(Schedulers.single());
+
+    for (int i = 0; i < 10000; i++) {
+      VerifyMonoLifecycleHandler<Integer> verifyMonoLifecycleHandler =
+          new VerifyMonoLifecycleHandler<>();
+      UnicastMonoProcessor<Integer> processor =
+          UnicastMonoProcessor.create(verifyMonoLifecycleHandler);
+      AssertSubscriber<Integer> assertSubscriber = new AssertSubscriber<>(0);
+
+      verifyMonoLifecycleHandler.assertNotSubscribed().assertNotTerminated();
+      assertThat(processor.state).isEqualTo(UnicastMonoProcessor.NO_SUBSCRIBER_NO_RESULT);
+
+      processor.subscribe(assertSubscriber);
+      processor.onNext(1);
+
+      verifyMonoLifecycleHandler.assertSubscribed().assertNotTerminated();
+      RaceTestUtils.race(assertSubscriber::cancel, assertSubscriber::cancel, Schedulers.single());
+
+      assertThat(processor.state).isEqualTo(UnicastMonoProcessor.CANCELLED);
+
+      verifyMonoLifecycleHandler.assertSubscribed().assertCancelled();
+      assertSubscriber.assertNoEvents();
     }
   }
 


### PR DESCRIPTION
This PR provides performance improvement for Fnf and Request-Response interactions:

## FnF:

**Baseline**
```
Benchmark                   Mode  Cnt        Score       Error  Units
RSocketPerf.fireAndForget  thrpt   10  1744956.946 ± 38511.378  ops/s
```

**Tunned**
```
Benchmark                   Mode  Cnt        Score       Error  Units
RSocketPerf.fireAndForget  thrpt   10  2130868.696 ± 66161.823  ops/s
```

## Request-Response:

**Baseline**
```
Benchmark                     Mode  Cnt       Score      Error  Units
RSocketPerf.requestResponse  thrpt   10  810142.933 ± 8680.778  ops/s
```

**Tunned**
```
Benchmark                     Mode  Cnt        Score       Error  Units
RSocketPerf.requestResponse  thrpt   10  1013187.966 ± 15647.848  ops/s
```