### PR TITLE
Restore ConnectionSetupPayload as abstract class

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/ConnectionSetupPayload.java
+++ b/rsocket-core/src/main/java/io/rsocket/ConnectionSetupPayload.java
@@ -13,31 +13,60 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.rsocket;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.ReferenceCounted;
+import io.netty.util.AbstractReferenceCounted;
+import io.rsocket.core.DefaultConnectionSetupPayload;
 import javax.annotation.Nullable;
 
 /**
  * Exposes information from the {@code SETUP} frame to a server, as well as to client responders.
  */
-public interface ConnectionSetupPayload extends ReferenceCounted, Payload {
+public abstract class ConnectionSetupPayload extends AbstractReferenceCounted implements Payload {
 
-  String metadataMimeType();
+  public abstract String metadataMimeType();
 
-  String dataMimeType();
+  public abstract String dataMimeType();
 
-  int keepAliveInterval();
+  public abstract int keepAliveInterval();
 
-  int keepAliveMaxLifetime();
+  public abstract int keepAliveMaxLifetime();
 
-  int getFlags();
+  public abstract int getFlags();
 
-  boolean willClientHonorLease();
+  public abstract boolean willClientHonorLease();
 
-  boolean isResumeEnabled();
+  public abstract boolean isResumeEnabled();
 
   @Nullable
-  ByteBuf resumeToken();
+  public abstract ByteBuf resumeToken();
+
+  @Override
+  public ConnectionSetupPayload retain() {
+    super.retain();
+    return this;
+  }
+
+  @Override
+  public ConnectionSetupPayload retain(int increment) {
+    super.retain(increment);
+    return this;
+  }
+
+  @Override
+  public abstract ConnectionSetupPayload touch();
+
+  /**
+   * Create a {@code ConnectionSetupPayload}.
+   *
+   * @deprecated as of 1.0 RC7. Please, use {@link
+   *     DefaultConnectionSetupPayload#DefaultConnectionSetupPayload(ByteBuf)
+   *     DefaultConnectionSetupPayload} constructor.
+   */
+  @Deprecated
+  public static ConnectionSetupPayload create(final ByteBuf setupFrame) {
+    return new DefaultConnectionSetupPayload(setupFrame);
+  }
 }

--- a/rsocket-core/src/main/java/io/rsocket/core/DefaultConnectionSetupPayload.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/DefaultConnectionSetupPayload.java
@@ -17,14 +17,15 @@
 package io.rsocket.core;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.AbstractReferenceCounted;
 import io.rsocket.ConnectionSetupPayload;
 import io.rsocket.frame.FrameHeaderFlyweight;
 import io.rsocket.frame.SetupFrameFlyweight;
 
-/** Default implementation of {@link ConnectionSetupPayload}. */
-class DefaultConnectionSetupPayload extends AbstractReferenceCounted
-    implements ConnectionSetupPayload {
+/**
+ * Default implementation of {@link ConnectionSetupPayload}. Primarily for internal use within
+ * RSocket Java but may be created in an application, e.g. for testing purposes.
+ */
+public class DefaultConnectionSetupPayload extends ConnectionSetupPayload {
 
   private final ByteBuf setupFrame;
 
@@ -33,30 +34,28 @@ class DefaultConnectionSetupPayload extends AbstractReferenceCounted
   }
 
   @Override
-  public ConnectionSetupPayload retain() {
-    super.retain();
-    return this;
-  }
-
-  @Override
-  public ConnectionSetupPayload retain(int increment) {
-    super.retain(increment);
-    return this;
-  }
-
-  @Override
   public boolean hasMetadata() {
     return FrameHeaderFlyweight.hasMetadata(setupFrame);
   }
 
   @Override
-  public int keepAliveInterval() {
-    return SetupFrameFlyweight.keepAliveInterval(setupFrame);
+  public ByteBuf sliceMetadata() {
+    return SetupFrameFlyweight.metadata(setupFrame);
   }
 
   @Override
-  public int keepAliveMaxLifetime() {
-    return SetupFrameFlyweight.keepAliveMaxLifetime(setupFrame);
+  public ByteBuf sliceData() {
+    return SetupFrameFlyweight.data(setupFrame);
+  }
+
+  @Override
+  public ByteBuf data() {
+    return sliceData();
+  }
+
+  @Override
+  public ByteBuf metadata() {
+    return sliceMetadata();
   }
 
   @Override
@@ -67,6 +66,16 @@ class DefaultConnectionSetupPayload extends AbstractReferenceCounted
   @Override
   public String dataMimeType() {
     return SetupFrameFlyweight.dataMimeType(setupFrame);
+  }
+
+  @Override
+  public int keepAliveInterval() {
+    return SetupFrameFlyweight.keepAliveInterval(setupFrame);
+  }
+
+  @Override
+  public int keepAliveMaxLifetime() {
+    return SetupFrameFlyweight.keepAliveMaxLifetime(setupFrame);
   }
 
   @Override
@@ -104,25 +113,5 @@ class DefaultConnectionSetupPayload extends AbstractReferenceCounted
   @Override
   protected void deallocate() {
     setupFrame.release();
-  }
-
-  @Override
-  public ByteBuf sliceMetadata() {
-    return SetupFrameFlyweight.metadata(setupFrame);
-  }
-
-  @Override
-  public ByteBuf sliceData() {
-    return SetupFrameFlyweight.data(setupFrame);
-  }
-
-  @Override
-  public ByteBuf data() {
-    return sliceData();
-  }
-
-  @Override
-  public ByteBuf metadata() {
-    return sliceMetadata();
   }
 }


### PR DESCRIPTION
Follow-up fix for 0ac54d4b. 

Changing `ConnectionSetupPayload` from abstract class to interface is problematic when framework code compiled against newer RSocket is used in an application on existing version. It is now restored as an abstract class. `DefaultConnectionSetupPayload` however remains in the "core" sub-package to avoid the package cycle with "frame".