### PR TITLE
disables gradle modules feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,10 @@ subprojects {
         }
     }
 
+    tasks.withType(GenerateModuleMetadata) {
+        enabled = false
+    }
+
     plugins.withType(JavaPlugin) {
         compileJava {
             sourceCompatibility = 1.8


### PR DESCRIPTION
This PR disabled Gradle 6 modules feature.

As I figured out bintray-gradle-plugin does not have proper integration with that future (hence `.module` files are not published along with other artifacts) so the simples solution, for now, is to disable that feature

Fix for #746 
 
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>