### PR TITLE
Reduce top-level package dependencies

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/ConnectionSetupPayload.java
+++ b/rsocket-core/src/main/java/io/rsocket/ConnectionSetupPayload.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,147 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.rsocket;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.AbstractReferenceCounted;
-import io.rsocket.frame.FrameHeaderFlyweight;
-import io.rsocket.frame.SetupFrameFlyweight;
+import io.netty.util.ReferenceCounted;
 import javax.annotation.Nullable;
 
 /**
- * Exposed to server for determination of ResponderRSocket based on mime types and SETUP
- * metadata/data
+ * Exposes information from the {@code SETUP} frame to a server, as well as to client responders.
  */
-public abstract class ConnectionSetupPayload extends AbstractReferenceCounted implements Payload {
+public interface ConnectionSetupPayload extends ReferenceCounted, Payload {
 
-  public static ConnectionSetupPayload create(final ByteBuf setupFrame) {
-    return new DefaultConnectionSetupPayload(setupFrame);
-  }
+  String metadataMimeType();
 
-  public abstract int keepAliveInterval();
+  String dataMimeType();
 
-  public abstract int keepAliveMaxLifetime();
+  int keepAliveInterval();
 
-  public abstract String metadataMimeType();
+  int keepAliveMaxLifetime();
 
-  public abstract String dataMimeType();
+  int getFlags();
 
-  public abstract int getFlags();
+  boolean willClientHonorLease();
 
-  public abstract boolean willClientHonorLease();
-
-  public abstract boolean isResumeEnabled();
+  boolean isResumeEnabled();
 
   @Nullable
-  public abstract ByteBuf resumeToken();
-
-  @Override
-  public ConnectionSetupPayload retain() {
-    super.retain();
-    return this;
-  }
-
-  @Override
-  public ConnectionSetupPayload retain(int increment) {
-    super.retain(increment);
-    return this;
-  }
-
-  @Override
-  public abstract ConnectionSetupPayload touch();
-
-  @Override
-  public abstract ConnectionSetupPayload touch(Object hint);
-
-  private static final class DefaultConnectionSetupPayload extends ConnectionSetupPayload {
-    private final ByteBuf setupFrame;
-
-    public DefaultConnectionSetupPayload(ByteBuf setupFrame) {
-      this.setupFrame = setupFrame;
-    }
-
-    @Override
-    public boolean hasMetadata() {
-      return FrameHeaderFlyweight.hasMetadata(setupFrame);
-    }
-
-    @Override
-    public int keepAliveInterval() {
-      return SetupFrameFlyweight.keepAliveInterval(setupFrame);
-    }
-
-    @Override
-    public int keepAliveMaxLifetime() {
-      return SetupFrameFlyweight.keepAliveMaxLifetime(setupFrame);
-    }
-
-    @Override
-    public String metadataMimeType() {
-      return SetupFrameFlyweight.metadataMimeType(setupFrame);
-    }
-
-    @Override
-    public String dataMimeType() {
-      return SetupFrameFlyweight.dataMimeType(setupFrame);
-    }
-
-    @Override
-    public int getFlags() {
-      return FrameHeaderFlyweight.flags(setupFrame);
-    }
-
-    @Override
-    public boolean willClientHonorLease() {
-      return SetupFrameFlyweight.honorLease(setupFrame);
-    }
-
-    @Override
-    public boolean isResumeEnabled() {
-      return SetupFrameFlyweight.resumeEnabled(setupFrame);
-    }
-
-    @Override
-    public ByteBuf resumeToken() {
-      return SetupFrameFlyweight.resumeToken(setupFrame);
-    }
-
-    @Override
-    public ConnectionSetupPayload touch() {
-      setupFrame.touch();
-      return this;
-    }
-
-    @Override
-    public ConnectionSetupPayload touch(Object hint) {
-      setupFrame.touch(hint);
-      return this;
-    }
-
-    @Override
-    protected void deallocate() {
-      setupFrame.release();
-    }
-
-    @Override
-    public ByteBuf sliceMetadata() {
-      return SetupFrameFlyweight.metadata(setupFrame);
-    }
-
-    @Override
-    public ByteBuf sliceData() {
-      return SetupFrameFlyweight.data(setupFrame);
-    }
-
-    @Override
-    public ByteBuf data() {
-      return sliceData();
-    }
-
-    @Override
-    public ByteBuf metadata() {
-      return sliceMetadata();
-    }
-  }
+  ByteBuf resumeToken();
 }

--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -89,25 +89,11 @@ public final class RSocketFactory {
 
     ClientRSocketFactory addConnectionPlugin(DuplexConnectionInterceptor interceptor);
 
-    @Deprecated
-    ClientRSocketFactory addClientPlugin(RSocketInterceptor interceptor);
-
     ClientRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor);
-
-    @Deprecated
-    ClientRSocketFactory addServerPlugin(RSocketInterceptor interceptor);
 
     ClientRSocketFactory addResponderPlugin(RSocketInterceptor interceptor);
 
     ClientRSocketFactory addSocketAcceptorPlugin(SocketAcceptorInterceptor interceptor);
-
-    /**
-     * Deprecated as Keep-Alive is not optional according to spec
-     *
-     * @return this ClientRSocketFactory
-     */
-    @Deprecated
-    ClientRSocketFactory keepAlive();
 
     ClientRSocketFactory keepAlive(Duration tickPeriod, Duration ackTimeout, int missedAcks);
 
@@ -244,13 +230,7 @@ public final class RSocketFactory {
 
     ServerRSocketFactory addConnectionPlugin(DuplexConnectionInterceptor interceptor);
 
-    @Deprecated
-    ServerRSocketFactory addClientPlugin(RSocketInterceptor interceptor);
-
     ServerRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor);
-
-    @Deprecated
-    ServerRSocketFactory addServerPlugin(RSocketInterceptor interceptor);
 
     ServerRSocketFactory addResponderPlugin(RSocketInterceptor interceptor);
 

--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,165 +13,93 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.rsocket;
-
-import static io.rsocket.internal.ClientSetup.DefaultClientSetup;
-import static io.rsocket.internal.ClientSetup.ResumableClientSetup;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.rsocket.exceptions.InvalidSetupException;
-import io.rsocket.exceptions.RejectedSetupException;
-import io.rsocket.frame.FrameHeaderFlyweight;
-import io.rsocket.frame.ResumeFrameFlyweight;
-import io.rsocket.frame.SetupFrameFlyweight;
 import io.rsocket.frame.decoder.PayloadDecoder;
-import io.rsocket.internal.ClientServerInputMultiplexer;
-import io.rsocket.internal.ClientSetup;
-import io.rsocket.internal.ServerSetup;
-import io.rsocket.keepalive.KeepAliveHandler;
 import io.rsocket.lease.LeaseStats;
 import io.rsocket.lease.Leases;
-import io.rsocket.lease.RequesterLeaseHandler;
-import io.rsocket.lease.ResponderLeaseHandler;
-import io.rsocket.plugins.*;
-import io.rsocket.resume.*;
+import io.rsocket.plugins.DuplexConnectionInterceptor;
+import io.rsocket.plugins.RSocketInterceptor;
+import io.rsocket.plugins.SocketAcceptorInterceptor;
+import io.rsocket.resume.ResumableFramesStore;
+import io.rsocket.resume.ResumeStrategy;
 import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.ServerTransport;
-import io.rsocket.util.ConnectionUtils;
-import io.rsocket.util.EmptyPayload;
-import io.rsocket.util.MultiSubscriberRSocket;
+import java.lang.reflect.Constructor;
 import java.time.Duration;
-import java.util.Objects;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
-/** Factory for creating RSocket clients and servers. */
-public class RSocketFactory {
+/**
+ * Main entry point to create RSocket clients or servers as follows:
+ *
+ * <ul>
+ *   <li>{@link ClientRSocketFactory} to connect as a client. Use {@link #connect()} for a default
+ *       instance.
+ *   <li>{@link ServerRSocketFactory} to start a server. Use {@link #receive()} for a default
+ *       instance.
+ * </ul>
+ */
+public final class RSocketFactory {
+
+  private static final Constructor<?> clientFactoryConstructor =
+      getConstructorFor("io.rsocket.core.DefaultClientRSocketFactory");
+
+  private static final Constructor<?> serverFactoryConstructor =
+      getConstructorFor("io.rsocket.core.DefaultServerRSocketFactory");
+
   /**
-   * Creates a factory that establishes client connections to other RSockets.
+   * Create a {@link ClientRSocketFactory} to connect to a remote RSocket endpoint. A shortcut for
+   * creating {@link io.rsocket.core.DefaultClientRSocketFactory}.
    *
-   * @return a client factory
+   * @return the {@code ClientRSocketFactory} instance
    */
   public static ClientRSocketFactory connect() {
-    return new ClientRSocketFactory();
+    try {
+      // Avoid explicit dependency and a package cycle
+      return (ClientRSocketFactory) clientFactoryConstructor.newInstance();
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to create ClientRSocketFactory", ex);
+    }
   }
 
   /**
-   * Creates a factory that receives server connections from client RSockets.
+   * Create a {@link ServerRSocketFactory} to accept connections from RSocket clients. A shortcut
+   * for creating {@link io.rsocket.core.DefaultServerRSocketFactory}.
    *
-   * @return a server factory.
+   * @return the {@code ClientRSocketFactory} instance
    */
   public static ServerRSocketFactory receive() {
-    return new ServerRSocketFactory();
-  }
-
-  public interface Start<T extends Closeable> {
-    Mono<T> start();
-  }
-
-  public interface ClientTransportAcceptor {
-    Start<RSocket> transport(Supplier<ClientTransport> transport);
-
-    default Start<RSocket> transport(ClientTransport transport) {
-      return transport(() -> transport);
+    try {
+      // Avoid explicit dependency and a package cycle
+      return (ServerRSocketFactory) serverFactoryConstructor.newInstance();
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to create ServerRSocketFactory", ex);
     }
   }
+  /** Factory to create and configure an RSocket client, and connect to a server. */
+  public interface ClientRSocketFactory extends ClientTransportAcceptor {
 
-  public interface ServerTransportAcceptor {
+    ClientRSocketFactory byteBufAllocator(ByteBufAllocator allocator);
 
-    ServerTransport.ConnectionAcceptor toConnectionAcceptor();
+    ClientRSocketFactory addConnectionPlugin(DuplexConnectionInterceptor interceptor);
 
-    <T extends Closeable> Start<T> transport(Supplier<ServerTransport<T>> transport);
-
-    default <T extends Closeable> Start<T> transport(ServerTransport<T> transport) {
-      return transport(() -> transport);
-    }
-  }
-
-  public static class ClientRSocketFactory implements ClientTransportAcceptor {
-    private static final String CLIENT_TAG = "client";
-
-    private static final BiConsumer<RSocket, Invalidatable> INVALIDATE_FUNCTION =
-        (r, i) -> r.onClose().subscribe(null, null, i::invalidate);
-
-    private SocketAcceptor acceptor = (setup, sendingSocket) -> Mono.just(new AbstractRSocket() {});
-
-    private Consumer<Throwable> errorConsumer = Throwable::printStackTrace;
-    private int mtu = 0;
-    private PluginRegistry plugins = new PluginRegistry(Plugins.defaultPlugins());
-
-    private Payload setupPayload = EmptyPayload.INSTANCE;
-    private PayloadDecoder payloadDecoder = PayloadDecoder.DEFAULT;
-
-    private Duration tickPeriod = Duration.ofSeconds(20);
-    private Duration ackTimeout = Duration.ofSeconds(30);
-    private int missedAcks = 3;
-
-    private String metadataMimeType = "application/binary";
-    private String dataMimeType = "application/binary";
-
-    private boolean resumeEnabled;
-    private boolean resumeCleanupStoreOnKeepAlive;
-    private Supplier<ByteBuf> resumeTokenSupplier = ResumeFrameFlyweight::generateResumeToken;
-    private Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory =
-        token -> new InMemoryResumableFramesStore(CLIENT_TAG, 100_000);
-    private Duration resumeSessionDuration = Duration.ofMinutes(2);
-    private Duration resumeStreamTimeout = Duration.ofSeconds(10);
-    private Supplier<ResumeStrategy> resumeStrategySupplier =
-        () ->
-            new ExponentialBackoffResumeStrategy(Duration.ofSeconds(1), Duration.ofSeconds(16), 2);
-
-    private boolean multiSubscriberRequester = true;
-    private boolean leaseEnabled;
-    private Supplier<Leases<?>> leasesSupplier = Leases::new;
-    private boolean reconnectEnabled;
-    private Retry retrySpec;
-
-    private ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
-
-    public ClientRSocketFactory byteBufAllocator(ByteBufAllocator allocator) {
-      Objects.requireNonNull(allocator);
-      this.allocator = allocator;
-      return this;
-    }
-
-    public ClientRSocketFactory addConnectionPlugin(DuplexConnectionInterceptor interceptor) {
-      plugins.addConnectionPlugin(interceptor);
-      return this;
-    }
-    /** Deprecated. Use {@link #addRequesterPlugin(RSocketInterceptor)} instead */
     @Deprecated
-    public ClientRSocketFactory addClientPlugin(RSocketInterceptor interceptor) {
-      return addRequesterPlugin(interceptor);
-    }
+    ClientRSocketFactory addClientPlugin(RSocketInterceptor interceptor);
 
-    public ClientRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor) {
-      plugins.addRequesterPlugin(interceptor);
-      return this;
-    }
+    ClientRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor);
 
-    /** Deprecated. Use {@link #addResponderPlugin(RSocketInterceptor)} instead */
     @Deprecated
-    public ClientRSocketFactory addServerPlugin(RSocketInterceptor interceptor) {
-      return addResponderPlugin(interceptor);
-    }
+    ClientRSocketFactory addServerPlugin(RSocketInterceptor interceptor);
 
-    public ClientRSocketFactory addResponderPlugin(RSocketInterceptor interceptor) {
-      plugins.addResponderPlugin(interceptor);
-      return this;
-    }
+    ClientRSocketFactory addResponderPlugin(RSocketInterceptor interceptor);
 
-    public ClientRSocketFactory addSocketAcceptorPlugin(SocketAcceptorInterceptor interceptor) {
-      plugins.addSocketAcceptorPlugin(interceptor);
-      return this;
-    }
+    ClientRSocketFactory addSocketAcceptorPlugin(SocketAcceptorInterceptor interceptor);
 
     /**
      * Deprecated as Keep-Alive is not optional according to spec
@@ -179,64 +107,27 @@ public class RSocketFactory {
      * @return this ClientRSocketFactory
      */
     @Deprecated
-    public ClientRSocketFactory keepAlive() {
-      return this;
-    }
+    ClientRSocketFactory keepAlive();
 
-    public ClientRSocketFactory keepAlive(
-        Duration tickPeriod, Duration ackTimeout, int missedAcks) {
-      this.tickPeriod = tickPeriod;
-      this.ackTimeout = ackTimeout;
-      this.missedAcks = missedAcks;
-      return this;
-    }
+    ClientRSocketFactory keepAlive(Duration tickPeriod, Duration ackTimeout, int missedAcks);
 
-    public ClientRSocketFactory keepAliveTickPeriod(Duration tickPeriod) {
-      this.tickPeriod = tickPeriod;
-      return this;
-    }
+    ClientRSocketFactory keepAliveTickPeriod(Duration tickPeriod);
 
-    public ClientRSocketFactory keepAliveAckTimeout(Duration ackTimeout) {
-      this.ackTimeout = ackTimeout;
-      return this;
-    }
+    ClientRSocketFactory keepAliveAckTimeout(Duration ackTimeout);
 
-    public ClientRSocketFactory keepAliveMissedAcks(int missedAcks) {
-      this.missedAcks = missedAcks;
-      return this;
-    }
+    ClientRSocketFactory keepAliveMissedAcks(int missedAcks);
 
-    public ClientRSocketFactory mimeType(String metadataMimeType, String dataMimeType) {
-      this.dataMimeType = dataMimeType;
-      this.metadataMimeType = metadataMimeType;
-      return this;
-    }
+    ClientRSocketFactory mimeType(String metadataMimeType, String dataMimeType);
 
-    public ClientRSocketFactory dataMimeType(String dataMimeType) {
-      this.dataMimeType = dataMimeType;
-      return this;
-    }
+    ClientRSocketFactory dataMimeType(String dataMimeType);
 
-    public ClientRSocketFactory metadataMimeType(String metadataMimeType) {
-      this.metadataMimeType = metadataMimeType;
-      return this;
-    }
+    ClientRSocketFactory metadataMimeType(String metadataMimeType);
 
-    public ClientRSocketFactory lease(Supplier<Leases<? extends LeaseStats>> leasesSupplier) {
-      this.leaseEnabled = true;
-      this.leasesSupplier = Objects.requireNonNull(leasesSupplier);
-      return this;
-    }
+    ClientRSocketFactory lease(Supplier<Leases<? extends LeaseStats>> leasesSupplier);
 
-    public ClientRSocketFactory lease() {
-      this.leaseEnabled = true;
-      return this;
-    }
+    ClientRSocketFactory lease();
 
-    public ClientRSocketFactory singleSubscriberRequester() {
-      this.multiSubscriberRequester = false;
-      return this;
-    }
+    ClientRSocketFactory singleSubscriberRequester();
 
     /**
      * Enables a reconnectable, shared instance of {@code Mono<RSocket>} so every subscriber will
@@ -312,531 +203,114 @@ public class RSocketFactory {
      * @param retrySpec a retry factory applied for {@link Mono#retryWhen(Retry)}
      * @return a shared instance of {@code Mono<RSocket>}.
      */
-    public ClientRSocketFactory reconnect(Retry retrySpec) {
-      this.retrySpec = Objects.requireNonNull(retrySpec);
-      this.reconnectEnabled = true;
-      return this;
-    }
+    ClientRSocketFactory reconnect(Retry retrySpec);
 
-    public ClientRSocketFactory resume() {
-      this.resumeEnabled = true;
-      return this;
-    }
+    ClientRSocketFactory resume();
 
-    public ClientRSocketFactory resumeToken(Supplier<ByteBuf> resumeTokenSupplier) {
-      this.resumeTokenSupplier = Objects.requireNonNull(resumeTokenSupplier);
-      return this;
-    }
+    ClientRSocketFactory resumeToken(Supplier<ByteBuf> resumeTokenSupplier);
 
-    public ClientRSocketFactory resumeStore(
-        Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory) {
-      this.resumeStoreFactory = resumeStoreFactory;
-      return this;
-    }
+    ClientRSocketFactory resumeStore(
+        Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory);
 
-    public ClientRSocketFactory resumeSessionDuration(Duration sessionDuration) {
-      this.resumeSessionDuration = Objects.requireNonNull(sessionDuration);
-      return this;
-    }
+    ClientRSocketFactory resumeSessionDuration(Duration sessionDuration);
 
-    public ClientRSocketFactory resumeStreamTimeout(Duration resumeStreamTimeout) {
-      this.resumeStreamTimeout = Objects.requireNonNull(resumeStreamTimeout);
-      return this;
-    }
+    ClientRSocketFactory resumeStreamTimeout(Duration resumeStreamTimeout);
 
-    public ClientRSocketFactory resumeStrategy(Supplier<ResumeStrategy> resumeStrategy) {
-      this.resumeStrategySupplier = Objects.requireNonNull(resumeStrategy);
-      return this;
-    }
+    ClientRSocketFactory resumeStrategy(Supplier<ResumeStrategy> resumeStrategy);
 
-    public ClientRSocketFactory resumeCleanupOnKeepAlive() {
-      resumeCleanupStoreOnKeepAlive = true;
-      return this;
-    }
+    ClientRSocketFactory resumeCleanupOnKeepAlive();
 
     @Override
-    public Start<RSocket> transport(Supplier<ClientTransport> transportClient) {
-      return new StartClient(transportClient);
-    }
+    Start<RSocket> transport(Supplier<ClientTransport> transportClient);
 
-    public ClientTransportAcceptor acceptor(Function<RSocket, RSocket> acceptor) {
-      return acceptor(() -> acceptor);
-    }
+    ClientTransportAcceptor acceptor(Function<RSocket, RSocket> acceptor);
 
-    public ClientTransportAcceptor acceptor(Supplier<Function<RSocket, RSocket>> acceptor) {
-      return acceptor((setup, sendingSocket) -> Mono.just(acceptor.get().apply(sendingSocket)));
-    }
+    ClientTransportAcceptor acceptor(Supplier<Function<RSocket, RSocket>> acceptor);
 
-    public ClientTransportAcceptor acceptor(SocketAcceptor acceptor) {
-      this.acceptor = acceptor;
-      return StartClient::new;
-    }
+    ClientTransportAcceptor acceptor(SocketAcceptor acceptor);
 
-    public ClientRSocketFactory fragment(int mtu) {
-      this.mtu = mtu;
-      return this;
-    }
+    ClientRSocketFactory fragment(int mtu);
 
-    public ClientRSocketFactory errorConsumer(Consumer<Throwable> errorConsumer) {
-      this.errorConsumer = errorConsumer;
-      return this;
-    }
+    ClientRSocketFactory errorConsumer(Consumer<Throwable> errorConsumer);
 
-    public ClientRSocketFactory setupPayload(Payload payload) {
-      this.setupPayload = payload;
-      return this;
-    }
+    ClientRSocketFactory setupPayload(Payload payload);
 
-    public ClientRSocketFactory frameDecoder(PayloadDecoder payloadDecoder) {
-      this.payloadDecoder = payloadDecoder;
-      return this;
-    }
+    ClientRSocketFactory frameDecoder(PayloadDecoder payloadDecoder);
+  }
 
-    private class StartClient implements Start<RSocket> {
-      private final Supplier<ClientTransport> transportClient;
+  /** Factory to create, configure, and start an RSocket server. */
+  public interface ServerRSocketFactory {
+    ServerRSocketFactory byteBufAllocator(ByteBufAllocator allocator);
 
-      StartClient(Supplier<ClientTransport> transportClient) {
-        this.transportClient = transportClient;
-      }
+    ServerRSocketFactory addConnectionPlugin(DuplexConnectionInterceptor interceptor);
 
-      @Override
-      public Mono<RSocket> start() {
-        return newConnection()
-            .flatMap(
-                connection -> {
-                  ClientSetup clientSetup = clientSetup(connection);
-                  ByteBuf resumeToken = clientSetup.resumeToken();
-                  KeepAliveHandler keepAliveHandler = clientSetup.keepAliveHandler();
-                  DuplexConnection wrappedConnection = clientSetup.connection();
+    @Deprecated
+    ServerRSocketFactory addClientPlugin(RSocketInterceptor interceptor);
 
-                  ClientServerInputMultiplexer multiplexer =
-                      new ClientServerInputMultiplexer(wrappedConnection, plugins, true);
+    ServerRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor);
 
-                  boolean isLeaseEnabled = leaseEnabled;
-                  Leases<?> leases = leasesSupplier.get();
-                  RequesterLeaseHandler requesterLeaseHandler =
-                      isLeaseEnabled
-                          ? new RequesterLeaseHandler.Impl(CLIENT_TAG, leases.receiver())
-                          : RequesterLeaseHandler.None;
+    @Deprecated
+    ServerRSocketFactory addServerPlugin(RSocketInterceptor interceptor);
 
-                  RSocket rSocketRequester =
-                      new RSocketRequester(
-                          allocator,
-                          multiplexer.asClientConnection(),
-                          payloadDecoder,
-                          errorConsumer,
-                          StreamIdSupplier.clientSupplier(),
-                          keepAliveTickPeriod(),
-                          keepAliveTimeout(),
-                          keepAliveHandler,
-                          requesterLeaseHandler);
+    ServerRSocketFactory addResponderPlugin(RSocketInterceptor interceptor);
 
-                  if (multiSubscriberRequester) {
-                    rSocketRequester = new MultiSubscriberRSocket(rSocketRequester);
-                  }
+    ServerRSocketFactory addSocketAcceptorPlugin(SocketAcceptorInterceptor interceptor);
 
-                  RSocket wrappedRSocketRequester = plugins.applyRequester(rSocketRequester);
+    ServerTransportAcceptor acceptor(SocketAcceptor acceptor);
 
-                  ByteBuf setupFrame =
-                      SetupFrameFlyweight.encode(
-                          allocator,
-                          isLeaseEnabled,
-                          keepAliveTickPeriod(),
-                          keepAliveTimeout(),
-                          resumeToken,
-                          metadataMimeType,
-                          dataMimeType,
-                          setupPayload);
+    ServerRSocketFactory frameDecoder(PayloadDecoder payloadDecoder);
 
-                  ConnectionSetupPayload setup = ConnectionSetupPayload.create(setupFrame);
+    ServerRSocketFactory fragment(int mtu);
 
-                  return plugins
-                      .applySocketAcceptorInterceptor(acceptor)
-                      .accept(setup, wrappedRSocketRequester)
-                      .flatMap(
-                          rSocketHandler -> {
-                            RSocket wrappedRSocketHandler = plugins.applyResponder(rSocketHandler);
+    ServerRSocketFactory errorConsumer(Consumer<Throwable> errorConsumer);
 
-                            ResponderLeaseHandler responderLeaseHandler =
-                                isLeaseEnabled
-                                    ? new ResponderLeaseHandler.Impl<>(
-                                        CLIENT_TAG,
-                                        allocator,
-                                        leases.sender(),
-                                        errorConsumer,
-                                        leases.stats())
-                                    : ResponderLeaseHandler.None;
+    ServerRSocketFactory lease(Supplier<Leases<?>> leasesSupplier);
 
-                            RSocket rSocketResponder =
-                                new RSocketResponder(
-                                    allocator,
-                                    multiplexer.asServerConnection(),
-                                    wrappedRSocketHandler,
-                                    payloadDecoder,
-                                    errorConsumer,
-                                    responderLeaseHandler);
+    ServerRSocketFactory lease();
 
-                            return wrappedConnection
-                                .sendOne(setupFrame)
-                                .thenReturn(wrappedRSocketRequester);
-                          });
-                })
-            .as(
-                source -> {
-                  if (reconnectEnabled) {
-                    return new ReconnectMono<>(
-                        source.retryWhen(retrySpec), Disposable::dispose, INVALIDATE_FUNCTION);
-                  } else {
-                    return source;
-                  }
-                });
-      }
+    ServerRSocketFactory singleSubscriberRequester();
 
-      private int keepAliveTickPeriod() {
-        return (int) tickPeriod.toMillis();
-      }
+    ServerRSocketFactory resume();
 
-      private int keepAliveTimeout() {
-        return (int) (ackTimeout.toMillis() + tickPeriod.toMillis() * missedAcks);
-      }
+    ServerRSocketFactory resumeStore(
+        Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory);
 
-      private ClientSetup clientSetup(DuplexConnection startConnection) {
-        if (resumeEnabled) {
-          ByteBuf resumeToken = resumeTokenSupplier.get();
-          return new ResumableClientSetup(
-              allocator,
-              startConnection,
-              newConnection(),
-              resumeToken,
-              resumeStoreFactory.apply(resumeToken),
-              resumeSessionDuration,
-              resumeStreamTimeout,
-              resumeStrategySupplier,
-              resumeCleanupStoreOnKeepAlive);
-        } else {
-          return new DefaultClientSetup(startConnection);
-        }
-      }
+    ServerRSocketFactory resumeSessionDuration(Duration sessionDuration);
 
-      private Mono<DuplexConnection> newConnection() {
-        return Mono.fromSupplier(transportClient).flatMap(t -> t.connect(mtu));
-      }
+    ServerRSocketFactory resumeStreamTimeout(Duration resumeStreamTimeout);
+
+    ServerRSocketFactory resumeCleanupOnKeepAlive();
+  }
+
+  public interface ClientTransportAcceptor {
+    Start<RSocket> transport(Supplier<ClientTransport> transport);
+
+    default Start<RSocket> transport(ClientTransport transport) {
+      return transport(() -> transport);
     }
   }
 
-  public static class ServerRSocketFactory {
-    private static final String SERVER_TAG = "server";
+  public interface ServerTransportAcceptor {
 
-    private SocketAcceptor acceptor;
-    private PayloadDecoder payloadDecoder = PayloadDecoder.DEFAULT;
-    private Consumer<Throwable> errorConsumer = Throwable::printStackTrace;
-    private int mtu = 0;
-    private PluginRegistry plugins = new PluginRegistry(Plugins.defaultPlugins());
+    ServerTransport.ConnectionAcceptor toConnectionAcceptor();
 
-    private boolean resumeSupported;
-    private Duration resumeSessionDuration = Duration.ofSeconds(120);
-    private Duration resumeStreamTimeout = Duration.ofSeconds(10);
-    private Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory =
-        token -> new InMemoryResumableFramesStore(SERVER_TAG, 100_000);
+    <T extends Closeable> Start<T> transport(Supplier<ServerTransport<T>> transport);
 
-    private boolean multiSubscriberRequester = true;
-    private boolean leaseEnabled;
-    private Supplier<Leases<?>> leasesSupplier = Leases::new;
-
-    private ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
-    private boolean resumeCleanupStoreOnKeepAlive;
-
-    private ServerRSocketFactory() {}
-
-    public ServerRSocketFactory byteBufAllocator(ByteBufAllocator allocator) {
-      Objects.requireNonNull(allocator);
-      this.allocator = allocator;
-      return this;
+    default <T extends Closeable> Start<T> transport(ServerTransport<T> transport) {
+      return transport(() -> transport);
     }
+  }
 
-    public ServerRSocketFactory addConnectionPlugin(DuplexConnectionInterceptor interceptor) {
-      plugins.addConnectionPlugin(interceptor);
-      return this;
-    }
-    /** Deprecated. Use {@link #addRequesterPlugin(RSocketInterceptor)} instead */
-    @Deprecated
-    public ServerRSocketFactory addClientPlugin(RSocketInterceptor interceptor) {
-      return addRequesterPlugin(interceptor);
-    }
+  public interface Start<T extends Closeable> {
+    Mono<T> start();
+  }
 
-    public ServerRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor) {
-      plugins.addRequesterPlugin(interceptor);
-      return this;
-    }
-
-    /** Deprecated. Use {@link #addResponderPlugin(RSocketInterceptor)} instead */
-    @Deprecated
-    public ServerRSocketFactory addServerPlugin(RSocketInterceptor interceptor) {
-      return addResponderPlugin(interceptor);
-    }
-
-    public ServerRSocketFactory addResponderPlugin(RSocketInterceptor interceptor) {
-      plugins.addResponderPlugin(interceptor);
-      return this;
-    }
-
-    public ServerRSocketFactory addSocketAcceptorPlugin(SocketAcceptorInterceptor interceptor) {
-      plugins.addSocketAcceptorPlugin(interceptor);
-      return this;
-    }
-
-    public ServerTransportAcceptor acceptor(SocketAcceptor acceptor) {
-      this.acceptor = acceptor;
-      return new ServerStart<>();
-    }
-
-    public ServerRSocketFactory frameDecoder(PayloadDecoder payloadDecoder) {
-      this.payloadDecoder = payloadDecoder;
-      return this;
-    }
-
-    public ServerRSocketFactory fragment(int mtu) {
-      this.mtu = mtu;
-      return this;
-    }
-
-    public ServerRSocketFactory errorConsumer(Consumer<Throwable> errorConsumer) {
-      this.errorConsumer = errorConsumer;
-      return this;
-    }
-
-    public ServerRSocketFactory lease(Supplier<Leases<?>> leasesSupplier) {
-      this.leaseEnabled = true;
-      this.leasesSupplier = Objects.requireNonNull(leasesSupplier);
-      return this;
-    }
-
-    public ServerRSocketFactory lease() {
-      this.leaseEnabled = true;
-      return this;
-    }
-
-    public ServerRSocketFactory singleSubscriberRequester() {
-      this.multiSubscriberRequester = false;
-      return this;
-    }
-
-    public ServerRSocketFactory resume() {
-      this.resumeSupported = true;
-      return this;
-    }
-
-    public ServerRSocketFactory resumeStore(
-        Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory) {
-      this.resumeStoreFactory = resumeStoreFactory;
-      return this;
-    }
-
-    public ServerRSocketFactory resumeSessionDuration(Duration sessionDuration) {
-      this.resumeSessionDuration = Objects.requireNonNull(sessionDuration);
-      return this;
-    }
-
-    public ServerRSocketFactory resumeStreamTimeout(Duration resumeStreamTimeout) {
-      this.resumeStreamTimeout = Objects.requireNonNull(resumeStreamTimeout);
-      return this;
-    }
-
-    public ServerRSocketFactory resumeCleanupOnKeepAlive() {
-      resumeCleanupStoreOnKeepAlive = true;
-      return this;
-    }
-
-    private class ServerStart<T extends Closeable> implements Start<T>, ServerTransportAcceptor {
-      private Supplier<ServerTransport<T>> transportServer;
-
-      @Override
-      public ServerTransport.ConnectionAcceptor toConnectionAcceptor() {
-        return new ServerTransport.ConnectionAcceptor() {
-          private final ServerSetup serverSetup = serverSetup();
-
-          @Override
-          public Mono<Void> apply(DuplexConnection connection) {
-            return acceptor(serverSetup, connection);
-          }
-        };
-      }
-
-      @Override
-      @SuppressWarnings("unchecked")
-      public <T extends Closeable> Start<T> transport(Supplier<ServerTransport<T>> transport) {
-        this.transportServer = (Supplier) transport;
-        return (Start) this::start;
-      }
-
-      private Mono<Void> acceptor(ServerSetup serverSetup, DuplexConnection connection) {
-        ClientServerInputMultiplexer multiplexer =
-            new ClientServerInputMultiplexer(connection, plugins, false);
-
-        return multiplexer
-            .asSetupConnection()
-            .receive()
-            .next()
-            .flatMap(startFrame -> accept(serverSetup, startFrame, multiplexer));
-      }
-
-      private Mono<Void> acceptResume(
-          ServerSetup serverSetup, ByteBuf resumeFrame, ClientServerInputMultiplexer multiplexer) {
-        return serverSetup.acceptRSocketResume(resumeFrame, multiplexer);
-      }
-
-      private Mono<Void> accept(
-          ServerSetup serverSetup, ByteBuf startFrame, ClientServerInputMultiplexer multiplexer) {
-        switch (FrameHeaderFlyweight.frameType(startFrame)) {
-          case SETUP:
-            return acceptSetup(serverSetup, startFrame, multiplexer);
-          case RESUME:
-            return acceptResume(serverSetup, startFrame, multiplexer);
-          default:
-            return acceptUnknown(startFrame, multiplexer);
-        }
-      }
-
-      private Mono<Void> acceptSetup(
-          ServerSetup serverSetup, ByteBuf setupFrame, ClientServerInputMultiplexer multiplexer) {
-
-        if (!SetupFrameFlyweight.isSupportedVersion(setupFrame)) {
-          return sendError(
-                  multiplexer,
-                  new InvalidSetupException(
-                      "Unsupported version: "
-                          + SetupFrameFlyweight.humanReadableVersion(setupFrame)))
-              .doFinally(
-                  signalType -> {
-                    setupFrame.release();
-                    multiplexer.dispose();
-                  });
-        }
-
-        boolean isLeaseEnabled = leaseEnabled;
-
-        if (SetupFrameFlyweight.honorLease(setupFrame) && !isLeaseEnabled) {
-          return sendError(multiplexer, new InvalidSetupException("lease is not supported"))
-              .doFinally(
-                  signalType -> {
-                    setupFrame.release();
-                    multiplexer.dispose();
-                  });
-        }
-
-        return serverSetup.acceptRSocketSetup(
-            setupFrame,
-            multiplexer,
-            (keepAliveHandler, wrappedMultiplexer) -> {
-              ConnectionSetupPayload setupPayload = ConnectionSetupPayload.create(setupFrame);
-
-              Leases<?> leases = leasesSupplier.get();
-              RequesterLeaseHandler requesterLeaseHandler =
-                  isLeaseEnabled
-                      ? new RequesterLeaseHandler.Impl(SERVER_TAG, leases.receiver())
-                      : RequesterLeaseHandler.None;
-
-              RSocket rSocketRequester =
-                  new RSocketRequester(
-                      allocator,
-                      wrappedMultiplexer.asServerConnection(),
-                      payloadDecoder,
-                      errorConsumer,
-                      StreamIdSupplier.serverSupplier(),
-                      setupPayload.keepAliveInterval(),
-                      setupPayload.keepAliveMaxLifetime(),
-                      keepAliveHandler,
-                      requesterLeaseHandler);
-
-              if (multiSubscriberRequester) {
-                rSocketRequester = new MultiSubscriberRSocket(rSocketRequester);
-              }
-              RSocket wrappedRSocketRequester = plugins.applyRequester(rSocketRequester);
-
-              return plugins
-                  .applySocketAcceptorInterceptor(acceptor)
-                  .accept(setupPayload, wrappedRSocketRequester)
-                  .onErrorResume(
-                      err -> sendError(multiplexer, rejectedSetupError(err)).then(Mono.error(err)))
-                  .doOnNext(
-                      rSocketHandler -> {
-                        RSocket wrappedRSocketHandler = plugins.applyResponder(rSocketHandler);
-
-                        ResponderLeaseHandler responderLeaseHandler =
-                            isLeaseEnabled
-                                ? new ResponderLeaseHandler.Impl<>(
-                                    SERVER_TAG,
-                                    allocator,
-                                    leases.sender(),
-                                    errorConsumer,
-                                    leases.stats())
-                                : ResponderLeaseHandler.None;
-
-                        RSocket rSocketResponder =
-                            new RSocketResponder(
-                                allocator,
-                                wrappedMultiplexer.asClientConnection(),
-                                wrappedRSocketHandler,
-                                payloadDecoder,
-                                errorConsumer,
-                                responderLeaseHandler);
-                      })
-                  .doFinally(signalType -> setupPayload.release())
-                  .then();
-            });
-      }
-
-      @Override
-      public Mono<T> start() {
-        return Mono.defer(
-            new Supplier<Mono<T>>() {
-
-              ServerSetup serverSetup = serverSetup();
-
-              @Override
-              public Mono<T> get() {
-                return Mono.fromSupplier(transportServer)
-                    .flatMap(
-                        transport ->
-                            transport.start(
-                                duplexConnection -> acceptor(serverSetup, duplexConnection), mtu))
-                    .doOnNext(c -> c.onClose().doFinally(v -> serverSetup.dispose()).subscribe());
-              }
-            });
-      }
-
-      private ServerSetup serverSetup() {
-        return resumeSupported
-            ? new ServerSetup.ResumableServerSetup(
-                allocator,
-                new SessionManager(),
-                resumeSessionDuration,
-                resumeStreamTimeout,
-                resumeStoreFactory,
-                resumeCleanupStoreOnKeepAlive)
-            : new ServerSetup.DefaultServerSetup(allocator);
-      }
-
-      private Mono<Void> acceptUnknown(ByteBuf frame, ClientServerInputMultiplexer multiplexer) {
-        return sendError(
-                multiplexer,
-                new InvalidSetupException(
-                    "invalid setup frame: " + FrameHeaderFlyweight.frameType(frame)))
-            .doFinally(
-                signalType -> {
-                  frame.release();
-                  multiplexer.dispose();
-                });
-      }
-
-      private Mono<Void> sendError(ClientServerInputMultiplexer multiplexer, Exception exception) {
-        return ConnectionUtils.sendError(allocator, multiplexer, exception);
-      }
-
-      private Exception rejectedSetupError(Throwable err) {
-        String msg = err.getMessage();
-        return new RejectedSetupException(msg == null ? "rejected by server acceptor" : msg);
-      }
+  private static Constructor<?> getConstructorFor(String className) {
+    try {
+      Class<?> clazz = Class.forName(className);
+      return clazz.getDeclaredConstructor();
+    } catch (Throwable ex) {
+      throw new IllegalStateException("No " + className);
     }
   }
 }

--- a/rsocket-core/src/main/java/io/rsocket/core/DefaultClientRSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/DefaultClientRSocketFactory.java
@@ -114,24 +114,10 @@ public class DefaultClientRSocketFactory implements RSocketFactory.ClientRSocket
     return this;
   }
 
-  /** Deprecated. Use {@link #addRequesterPlugin(RSocketInterceptor)} instead */
-  @Override
-  @Deprecated
-  public RSocketFactory.ClientRSocketFactory addClientPlugin(RSocketInterceptor interceptor) {
-    return addRequesterPlugin(interceptor);
-  }
-
   @Override
   public RSocketFactory.ClientRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor) {
     plugins.addRequesterPlugin(interceptor);
     return this;
-  }
-
-  /** Deprecated. Use {@link #addResponderPlugin(RSocketInterceptor)} instead */
-  @Override
-  @Deprecated
-  public RSocketFactory.ClientRSocketFactory addServerPlugin(RSocketInterceptor interceptor) {
-    return addResponderPlugin(interceptor);
   }
 
   @Override
@@ -144,12 +130,6 @@ public class DefaultClientRSocketFactory implements RSocketFactory.ClientRSocket
   public RSocketFactory.ClientRSocketFactory addSocketAcceptorPlugin(
       SocketAcceptorInterceptor interceptor) {
     plugins.addSocketAcceptorPlugin(interceptor);
-    return this;
-  }
-
-  @Override
-  @Deprecated
-  public RSocketFactory.ClientRSocketFactory keepAlive() {
     return this;
   }
 

--- a/rsocket-core/src/main/java/io/rsocket/core/DefaultClientRSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/DefaultClientRSocketFactory.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rsocket.core;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.rsocket.AbstractRSocket;
+import io.rsocket.ConnectionSetupPayload;
+import io.rsocket.DuplexConnection;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.RSocketFactory;
+import io.rsocket.SocketAcceptor;
+import io.rsocket.frame.ResumeFrameFlyweight;
+import io.rsocket.frame.SetupFrameFlyweight;
+import io.rsocket.frame.decoder.PayloadDecoder;
+import io.rsocket.internal.ClientServerInputMultiplexer;
+import io.rsocket.internal.ClientSetup;
+import io.rsocket.keepalive.KeepAliveHandler;
+import io.rsocket.lease.LeaseStats;
+import io.rsocket.lease.Leases;
+import io.rsocket.lease.RequesterLeaseHandler;
+import io.rsocket.lease.ResponderLeaseHandler;
+import io.rsocket.plugins.DuplexConnectionInterceptor;
+import io.rsocket.plugins.PluginRegistry;
+import io.rsocket.plugins.Plugins;
+import io.rsocket.plugins.RSocketInterceptor;
+import io.rsocket.plugins.SocketAcceptorInterceptor;
+import io.rsocket.resume.ExponentialBackoffResumeStrategy;
+import io.rsocket.resume.InMemoryResumableFramesStore;
+import io.rsocket.resume.ResumableFramesStore;
+import io.rsocket.resume.ResumeStrategy;
+import io.rsocket.transport.ClientTransport;
+import io.rsocket.util.EmptyPayload;
+import io.rsocket.util.MultiSubscriberRSocket;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+/**
+ * Default implementation of {@link RSocketFactory.ClientRSocketFactory} that can be instantiated
+ * directly or through the shortcut {@link RSocketFactory#connect()}.
+ */
+public class DefaultClientRSocketFactory implements RSocketFactory.ClientRSocketFactory {
+  private static final String CLIENT_TAG = "client";
+
+  private static final BiConsumer<RSocket, Invalidatable> INVALIDATE_FUNCTION =
+      (r, i) -> r.onClose().subscribe(null, null, i::invalidate);
+
+  private SocketAcceptor acceptor = (setup, sendingSocket) -> Mono.just(new AbstractRSocket() {});
+
+  private Consumer<Throwable> errorConsumer = Throwable::printStackTrace;
+  private int mtu = 0;
+  private PluginRegistry plugins = new PluginRegistry(Plugins.defaultPlugins());
+
+  private Payload setupPayload = EmptyPayload.INSTANCE;
+  private PayloadDecoder payloadDecoder = PayloadDecoder.DEFAULT;
+
+  private Duration tickPeriod = Duration.ofSeconds(20);
+  private Duration ackTimeout = Duration.ofSeconds(30);
+  private int missedAcks = 3;
+
+  private String metadataMimeType = "application/binary";
+  private String dataMimeType = "application/binary";
+
+  private boolean resumeEnabled;
+  private boolean resumeCleanupStoreOnKeepAlive;
+  private Supplier<ByteBuf> resumeTokenSupplier = ResumeFrameFlyweight::generateResumeToken;
+  private Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory =
+      token -> new InMemoryResumableFramesStore(CLIENT_TAG, 100_000);
+  private Duration resumeSessionDuration = Duration.ofMinutes(2);
+  private Duration resumeStreamTimeout = Duration.ofSeconds(10);
+  private Supplier<ResumeStrategy> resumeStrategySupplier =
+      () -> new ExponentialBackoffResumeStrategy(Duration.ofSeconds(1), Duration.ofSeconds(16), 2);
+
+  private boolean multiSubscriberRequester = true;
+  private boolean leaseEnabled;
+  private Supplier<Leases<?>> leasesSupplier = Leases::new;
+  private boolean reconnectEnabled;
+  private Retry retrySpec;
+
+  private ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory byteBufAllocator(ByteBufAllocator allocator) {
+    Objects.requireNonNull(allocator);
+    this.allocator = allocator;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory addConnectionPlugin(
+      DuplexConnectionInterceptor interceptor) {
+    plugins.addConnectionPlugin(interceptor);
+    return this;
+  }
+
+  /** Deprecated. Use {@link #addRequesterPlugin(RSocketInterceptor)} instead */
+  @Override
+  @Deprecated
+  public RSocketFactory.ClientRSocketFactory addClientPlugin(RSocketInterceptor interceptor) {
+    return addRequesterPlugin(interceptor);
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor) {
+    plugins.addRequesterPlugin(interceptor);
+    return this;
+  }
+
+  /** Deprecated. Use {@link #addResponderPlugin(RSocketInterceptor)} instead */
+  @Override
+  @Deprecated
+  public RSocketFactory.ClientRSocketFactory addServerPlugin(RSocketInterceptor interceptor) {
+    return addResponderPlugin(interceptor);
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory addResponderPlugin(RSocketInterceptor interceptor) {
+    plugins.addResponderPlugin(interceptor);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory addSocketAcceptorPlugin(
+      SocketAcceptorInterceptor interceptor) {
+    plugins.addSocketAcceptorPlugin(interceptor);
+    return this;
+  }
+
+  @Override
+  @Deprecated
+  public RSocketFactory.ClientRSocketFactory keepAlive() {
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory keepAlive(
+      Duration tickPeriod, Duration ackTimeout, int missedAcks) {
+    this.tickPeriod = tickPeriod;
+    this.ackTimeout = ackTimeout;
+    this.missedAcks = missedAcks;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory keepAliveTickPeriod(Duration tickPeriod) {
+    this.tickPeriod = tickPeriod;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory keepAliveAckTimeout(Duration ackTimeout) {
+    this.ackTimeout = ackTimeout;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory keepAliveMissedAcks(int missedAcks) {
+    this.missedAcks = missedAcks;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory mimeType(
+      String metadataMimeType, String dataMimeType) {
+    this.dataMimeType = dataMimeType;
+    this.metadataMimeType = metadataMimeType;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory dataMimeType(String dataMimeType) {
+    this.dataMimeType = dataMimeType;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory metadataMimeType(String metadataMimeType) {
+    this.metadataMimeType = metadataMimeType;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory lease(
+      Supplier<Leases<? extends LeaseStats>> leasesSupplier) {
+    this.leaseEnabled = true;
+    this.leasesSupplier = Objects.requireNonNull(leasesSupplier);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory lease() {
+    this.leaseEnabled = true;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory singleSubscriberRequester() {
+    this.multiSubscriberRequester = false;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory reconnect(Retry retrySpec) {
+    this.retrySpec = Objects.requireNonNull(retrySpec);
+    this.reconnectEnabled = true;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory resume() {
+    this.resumeEnabled = true;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory resumeToken(Supplier<ByteBuf> resumeTokenSupplier) {
+    this.resumeTokenSupplier = Objects.requireNonNull(resumeTokenSupplier);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory resumeStore(
+      Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory) {
+    this.resumeStoreFactory = resumeStoreFactory;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory resumeSessionDuration(Duration sessionDuration) {
+    this.resumeSessionDuration = Objects.requireNonNull(sessionDuration);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory resumeStreamTimeout(Duration resumeStreamTimeout) {
+    this.resumeStreamTimeout = Objects.requireNonNull(resumeStreamTimeout);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory resumeStrategy(
+      Supplier<ResumeStrategy> resumeStrategy) {
+    this.resumeStrategySupplier = Objects.requireNonNull(resumeStrategy);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory resumeCleanupOnKeepAlive() {
+    resumeCleanupStoreOnKeepAlive = true;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.Start<RSocket> transport(Supplier<ClientTransport> transportClient) {
+    return new StartClient(transportClient);
+  }
+
+  @Override
+  public RSocketFactory.ClientTransportAcceptor acceptor(Function<RSocket, RSocket> acceptor) {
+    return acceptor(() -> acceptor);
+  }
+
+  @Override
+  public RSocketFactory.ClientTransportAcceptor acceptor(
+      Supplier<Function<RSocket, RSocket>> acceptor) {
+    return acceptor((setup, sendingSocket) -> Mono.just(acceptor.get().apply(sendingSocket)));
+  }
+
+  @Override
+  public RSocketFactory.ClientTransportAcceptor acceptor(SocketAcceptor acceptor) {
+    this.acceptor = acceptor;
+    return StartClient::new;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory fragment(int mtu) {
+    this.mtu = mtu;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory errorConsumer(Consumer<Throwable> errorConsumer) {
+    this.errorConsumer = errorConsumer;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory setupPayload(Payload payload) {
+    this.setupPayload = payload;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ClientRSocketFactory frameDecoder(PayloadDecoder payloadDecoder) {
+    this.payloadDecoder = payloadDecoder;
+    return this;
+  }
+
+  private class StartClient implements RSocketFactory.Start<RSocket> {
+    private final Supplier<ClientTransport> transportClient;
+
+    StartClient(Supplier<ClientTransport> transportClient) {
+      this.transportClient = transportClient;
+    }
+
+    @Override
+    public Mono<RSocket> start() {
+      return newConnection()
+          .flatMap(
+              connection -> {
+                ClientSetup clientSetup = clientSetup(connection);
+                ByteBuf resumeToken = clientSetup.resumeToken();
+                KeepAliveHandler keepAliveHandler = clientSetup.keepAliveHandler();
+                DuplexConnection wrappedConnection = clientSetup.connection();
+
+                ClientServerInputMultiplexer multiplexer =
+                    new ClientServerInputMultiplexer(wrappedConnection, plugins, true);
+
+                boolean isLeaseEnabled = leaseEnabled;
+                Leases<?> leases = leasesSupplier.get();
+                RequesterLeaseHandler requesterLeaseHandler =
+                    isLeaseEnabled
+                        ? new RequesterLeaseHandler.Impl(CLIENT_TAG, leases.receiver())
+                        : RequesterLeaseHandler.None;
+
+                RSocket rSocketRequester =
+                    new RSocketRequester(
+                        allocator,
+                        multiplexer.asClientConnection(),
+                        payloadDecoder,
+                        errorConsumer,
+                        StreamIdSupplier.clientSupplier(),
+                        keepAliveTickPeriod(),
+                        keepAliveTimeout(),
+                        keepAliveHandler,
+                        requesterLeaseHandler);
+
+                if (multiSubscriberRequester) {
+                  rSocketRequester = new MultiSubscriberRSocket(rSocketRequester);
+                }
+
+                RSocket wrappedRSocketRequester = plugins.applyRequester(rSocketRequester);
+
+                ByteBuf setupFrame =
+                    SetupFrameFlyweight.encode(
+                        allocator,
+                        isLeaseEnabled,
+                        keepAliveTickPeriod(),
+                        keepAliveTimeout(),
+                        resumeToken,
+                        metadataMimeType,
+                        dataMimeType,
+                        setupPayload);
+
+                ConnectionSetupPayload setup = new DefaultConnectionSetupPayload(setupFrame);
+
+                return plugins
+                    .applySocketAcceptorInterceptor(acceptor)
+                    .accept(setup, wrappedRSocketRequester)
+                    .flatMap(
+                        rSocketHandler -> {
+                          RSocket wrappedRSocketHandler = plugins.applyResponder(rSocketHandler);
+
+                          ResponderLeaseHandler responderLeaseHandler =
+                              isLeaseEnabled
+                                  ? new ResponderLeaseHandler.Impl<>(
+                                      CLIENT_TAG,
+                                      allocator,
+                                      leases.sender(),
+                                      errorConsumer,
+                                      leases.stats())
+                                  : ResponderLeaseHandler.None;
+
+                          RSocket rSocketResponder =
+                              new RSocketResponder(
+                                  allocator,
+                                  multiplexer.asServerConnection(),
+                                  wrappedRSocketHandler,
+                                  payloadDecoder,
+                                  errorConsumer,
+                                  responderLeaseHandler);
+
+                          return wrappedConnection
+                              .sendOne(setupFrame)
+                              .thenReturn(wrappedRSocketRequester);
+                        });
+              })
+          .as(
+              source -> {
+                if (reconnectEnabled) {
+                  return new ReconnectMono<>(
+                      source.retryWhen(retrySpec), Disposable::dispose, INVALIDATE_FUNCTION);
+                } else {
+                  return source;
+                }
+              });
+    }
+
+    private int keepAliveTickPeriod() {
+      return (int) tickPeriod.toMillis();
+    }
+
+    private int keepAliveTimeout() {
+      return (int) (ackTimeout.toMillis() + tickPeriod.toMillis() * missedAcks);
+    }
+
+    private ClientSetup clientSetup(DuplexConnection startConnection) {
+      if (resumeEnabled) {
+        ByteBuf resumeToken = resumeTokenSupplier.get();
+        return new ClientSetup.ResumableClientSetup(
+            allocator,
+            startConnection,
+            newConnection(),
+            resumeToken,
+            resumeStoreFactory.apply(resumeToken),
+            resumeSessionDuration,
+            resumeStreamTimeout,
+            resumeStrategySupplier,
+            resumeCleanupStoreOnKeepAlive);
+      } else {
+        return new ClientSetup.DefaultClientSetup(startConnection);
+      }
+    }
+
+    private Mono<DuplexConnection> newConnection() {
+      return Mono.fromSupplier(transportClient).flatMap(t -> t.connect(mtu));
+    }
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/core/DefaultConnectionSetupPayload.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/DefaultConnectionSetupPayload.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.core;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.AbstractReferenceCounted;
+import io.rsocket.ConnectionSetupPayload;
+import io.rsocket.frame.FrameHeaderFlyweight;
+import io.rsocket.frame.SetupFrameFlyweight;
+
+/** Default implementation of {@link ConnectionSetupPayload}. */
+class DefaultConnectionSetupPayload extends AbstractReferenceCounted
+    implements ConnectionSetupPayload {
+
+  private final ByteBuf setupFrame;
+
+  public DefaultConnectionSetupPayload(ByteBuf setupFrame) {
+    this.setupFrame = setupFrame;
+  }
+
+  @Override
+  public ConnectionSetupPayload retain() {
+    super.retain();
+    return this;
+  }
+
+  @Override
+  public ConnectionSetupPayload retain(int increment) {
+    super.retain(increment);
+    return this;
+  }
+
+  @Override
+  public boolean hasMetadata() {
+    return FrameHeaderFlyweight.hasMetadata(setupFrame);
+  }
+
+  @Override
+  public int keepAliveInterval() {
+    return SetupFrameFlyweight.keepAliveInterval(setupFrame);
+  }
+
+  @Override
+  public int keepAliveMaxLifetime() {
+    return SetupFrameFlyweight.keepAliveMaxLifetime(setupFrame);
+  }
+
+  @Override
+  public String metadataMimeType() {
+    return SetupFrameFlyweight.metadataMimeType(setupFrame);
+  }
+
+  @Override
+  public String dataMimeType() {
+    return SetupFrameFlyweight.dataMimeType(setupFrame);
+  }
+
+  @Override
+  public int getFlags() {
+    return FrameHeaderFlyweight.flags(setupFrame);
+  }
+
+  @Override
+  public boolean willClientHonorLease() {
+    return SetupFrameFlyweight.honorLease(setupFrame);
+  }
+
+  @Override
+  public boolean isResumeEnabled() {
+    return SetupFrameFlyweight.resumeEnabled(setupFrame);
+  }
+
+  @Override
+  public ByteBuf resumeToken() {
+    return SetupFrameFlyweight.resumeToken(setupFrame);
+  }
+
+  @Override
+  public ConnectionSetupPayload touch() {
+    setupFrame.touch();
+    return this;
+  }
+
+  @Override
+  public ConnectionSetupPayload touch(Object hint) {
+    setupFrame.touch(hint);
+    return this;
+  }
+
+  @Override
+  protected void deallocate() {
+    setupFrame.release();
+  }
+
+  @Override
+  public ByteBuf sliceMetadata() {
+    return SetupFrameFlyweight.metadata(setupFrame);
+  }
+
+  @Override
+  public ByteBuf sliceData() {
+    return SetupFrameFlyweight.data(setupFrame);
+  }
+
+  @Override
+  public ByteBuf data() {
+    return sliceData();
+  }
+
+  @Override
+  public ByteBuf metadata() {
+    return sliceMetadata();
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/core/DefaultServerRSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/DefaultServerRSocketFactory.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rsocket.core;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.rsocket.Closeable;
+import io.rsocket.ConnectionSetupPayload;
+import io.rsocket.DuplexConnection;
+import io.rsocket.RSocket;
+import io.rsocket.RSocketFactory;
+import io.rsocket.SocketAcceptor;
+import io.rsocket.exceptions.InvalidSetupException;
+import io.rsocket.exceptions.RejectedSetupException;
+import io.rsocket.frame.FrameHeaderFlyweight;
+import io.rsocket.frame.SetupFrameFlyweight;
+import io.rsocket.frame.decoder.PayloadDecoder;
+import io.rsocket.internal.ClientServerInputMultiplexer;
+import io.rsocket.internal.ServerSetup;
+import io.rsocket.lease.Leases;
+import io.rsocket.lease.RequesterLeaseHandler;
+import io.rsocket.lease.ResponderLeaseHandler;
+import io.rsocket.plugins.DuplexConnectionInterceptor;
+import io.rsocket.plugins.PluginRegistry;
+import io.rsocket.plugins.Plugins;
+import io.rsocket.plugins.RSocketInterceptor;
+import io.rsocket.plugins.SocketAcceptorInterceptor;
+import io.rsocket.resume.InMemoryResumableFramesStore;
+import io.rsocket.resume.ResumableFramesStore;
+import io.rsocket.resume.SessionManager;
+import io.rsocket.transport.ServerTransport;
+import io.rsocket.util.ConnectionUtils;
+import io.rsocket.util.MultiSubscriberRSocket;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default implementation of {@link RSocketFactory.ServerRSocketFactory} that can be instantiated
+ * directly or through the shortcut {@link RSocketFactory#receive()}.
+ */
+public class DefaultServerRSocketFactory implements RSocketFactory.ServerRSocketFactory {
+  private static final String SERVER_TAG = "server";
+
+  private SocketAcceptor acceptor;
+  private PayloadDecoder payloadDecoder = PayloadDecoder.DEFAULT;
+  private Consumer<Throwable> errorConsumer = Throwable::printStackTrace;
+  private int mtu = 0;
+  private PluginRegistry plugins = new PluginRegistry(Plugins.defaultPlugins());
+
+  private boolean resumeSupported;
+  private Duration resumeSessionDuration = Duration.ofSeconds(120);
+  private Duration resumeStreamTimeout = Duration.ofSeconds(10);
+  private Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory =
+      token -> new InMemoryResumableFramesStore(SERVER_TAG, 100_000);
+
+  private boolean multiSubscriberRequester = true;
+  private boolean leaseEnabled;
+  private Supplier<Leases<?>> leasesSupplier = Leases::new;
+
+  private ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+  private boolean resumeCleanupStoreOnKeepAlive;
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory byteBufAllocator(ByteBufAllocator allocator) {
+    Objects.requireNonNull(allocator);
+    this.allocator = allocator;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory addConnectionPlugin(
+      DuplexConnectionInterceptor interceptor) {
+    plugins.addConnectionPlugin(interceptor);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory addRequesterPlugin(RSocketInterceptor interceptor) {
+    plugins.addRequesterPlugin(interceptor);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory addResponderPlugin(RSocketInterceptor interceptor) {
+    plugins.addResponderPlugin(interceptor);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory addSocketAcceptorPlugin(
+      SocketAcceptorInterceptor interceptor) {
+    plugins.addSocketAcceptorPlugin(interceptor);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerTransportAcceptor acceptor(SocketAcceptor acceptor) {
+    this.acceptor = acceptor;
+    return new ServerStart<>();
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory frameDecoder(PayloadDecoder payloadDecoder) {
+    this.payloadDecoder = payloadDecoder;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory fragment(int mtu) {
+    this.mtu = mtu;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory errorConsumer(Consumer<Throwable> errorConsumer) {
+    this.errorConsumer = errorConsumer;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory lease(Supplier<Leases<?>> leasesSupplier) {
+    this.leaseEnabled = true;
+    this.leasesSupplier = Objects.requireNonNull(leasesSupplier);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory lease() {
+    this.leaseEnabled = true;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory singleSubscriberRequester() {
+    this.multiSubscriberRequester = false;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory resume() {
+    this.resumeSupported = true;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory resumeStore(
+      Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory) {
+    this.resumeStoreFactory = resumeStoreFactory;
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory resumeSessionDuration(Duration sessionDuration) {
+    this.resumeSessionDuration = Objects.requireNonNull(sessionDuration);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory resumeStreamTimeout(Duration resumeStreamTimeout) {
+    this.resumeStreamTimeout = Objects.requireNonNull(resumeStreamTimeout);
+    return this;
+  }
+
+  @Override
+  public RSocketFactory.ServerRSocketFactory resumeCleanupOnKeepAlive() {
+    resumeCleanupStoreOnKeepAlive = true;
+    return this;
+  }
+
+  private class ServerStart<T extends Closeable>
+      implements RSocketFactory.Start, RSocketFactory.ServerTransportAcceptor {
+    private Supplier<ServerTransport<T>> transportServer;
+
+    @Override
+    public ServerTransport.ConnectionAcceptor toConnectionAcceptor() {
+      return new ServerTransport.ConnectionAcceptor() {
+        private final ServerSetup serverSetup = serverSetup();
+
+        @Override
+        public Mono<Void> apply(DuplexConnection connection) {
+          return acceptor(serverSetup, connection);
+        }
+      };
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends Closeable> RSocketFactory.Start<T> transport(
+        Supplier<ServerTransport<T>> transport) {
+      this.transportServer = (Supplier) transport;
+      return (RSocketFactory.Start) this::start;
+    }
+
+    private Mono<Void> acceptor(ServerSetup serverSetup, DuplexConnection connection) {
+      ClientServerInputMultiplexer multiplexer =
+          new ClientServerInputMultiplexer(connection, plugins, false);
+
+      return multiplexer
+          .asSetupConnection()
+          .receive()
+          .next()
+          .flatMap(startFrame -> accept(serverSetup, startFrame, multiplexer));
+    }
+
+    private Mono<Void> acceptResume(
+        ServerSetup serverSetup, ByteBuf resumeFrame, ClientServerInputMultiplexer multiplexer) {
+      return serverSetup.acceptRSocketResume(resumeFrame, multiplexer);
+    }
+
+    private Mono<Void> accept(
+        ServerSetup serverSetup, ByteBuf startFrame, ClientServerInputMultiplexer multiplexer) {
+      switch (FrameHeaderFlyweight.frameType(startFrame)) {
+        case SETUP:
+          return acceptSetup(serverSetup, startFrame, multiplexer);
+        case RESUME:
+          return acceptResume(serverSetup, startFrame, multiplexer);
+        default:
+          return acceptUnknown(startFrame, multiplexer);
+      }
+    }
+
+    private Mono<Void> acceptSetup(
+        ServerSetup serverSetup, ByteBuf setupFrame, ClientServerInputMultiplexer multiplexer) {
+
+      if (!SetupFrameFlyweight.isSupportedVersion(setupFrame)) {
+        return sendError(
+                multiplexer,
+                new InvalidSetupException(
+                    "Unsupported version: " + SetupFrameFlyweight.humanReadableVersion(setupFrame)))
+            .doFinally(
+                signalType -> {
+                  setupFrame.release();
+                  multiplexer.dispose();
+                });
+      }
+
+      boolean isLeaseEnabled = leaseEnabled;
+
+      if (SetupFrameFlyweight.honorLease(setupFrame) && !isLeaseEnabled) {
+        return sendError(multiplexer, new InvalidSetupException("lease is not supported"))
+            .doFinally(
+                signalType -> {
+                  setupFrame.release();
+                  multiplexer.dispose();
+                });
+      }
+
+      return serverSetup.acceptRSocketSetup(
+          setupFrame,
+          multiplexer,
+          (keepAliveHandler, wrappedMultiplexer) -> {
+            ConnectionSetupPayload setupPayload = new DefaultConnectionSetupPayload(setupFrame);
+
+            Leases<?> leases = leasesSupplier.get();
+            RequesterLeaseHandler requesterLeaseHandler =
+                isLeaseEnabled
+                    ? new RequesterLeaseHandler.Impl(SERVER_TAG, leases.receiver())
+                    : RequesterLeaseHandler.None;
+
+            RSocket rSocketRequester =
+                new RSocketRequester(
+                    allocator,
+                    wrappedMultiplexer.asServerConnection(),
+                    payloadDecoder,
+                    errorConsumer,
+                    StreamIdSupplier.serverSupplier(),
+                    setupPayload.keepAliveInterval(),
+                    setupPayload.keepAliveMaxLifetime(),
+                    keepAliveHandler,
+                    requesterLeaseHandler);
+
+            if (multiSubscriberRequester) {
+              rSocketRequester = new MultiSubscriberRSocket(rSocketRequester);
+            }
+            RSocket wrappedRSocketRequester = plugins.applyRequester(rSocketRequester);
+
+            return plugins
+                .applySocketAcceptorInterceptor(acceptor)
+                .accept(setupPayload, wrappedRSocketRequester)
+                .onErrorResume(
+                    err -> sendError(multiplexer, rejectedSetupError(err)).then(Mono.error(err)))
+                .doOnNext(
+                    rSocketHandler -> {
+                      RSocket wrappedRSocketHandler = plugins.applyResponder(rSocketHandler);
+
+                      ResponderLeaseHandler responderLeaseHandler =
+                          isLeaseEnabled
+                              ? new ResponderLeaseHandler.Impl<>(
+                                  SERVER_TAG,
+                                  allocator,
+                                  leases.sender(),
+                                  errorConsumer,
+                                  leases.stats())
+                              : ResponderLeaseHandler.None;
+
+                      RSocket rSocketResponder =
+                          new RSocketResponder(
+                              allocator,
+                              wrappedMultiplexer.asClientConnection(),
+                              wrappedRSocketHandler,
+                              payloadDecoder,
+                              errorConsumer,
+                              responderLeaseHandler);
+                    })
+                .doFinally(signalType -> setupPayload.release())
+                .then();
+          });
+    }
+
+    @Override
+    public Mono<T> start() {
+      return Mono.defer(
+          new Supplier<Mono<T>>() {
+
+            ServerSetup serverSetup = serverSetup();
+
+            @Override
+            public Mono<T> get() {
+              return Mono.fromSupplier(transportServer)
+                  .flatMap(
+                      transport ->
+                          transport.start(
+                              duplexConnection -> acceptor(serverSetup, duplexConnection), mtu))
+                  .doOnNext(c -> c.onClose().doFinally(v -> serverSetup.dispose()).subscribe());
+            }
+          });
+    }
+
+    private ServerSetup serverSetup() {
+      return resumeSupported
+          ? new ServerSetup.ResumableServerSetup(
+              allocator,
+              new SessionManager(),
+              resumeSessionDuration,
+              resumeStreamTimeout,
+              resumeStoreFactory,
+              resumeCleanupStoreOnKeepAlive)
+          : new ServerSetup.DefaultServerSetup(allocator);
+    }
+
+    private Mono<Void> acceptUnknown(ByteBuf frame, ClientServerInputMultiplexer multiplexer) {
+      return sendError(
+              multiplexer,
+              new InvalidSetupException(
+                  "invalid setup frame: " + FrameHeaderFlyweight.frameType(frame)))
+          .doFinally(
+              signalType -> {
+                frame.release();
+                multiplexer.dispose();
+              });
+    }
+
+    private Mono<Void> sendError(ClientServerInputMultiplexer multiplexer, Exception exception) {
+      return ConnectionUtils.sendError(allocator, multiplexer, exception);
+    }
+
+    private Exception rejectedSetupError(Throwable err) {
+      String msg = err.getMessage();
+      return new RejectedSetupException(msg == null ? "rejected by server acceptor" : msg);
+    }
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import static io.rsocket.keepalive.KeepAliveSupport.ClientKeepAliveSupport;
 import static io.rsocket.keepalive.KeepAliveSupport.KeepAlive;
@@ -23,6 +23,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.collection.IntObjectMap;
+import io.rsocket.DuplexConnection;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
 import io.rsocket.exceptions.ConnectionErrorException;
 import io.rsocket.exceptions.Exceptions;
 import io.rsocket.frame.CancelFrameFlyweight;

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.collection.IntObjectMap;
+import io.rsocket.DuplexConnection;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.ResponderRSocket;
 import io.rsocket.exceptions.ApplicationErrorException;
 import io.rsocket.frame.*;
 import io.rsocket.frame.decoder.PayloadDecoder;

--- a/rsocket-core/src/main/java/io/rsocket/core/ReconnectMono.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ReconnectMono.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import java.time.Duration;
 import java.util.concurrent.CancellationException;

--- a/rsocket-core/src/main/java/io/rsocket/core/StreamIdSupplier.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/StreamIdSupplier.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.rsocket;
+package io.rsocket.core;
 
 import io.netty.util.collection.IntObjectMap;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;

--- a/rsocket-core/src/main/java/io/rsocket/core/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains core RSocket protocol, client and server implementation classes, including factories to
+ * create and configure them.
+ */
+@NonNullApi
+package io.rsocket.core;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/plugins/SocketAcceptorInterceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/SocketAcceptorInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rsocket-core/src/test/java/io/rsocket/core/AbstractSocketRule.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/AbstractSocketRule.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
+import io.rsocket.RSocket;
 import io.rsocket.test.util.TestDuplexConnection;
 import io.rsocket.test.util.TestSubscriber;
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/rsocket-core/src/test/java/io/rsocket/core/ConnectionSetupPayloadTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/ConnectionSetupPayloadTest.java
@@ -1,4 +1,4 @@
-package io.rsocket;
+package io.rsocket.core;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.rsocket.ConnectionSetupPayload;
+import io.rsocket.Payload;
 import io.rsocket.frame.SetupFrameFlyweight;
 import io.rsocket.util.DefaultPayload;
 import org.junit.jupiter.api.Test;
@@ -24,7 +26,7 @@ class ConnectionSetupPayloadTest {
     boolean leaseEnabled = true;
 
     ByteBuf frame = encodeSetupFrame(leaseEnabled, payload);
-    ConnectionSetupPayload setupPayload = ConnectionSetupPayload.create(frame);
+    ConnectionSetupPayload setupPayload = new DefaultConnectionSetupPayload(frame);
 
     assertTrue(setupPayload.willClientHonorLease());
     assertEquals(KEEP_ALIVE_INTERVAL, setupPayload.keepAliveInterval());
@@ -46,7 +48,7 @@ class ConnectionSetupPayloadTest {
     boolean leaseEnabled = false;
 
     ByteBuf frame = encodeSetupFrame(leaseEnabled, payload);
-    ConnectionSetupPayload setupPayload = ConnectionSetupPayload.create(frame);
+    ConnectionSetupPayload setupPayload = new DefaultConnectionSetupPayload(frame);
 
     assertFalse(setupPayload.willClientHonorLease());
     assertFalse(setupPayload.hasMetadata());
@@ -64,7 +66,7 @@ class ConnectionSetupPayloadTest {
     boolean leaseEnabled = false;
 
     ByteBuf frame = encodeSetupFrame(leaseEnabled, payload);
-    ConnectionSetupPayload setupPayload = ConnectionSetupPayload.create(frame);
+    ConnectionSetupPayload setupPayload = new DefaultConnectionSetupPayload(frame);
 
     assertFalse(setupPayload.willClientHonorLease());
     assertTrue(setupPayload.hasMetadata());

--- a/rsocket-core/src/test/java/io/rsocket/core/KeepAliveTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/KeepAliveTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import static io.rsocket.keepalive.KeepAliveHandler.DefaultKeepAliveHandler;
 import static io.rsocket.keepalive.KeepAliveHandler.ResumableKeepAliveHandler;
@@ -22,6 +22,7 @@ import static io.rsocket.keepalive.KeepAliveHandler.ResumableKeepAliveHandler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.rsocket.RSocket;
 import io.rsocket.exceptions.ConnectionErrorException;
 import io.rsocket.frame.FrameHeaderFlyweight;
 import io.rsocket.frame.FrameType;

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketLeaseTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketLeaseTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import static io.rsocket.frame.FrameType.ERROR;
 import static io.rsocket.frame.FrameType.SETUP;
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.rsocket.*;
 import io.rsocket.exceptions.Exceptions;
 import io.rsocket.exceptions.MissingLeaseException;
 import io.rsocket.frame.FrameHeaderFlyweight;

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketReconnectTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketReconnectTest.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.rsocket;
+package io.rsocket.core;
 
 import static org.junit.Assert.assertEquals;
 
+import io.rsocket.RSocket;
+import io.rsocket.RSocketFactory;
 import io.rsocket.test.util.TestClientTransport;
 import io.rsocket.transport.ClientTransport;
 import java.io.UncheckedIOException;

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.rsocket.RSocket;
 import io.rsocket.frame.FrameHeaderFlyweight;
 import io.rsocket.frame.FrameType;
 import io.rsocket.frame.decoder.PayloadDecoder;

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTerminationTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTerminationTest.java
@@ -1,6 +1,8 @@
-package io.rsocket;
+package io.rsocket.core;
 
-import io.rsocket.RSocketRequesterTest.ClientSocketRule;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.core.RSocketRequesterTest.ClientSocketRule;
 import io.rsocket.util.EmptyPayload;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import static io.rsocket.frame.FrameHeaderFlyweight.frameType;
 import static io.rsocket.frame.FrameType.*;
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.rsocket.Payload;
 import io.rsocket.exceptions.ApplicationErrorException;
 import io.rsocket.exceptions.RejectedSetupException;
 import io.rsocket.frame.*;

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import static io.rsocket.frame.FrameHeaderFlyweight.frameType;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,6 +23,9 @@ import static org.hamcrest.Matchers.*;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.rsocket.AbstractRSocket;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
 import io.rsocket.frame.*;
 import io.rsocket.lease.ResponderLeaseHandler;
 import io.rsocket.test.util.TestDuplexConnection;

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -23,6 +23,9 @@ import static org.mockito.Mockito.verify;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.rsocket.AbstractRSocket;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
 import io.rsocket.exceptions.ApplicationErrorException;
 import io.rsocket.exceptions.CustomRSocketException;
 import io.rsocket.lease.RequesterLeaseHandler;

--- a/rsocket-core/src/test/java/io/rsocket/core/ReconnectMonoTests.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/ReconnectMonoTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import static org.junit.Assert.assertEquals;
 

--- a/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
@@ -1,10 +1,11 @@
-package io.rsocket;
+package io.rsocket.core;
 
 import static io.rsocket.transport.ServerTransport.ConnectionAcceptor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.rsocket.*;
 import io.rsocket.exceptions.Exceptions;
 import io.rsocket.exceptions.RejectedSetupException;
 import io.rsocket.frame.ErrorFrameFlyweight;

--- a/rsocket-core/src/test/java/io/rsocket/core/StreamIdSupplierTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/StreamIdSupplierTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket;
+package io.rsocket.core;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/rsocket-core/src/test/java/io/rsocket/core/TestingStuff.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/TestingStuff.java
@@ -1,4 +1,4 @@
-package io.rsocket;
+package io.rsocket.core;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -16,6 +16,6 @@ public class TestingStuff {
     ByteBuf byteBuf = Unpooled.wrappedBuffer(ByteBufUtil.decodeHexDump(f1));
     System.out.println(ByteBufUtil.prettyHexDump(byteBuf));
 
-    ConnectionSetupPayload.create(byteBuf);
+    new DefaultConnectionSetupPayload(byteBuf);
   }
 }


### PR DESCRIPTION
The top-level `io.rsocket` package is at the center of a large package cycle because it contains both high level abstractions, accessed by everything, and also core protocol implementations classes that access everything:

![before](https://user-images.githubusercontent.com/401908/78829150-c0f16400-79dd-11ea-8dee-ad52a6c254b4.png)

This change extracts interfaces for `ClientRSocketFactory`, `ServerRSocketFactory`, and `ConnectionSetupPayload`, and moves the core implementations into a sub-package without references to it from the top-level package. After the changes:

![after](https://user-images.githubusercontent.com/401908/78829633-994ecb80-79de-11ea-9350-f5af85768ef6.png)

This isn't the end of it but it helps quite a bit while keeping the refactoring functionally neutral and backwards compatible.