### PR TITLE
fixes requestChannel and ensure support of half-closed state

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -604,8 +604,8 @@ class RSocketRequester implements RSocket {
         {
           Subscription sender = senders.get(streamId);
           if (sender != null) {
-            long n = RequestNFrameFlyweight.requestN(frame);
-            sender.request(n);
+            int n = RequestNFrameFlyweight.requestN(frame);
+            sender.request(n >= Integer.MAX_VALUE ? Long.MAX_VALUE : n);
           }
           break;
         }

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -560,46 +560,58 @@ class RSocketRequester implements RSocket {
 
   private void handleFrame(int streamId, FrameType type, ByteBuf frame) {
     Subscriber<Payload> receiver = receivers.get(streamId);
-    if (receiver == null) {
-      handleMissingResponseProcessor(streamId, type, frame);
-    } else {
-      switch (type) {
-        case ERROR:
-          receiver.onError(Exceptions.from(streamId, frame));
-          receivers.remove(streamId);
-          break;
-        case NEXT_COMPLETE:
-          receiver.onNext(payloadDecoder.apply(frame));
-          receiver.onComplete();
-          break;
-        case CANCEL:
-          {
-            Subscription sender = senders.remove(streamId);
-            if (sender != null) {
-              sender.cancel();
-            }
-            break;
+    switch (type) {
+      case NEXT:
+        if (receiver == null) {
+          handleMissingResponseProcessor(streamId, type, frame);
+          return;
+        }
+        receiver.onNext(payloadDecoder.apply(frame));
+        break;
+      case NEXT_COMPLETE:
+        if (receiver == null) {
+          handleMissingResponseProcessor(streamId, type, frame);
+          return;
+        }
+        receiver.onNext(payloadDecoder.apply(frame));
+        receiver.onComplete();
+        break;
+      case COMPLETE:
+        if (receiver == null) {
+          handleMissingResponseProcessor(streamId, type, frame);
+          return;
+        }
+        receiver.onComplete();
+        receivers.remove(streamId);
+        break;
+      case ERROR:
+        if (receiver == null) {
+          handleMissingResponseProcessor(streamId, type, frame);
+          return;
+        }
+        receiver.onError(Exceptions.from(streamId, frame));
+        receivers.remove(streamId);
+        break;
+      case CANCEL:
+        {
+          Subscription sender = senders.remove(streamId);
+          if (sender != null) {
+            sender.cancel();
           }
-        case NEXT:
-          receiver.onNext(payloadDecoder.apply(frame));
           break;
-        case REQUEST_N:
-          {
-            Subscription sender = senders.get(streamId);
-            if (sender != null) {
-              int n = RequestNFrameFlyweight.requestN(frame);
-              sender.request(n >= Integer.MAX_VALUE ? Long.MAX_VALUE : n);
-            }
-            break;
+        }
+      case REQUEST_N:
+        {
+          Subscription sender = senders.get(streamId);
+          if (sender != null) {
+            long n = RequestNFrameFlyweight.requestN(frame);
+            sender.request(n);
           }
-        case COMPLETE:
-          receiver.onComplete();
-          receivers.remove(streamId);
           break;
-        default:
-          throw new IllegalStateException(
-              "Client received supported frame on stream " + streamId + ": " + frame.toString());
-      }
+        }
+      default:
+        throw new IllegalStateException(
+            "Client received supported frame on stream " + streamId + ": " + frame.toString());
     }
   }
 

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
@@ -182,7 +182,7 @@ public class RSocketTest {
   }
 
   @Test
-  public void requestChannelIndependentTerminationOfUpstreamAndDownstreamTest1() {
+  public void requestChannelCase_StreamIsTerminatedAfterBothSidesSentCompletion1() {
     TestPublisher<Payload> outerPublisher = TestPublisher.create();
     AssertSubscriber<Payload> outerAssertSubscriber = new AssertSubscriber<>(0);
 
@@ -202,7 +202,7 @@ public class RSocketTest {
   }
 
   @Test
-  public void requestChannelIndependentTerminationOfUpstreamAndDownstreamTest2() {
+  public void requestChannelCase_StreamIsTerminatedAfterBothSidesSentCompletion2() {
     TestPublisher<Payload> outerPublisher = TestPublisher.create();
     AssertSubscriber<Payload> outerAssertSubscriber = new AssertSubscriber<>(0);
 
@@ -222,7 +222,8 @@ public class RSocketTest {
   }
 
   @Test
-  public void requestChannelIndependentTerminationOfUpstreamAndDownstreamTest3() {
+  public void
+      requestChannelCase_CancellationFromResponderShouldLeaveStreamInHalfClosedStateWithNextCompletionPossibleFromRequester() {
     TestPublisher<Payload> outerPublisher = TestPublisher.create();
     AssertSubscriber<Payload> outerAssertSubscriber = new AssertSubscriber<>(0);
 
@@ -242,7 +243,8 @@ public class RSocketTest {
   }
 
   @Test
-  public void requestChannelIndependentTerminationOfUpstreamAndDownstreamTest4() {
+  public void
+      requestChannelCase_CompletionFromRequesterShouldLeaveStreamInHalfClosedStateWithNextCancellationPossibleFromResponder() {
     TestPublisher<Payload> outerPublisher = TestPublisher.create();
     AssertSubscriber<Payload> outerAssertSubscriber = new AssertSubscriber<>(0);
 
@@ -262,7 +264,8 @@ public class RSocketTest {
   }
 
   @Test
-  public void requestChannelIndependentTerminationOfUpstreamAndDownstreamTest5() {
+  public void
+      requestChannelCase_ensureThatRequesterSubscriberCancellationTerminatesStreamsOnBothSides() {
     TestPublisher<Payload> outerPublisher = TestPublisher.create();
     AssertSubscriber<Payload> outerAssertSubscriber = new AssertSubscriber<>(0);
 


### PR DESCRIPTION
This PR fixes a bug on the requester side and ensures that the requester is capable of handling requests when its publisher has already sent or received completion.

The Bug here is in the fact that RequestChannel on the requester side has 2 maps to track the state:
 - `receivers` which is there to receive OnNext/OnError/OnComplete signals 
 - `senders` -  requestChannel specific map to hold a subscription and receive the request/cancel signals from the remote.

This means if one is absent and another is present - the stream is in the half-closed state.

Originally, we had that -> https://github.com/rsocket/rsocket-java/blob/develop/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java#L562

```
Subscriber<Payload> receiver = receivers.get(streamId);
    if (receiver == null) {
      handleMissingResponseProcessor(streamId, type, frame);
    }
```

which means that if there is no receiver - it is impossible to handle any frames even though the sender map contains handling subscriptions.

Due to the spec, there is a half-closed state when the responder may send incomplete, but the requester may still continue its stream and send onXXX signals along with being able to receive demand (requestN) and cancel frames.

OUTER PUBLISHER COMPLETED - INNER PUBLISHER CAN SEND
OUTER PUBLISHER CANCELLED - INNER PUBLISHER CAN SEND
INNER PUBLISHER COMPLETED - OUTER PUBLISHER CAN SEND
INNER PUBLISHER CANCELLED - the WHOLE CHAIN IS TERMINATED

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>