### PR TITLE
provides support for the JDK 14 based builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - jdk: openjdk8
     - jdk: openjdk11
       env: SKIP_RELEASE=true
-    - jdk: openjdk13
+    - jdk: openjdk14
       env: SKIP_RELEASE=true
 
 env:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR:
 1. upgrades Gradle to 6.3 which support JDK14 
 2. changes Travis build matrix and replaces JDK 13 build to JDK 14 build


Signed-off-by: Oleh Dokuka <shadowgun@i.ua>