### PR TITLE
Removes redundant frames being sent

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -261,9 +261,7 @@ class RSocketRequester implements RSocket {
                   @Nonnull SignalType signalType,
                   @Nullable Payload element,
                   @Nullable Throwable e) {
-                if (signalType == SignalType.ON_ERROR) {
-                  sendProcessor.onNext(ErrorFrameFlyweight.encode(allocator, streamId, e));
-                } else if (signalType == SignalType.CANCEL) {
+                if (signalType == SignalType.CANCEL) {
                   sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
                 }
                 removeStreamReceiver(streamId);

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -174,8 +174,8 @@ public class RSocketRequesterTest {
     verify(responseSub).onError(any(ApplicationErrorException.class));
 
     Assertions.assertThat(rule.connection.getSent())
-        // requestResponseFrame FIXME
-        //        .hasSize(1)
+        // requestResponseFrame
+        .hasSize(1)
         .allMatch(ReferenceCounted::release);
 
     rule.assertHasNoLeaks();
@@ -356,8 +356,6 @@ public class RSocketRequesterTest {
                               .isInstanceOf(IllegalArgumentException.class)
                               .hasMessage(INVALID_PAYLOAD_ERROR_MESSAGE))
                   .verify();
-              // FIXME: should be removed
-              Assertions.assertThat(rule.connection.getSent()).allMatch(bb -> bb.release());
               rule.assertHasNoLeaks();
             });
   }


### PR DESCRIPTION
Removed frames should not be sent to the remote side upon receiving some specific signals, thus were removed accordingly without braking logical functionality

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>