### PR TITLE
Report no active sockets as an error which enables users of

### DIFF
--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
@@ -377,9 +377,8 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
     refreshSockets();
 
     if (activeSockets.isEmpty()) {
-      return FAILING_REACTIVE_SOCKET;
+      throw NoAvailableRSocketException.INSTANCE;
     }
-
     int size = activeSockets.size();
     if (size == 1) {
       return activeSockets.get(0);

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/NoAvailableRSocketException.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/NoAvailableRSocketException.java
@@ -17,7 +17,7 @@
 package io.rsocket.client;
 
 /** An exception that indicates that no RSocket was available. */
-public final class NoAvailableRSocketException extends Exception {
+public final class NoAvailableRSocketException extends RuntimeException {
 
   /**
    * The single instance of this type. <b>Note</b> that it is initialized without any stack trace.


### PR DESCRIPTION
LoadBalancedRSocketMono to correctly react on that.
Issue #713

Due to that change I can now use 
```
LoadBalancedRSocketMono.create(...)
   .retryBackoff(1, Duration.ofMillis(100))

```
which makes the first call also work from a user perspective