### PR TITLE
fixes error handling to match specification

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
@@ -470,7 +470,7 @@ class RSocketRequester implements RSocket {
     } else {
       switch (type) {
         case ERROR:
-          receiver.onError(Exceptions.from(frame));
+          receiver.onError(Exceptions.from(streamId, frame));
           receivers.remove(streamId);
           break;
         case NEXT_COMPLETE:
@@ -544,7 +544,7 @@ class RSocketRequester implements RSocket {
   }
 
   private void tryTerminateOnZeroError(ByteBuf errorFrame) {
-    tryTerminate(() -> Exceptions.from(errorFrame));
+    tryTerminate(() -> Exceptions.from(0, errorFrame));
   }
 
   private void tryTerminate(Supplier<Exception> errorSupplier) {

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/CustomRSocketException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/CustomRSocketException.java
@@ -1,0 +1,51 @@
+package io.rsocket.exceptions;
+
+import io.rsocket.frame.ErrorType;
+
+public class CustomRSocketException extends RSocketException {
+  private static final long serialVersionUID = 7873267740343446585L;
+
+  private final int errorCode;
+
+  /**
+   * Constructs a new exception with the specified message.
+   *
+   * @param errorCode customizable error code. Should be in range [0x00000301-0xFFFFFFFE]
+   * @param message the message
+   * @throws NullPointerException if {@code message} is {@code null}
+   * @throws IllegalArgumentException if {@code errorCode} is out of allowed range
+   */
+  public CustomRSocketException(int errorCode, String message) {
+    super(message);
+    if (errorCode > ErrorType.MAX_USER_ALLOWED_ERROR_CODE
+        && errorCode < ErrorType.MIN_USER_ALLOWED_ERROR_CODE) {
+      throw new IllegalArgumentException(
+          "Allowed errorCode value should be in range [0x00000301-0xFFFFFFFE]");
+    }
+    this.errorCode = errorCode;
+  }
+
+  /**
+   * Constructs a new exception with the specified message and cause.
+   *
+   * @param errorCode customizable error code. Should be in range [0x00000301-0xFFFFFFFE]
+   * @param message the message
+   * @param cause the cause of this exception
+   * @throws NullPointerException if {@code message} or {@code cause} is {@code null}
+   * @throws IllegalArgumentException if {@code errorCode} is out of allowed range
+   */
+  public CustomRSocketException(int errorCode, String message, Throwable cause) {
+    super(message, cause);
+    if (errorCode > ErrorType.MAX_USER_ALLOWED_ERROR_CODE
+        && errorCode < ErrorType.MIN_USER_ALLOWED_ERROR_CODE) {
+      throw new IllegalArgumentException(
+          "Allowed errorCode value should be in range [0x00000301-0xFFFFFFFE]");
+    }
+    this.errorCode = errorCode;
+  }
+
+  @Override
+  public int errorCode() {
+    return errorCode;
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/frame/ErrorFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/ErrorFrameFlyweight.java
@@ -8,17 +8,21 @@ import java.nio.charset.StandardCharsets;
 
 public class ErrorFrameFlyweight {
 
-  // defined error codes
+  // defined zero stream id error codes
   public static final int INVALID_SETUP = 0x00000001;
   public static final int UNSUPPORTED_SETUP = 0x00000002;
   public static final int REJECTED_SETUP = 0x00000003;
   public static final int REJECTED_RESUME = 0x00000004;
   public static final int CONNECTION_ERROR = 0x00000101;
   public static final int CONNECTION_CLOSE = 0x00000102;
+  // defined non-zero stream id error codes
   public static final int APPLICATION_ERROR = 0x00000201;
   public static final int REJECTED = 0x00000202;
   public static final int CANCELED = 0x00000203;
   public static final int INVALID = 0x00000204;
+  // defined user-allowed error codes range
+  public static final int MIN_USER_ALLOWED_ERROR_CODE = 0x00000301;
+  public static final int MAX_USER_ALLOWED_ERROR_CODE = 0xFFFFFFFE;
 
   public static ByteBuf encode(
       ByteBufAllocator allocator, int streamId, Throwable t, ByteBuf data) {

--- a/rsocket-core/src/main/java/io/rsocket/frame/ErrorType.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/ErrorType.java
@@ -11,7 +11,7 @@ public final class ErrorType {
   /**
    * Application layer logic generating a Reactive Streams onError event. Stream ID MUST be &gt; 0.
    */
-  public static final int APPLICATION_ERROR = 0x00000201;;
+  public static final int APPLICATION_ERROR = 0x00000201;
 
   /**
    * The Responder canceled the request but may have started processing it (similar to REJECTED but
@@ -69,6 +69,15 @@ public final class ErrorType {
    * ID MUST be 0.
    */
   public static final int UNSUPPORTED_SETUP = 0x00000002;
+
+  /** Minimum allowed user defined error code value */
+  public static final int MIN_USER_ALLOWED_ERROR_CODE = 0x00000301;
+
+  /**
+   * Maximum allowed user defined error code value. Note, the value is above signed integer maximum,
+   * so it will be negative after overflow.
+   */
+  public static final int MAX_USER_ALLOWED_ERROR_CODE = 0xFFFFFFFE;
 
   private ErrorType() {}
 }

--- a/rsocket-core/src/test/java/io/rsocket/RSocketLeaseTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketLeaseTest.java
@@ -141,7 +141,8 @@ class RSocketLeaseTest {
     Assertions.assertThat(sent).hasSize(1);
     ByteBuf error = sent.iterator().next();
     Assertions.assertThat(FrameHeaderFlyweight.frameType(error)).isEqualTo(ERROR);
-    Assertions.assertThat(Exceptions.from(error).getMessage()).isEqualTo("lease is not supported");
+    Assertions.assertThat(Exceptions.from(0, error).getMessage())
+        .isEqualTo("lease is not supported");
   }
 
   @Test

--- a/rsocket-core/src/test/java/io/rsocket/SetupRejectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/SetupRejectionTest.java
@@ -37,7 +37,7 @@ public class SetupRejectionTest {
 
     ByteBuf sentFrame = transport.awaitSent();
     assertThat(FrameHeaderFlyweight.frameType(sentFrame)).isEqualTo(FrameType.ERROR);
-    RuntimeException error = Exceptions.from(sentFrame);
+    RuntimeException error = Exceptions.from(0, sentFrame);
     assertThat(errorMsg).isEqualTo(error.getMessage());
     assertThat(error).isInstanceOf(RejectedSetupException.class);
     RSocket acceptorSender = acceptor.senderRSocket().block();

--- a/rsocket-core/src/test/java/io/rsocket/exceptions/ExceptionsTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/exceptions/ExceptionsTest.java
@@ -16,131 +16,220 @@
 
 package io.rsocket.exceptions;
 
+import static io.rsocket.frame.ErrorFrameFlyweight.APPLICATION_ERROR;
+import static io.rsocket.frame.ErrorFrameFlyweight.CANCELED;
+import static io.rsocket.frame.ErrorFrameFlyweight.CONNECTION_CLOSE;
+import static io.rsocket.frame.ErrorFrameFlyweight.CONNECTION_ERROR;
+import static io.rsocket.frame.ErrorFrameFlyweight.INVALID;
+import static io.rsocket.frame.ErrorFrameFlyweight.INVALID_SETUP;
+import static io.rsocket.frame.ErrorFrameFlyweight.REJECTED;
+import static io.rsocket.frame.ErrorFrameFlyweight.REJECTED_RESUME;
+import static io.rsocket.frame.ErrorFrameFlyweight.REJECTED_SETUP;
+import static io.rsocket.frame.ErrorFrameFlyweight.UNSUPPORTED_SETUP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.rsocket.frame.ErrorFrameFlyweight;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 final class ExceptionsTest {
-  /*
   @DisplayName("from returns ApplicationErrorException")
   @Test
   void fromApplicationException() {
-    ByteBuf byteBuf = createErrorFrame(APPLICATION_ERROR, "test-message");
+    ByteBuf byteBuf = createErrorFrame(1, APPLICATION_ERROR, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(1, byteBuf))
         .isInstanceOf(ApplicationErrorException.class)
-        .withFailMessage("test-message");
+        .hasMessage("test-message");
+
+    assertThat(Exceptions.from(0, byteBuf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid Error frame in Stream ID 0: 0x%08X '%s'", APPLICATION_ERROR, "test-message");
   }
 
   @DisplayName("from returns CanceledException")
   @Test
   void fromCanceledException() {
-    ByteBuf byteBuf = createErrorFrame(CANCELED, "test-message");
+    ByteBuf byteBuf = createErrorFrame(1, CANCELED, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(1, byteBuf))
         .isInstanceOf(CanceledException.class)
-        .withFailMessage("test-message");
+        .hasMessage("test-message");
+
+    assertThat(Exceptions.from(0, byteBuf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid Error frame in Stream ID 0: 0x%08X '%s'", CANCELED, "test-message");
   }
 
   @DisplayName("from returns ConnectionCloseException")
   @Test
   void fromConnectionCloseException() {
-    ByteBuf byteBuf = createErrorFrame(CONNECTION_CLOSE, "test-message");
+    ByteBuf byteBuf = createErrorFrame(0, CONNECTION_CLOSE, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(0, byteBuf))
         .isInstanceOf(ConnectionCloseException.class)
-        .withFailMessage("test-message");
+        .hasMessage("test-message");
+
+    assertThat(Exceptions.from(1, byteBuf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid Error frame in Stream ID 1: 0x%08X '%s'", CONNECTION_CLOSE, "test-message");
   }
 
   @DisplayName("from returns ConnectionErrorException")
   @Test
   void fromConnectionErrorException() {
-    ByteBuf byteBuf = createErrorFrame(CONNECTION_ERROR, "test-message");
+    ByteBuf byteBuf = createErrorFrame(0, CONNECTION_ERROR, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(0, byteBuf))
         .isInstanceOf(ConnectionErrorException.class)
-        .withFailMessage("test-message");
+        .hasMessage("test-message");
+
+    assertThat(Exceptions.from(1, byteBuf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid Error frame in Stream ID 1: 0x%08X '%s'", CONNECTION_ERROR, "test-message");
   }
 
   @DisplayName("from returns IllegalArgumentException if error frame has illegal error code")
   @Test
   void fromIllegalErrorFrame() {
-    ByteBuf byteBuf = createErrorFrame(0x00000000, "test-message");
+    ByteBuf byteBuf = createErrorFrame(0, 0x00000000, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .withFailMessage("Invalid Error frame: %d, '%s'", 0, "test-message");
+    assertThat(Exceptions.from(0, byteBuf))
+        .hasMessage("Invalid Error frame in Stream ID 0: 0x%08X '%s'", 0, "test-message")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThat(Exceptions.from(1, byteBuf))
+        .hasMessage("Invalid Error frame in Stream ID 1: 0x%08X '%s'", 0x00000000, "test-message")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @DisplayName("from returns InvalidException")
   @Test
   void fromInvalidException() {
-    ByteBuf byteBuf = createErrorFrame(INVALID, "test-message");
+    ByteBuf byteBuf = createErrorFrame(1, INVALID, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(1, byteBuf))
         .isInstanceOf(InvalidException.class)
-        .withFailMessage("test-message");
+        .hasMessage("test-message");
+
+    assertThat(Exceptions.from(0, byteBuf))
+        .hasMessage("Invalid Error frame in Stream ID 0: 0x%08X '%s'", INVALID, "test-message")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @DisplayName("from returns InvalidSetupException")
   @Test
   void fromInvalidSetupException() {
-    ByteBuf byteBuf = createErrorFrame(INVALID_SETUP, "test-message");
+    ByteBuf byteBuf = createErrorFrame(0, INVALID_SETUP, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(0, byteBuf))
         .isInstanceOf(InvalidSetupException.class)
-        .withFailMessage("test-message");
+        .hasMessage("test-message");
+
+    assertThat(Exceptions.from(1, byteBuf))
+        .hasMessage(
+            "Invalid Error frame in Stream ID 1: 0x%08X '%s'", INVALID_SETUP, "test-message")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @DisplayName("from returns RejectedException")
   @Test
   void fromRejectedException() {
-    ByteBuf byteBuf = createErrorFrame(REJECTED, "test-message");
+    ByteBuf byteBuf = createErrorFrame(1, REJECTED, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(1, byteBuf))
         .isInstanceOf(RejectedException.class)
         .withFailMessage("test-message");
+
+    assertThat(Exceptions.from(0, byteBuf))
+        .hasMessage("Invalid Error frame in Stream ID 0: 0x%08X '%s'", REJECTED, "test-message")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @DisplayName("from returns RejectedResumeException")
   @Test
   void fromRejectedResumeException() {
-    ByteBuf byteBuf = createErrorFrame(REJECTED_RESUME, "test-message");
+    ByteBuf byteBuf = createErrorFrame(0, REJECTED_RESUME, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(0, byteBuf))
         .isInstanceOf(RejectedResumeException.class)
-        .withFailMessage("test-message");
+        .hasMessage("test-message");
+
+    assertThat(Exceptions.from(1, byteBuf))
+        .hasMessage(
+            "Invalid Error frame in Stream ID 1: 0x%08X '%s'", REJECTED_RESUME, "test-message")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @DisplayName("from returns RejectedSetupException")
   @Test
   void fromRejectedSetupException() {
-    ByteBuf byteBuf = createErrorFrame(REJECTED_SETUP, "test-message");
+    ByteBuf byteBuf = createErrorFrame(0, REJECTED_SETUP, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(0, byteBuf))
         .isInstanceOf(RejectedSetupException.class)
         .withFailMessage("test-message");
+
+    assertThat(Exceptions.from(1, byteBuf))
+        .hasMessage(
+            "Invalid Error frame in Stream ID 1: 0x%08X '%s'", REJECTED_SETUP, "test-message")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @DisplayName("from returns UnsupportedSetupException")
   @Test
   void fromUnsupportedSetupException() {
-    ByteBuf byteBuf = createErrorFrame(UNSUPPORTED_SETUP, "test-message");
+    ByteBuf byteBuf = createErrorFrame(0, UNSUPPORTED_SETUP, "test-message");
 
-    assertThat(Exceptions.from(Frame.from(byteBuf)))
+    assertThat(Exceptions.from(0, byteBuf))
         .isInstanceOf(UnsupportedSetupException.class)
-        .withFailMessage("test-message");
+        .hasMessage("test-message");
+
+    assertThat(Exceptions.from(1, byteBuf))
+        .hasMessage(
+            "Invalid Error frame in Stream ID 1: 0x%08X '%s'", UNSUPPORTED_SETUP, "test-message")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @DisplayName("from returns CustomRSocketException")
+  @Test
+  void fromCustomRSocketException() {
+    for (int i = 0; i < 1000; i++) {
+      int randomCode =
+          ThreadLocalRandom.current().nextBoolean()
+              ? ThreadLocalRandom.current()
+                  .nextInt(Integer.MIN_VALUE, ErrorFrameFlyweight.MAX_USER_ALLOWED_ERROR_CODE)
+              : ThreadLocalRandom.current()
+                  .nextInt(ErrorFrameFlyweight.MIN_USER_ALLOWED_ERROR_CODE, Integer.MAX_VALUE);
+      ByteBuf byteBuf = createErrorFrame(0, randomCode, "test-message");
+
+      assertThat(Exceptions.from(1, byteBuf))
+          .isInstanceOf(CustomRSocketException.class)
+          .hasMessage("test-message");
+
+      assertThat(Exceptions.from(0, byteBuf))
+          .hasMessage("Invalid Error frame in Stream ID 0: 0x%08X '%s'", randomCode, "test-message")
+          .isInstanceOf(IllegalArgumentException.class);
+    }
   }
 
   @DisplayName("from throws NullPointerException with null frame")
   @Test
   void fromWithNullFrame() {
     assertThatNullPointerException()
-        .isThrownBy(() -> Exceptions.from(null))
+        .isThrownBy(() -> Exceptions.from(0, null))
         .withMessage("frame must not be null");
   }
 
-  private ByteBuf createErrorFrame(int errorCode, String message) {
-    ByteBuf byteBuf = Unpooled.buffer();
-
-    ErrorFrameFlyweight.encode(byteBuf, 0, errorCode, Unpooled.copiedBuffer(message, UTF_8));
-
-    return byteBuf;
-  }*/
+  private ByteBuf createErrorFrame(int streamId, int errorCode, String message) {
+    return ErrorFrameFlyweight.encode(
+        UnpooledByteBufAllocator.DEFAULT, streamId, new TestRSocketException(errorCode, message));
+  }
 }

--- a/rsocket-core/src/test/java/io/rsocket/exceptions/TestRSocketException.java
+++ b/rsocket-core/src/test/java/io/rsocket/exceptions/TestRSocketException.java
@@ -1,0 +1,39 @@
+package io.rsocket.exceptions;
+
+public class TestRSocketException extends RSocketException {
+  private static final long serialVersionUID = 7873267740343446585L;
+
+  private final int errorCode;
+
+  /**
+   * Constructs a new exception with the specified message.
+   *
+   * @param errorCode customizable error code
+   * @param message the message
+   * @throws NullPointerException if {@code message} is {@code null}
+   * @throws IllegalArgumentException if {@code errorCode} is out of allowed range
+   */
+  public TestRSocketException(int errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  /**
+   * Constructs a new exception with the specified message and cause.
+   *
+   * @param errorCode customizable error code
+   * @param message the message
+   * @param cause the cause of this exception
+   * @throws NullPointerException if {@code message} or {@code cause} is {@code null}
+   * @throws IllegalArgumentException if {@code errorCode} is out of allowed range
+   */
+  public TestRSocketException(int errorCode, String message, Throwable cause) {
+    super(message, cause);
+    this.errorCode = errorCode;
+  }
+
+  @Override
+  public int errorCode() {
+    return errorCode;
+  }
+}


### PR DESCRIPTION
This PR extends the current implementation of error handling to match what is defined in the spec and let the user use a range of user allowed error codes using `CastomRSocketException` class
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>