### PR TITLE
Refactors how `ByteBufAllocator` is used and setup

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/DuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/DuplexConnection.java
@@ -17,6 +17,7 @@
 package io.rsocket;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import java.nio.channels.ClosedChannelException;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -77,6 +78,13 @@ public interface DuplexConnection extends Availability, Closeable {
    * @return Stream of all {@code Frame}s received.
    */
   Flux<ByteBuf> receive();
+
+  /**
+   * Returns the assigned {@link ByteBufAllocator}.
+   *
+   * @return the {@link ByteBufAllocator}
+   */
+  ByteBufAllocator alloc();
 
   @Override
   default double availability() {

--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -113,8 +113,29 @@ public final class RSocketFactory {
       this.connector = connector;
     }
 
+    /**
+     * @deprecated this method is deprecated and deliberately has no effect anymore. Right now, in
+     *     order configure the custom {@link ByteBufAllocator} it is recommended to use the
+     *     following setup for Reactor Netty based transport: <br>
+     *     1. For Client: <br>
+     *     <pre>{@code
+     * TcpClient.create()
+     *          ...
+     *          .bootstrap(bootstrap -> bootstrap.option(ChannelOption.ALLOCATOR, clientAllocator))
+     * }</pre>
+     *     <br>
+     *     2. For server: <br>
+     *     <pre>{@code
+     * TcpServer.create()
+     *          ...
+     *          .bootstrap(serverBootstrap -> serverBootstrap.childOption(ChannelOption.ALLOCATOR, serverAllocator))
+     * }</pre>
+     *     Or in case of local transport, to use corresponding factory method {@code
+     *     LocalClientTransport.creat(String, ByteBufAllocator)}
+     * @param allocator instance of {@link ByteBufAllocator}
+     * @return this factory instance
+     */
     public ClientRSocketFactory byteBufAllocator(ByteBufAllocator allocator) {
-      connector.byteBufAllocator(allocator);
       return this;
     }
 
@@ -395,8 +416,30 @@ public final class RSocketFactory {
       this.server = server;
     }
 
+    /**
+     * @deprecated this method is deprecated and deliberately has no effect anymore. Right now, in
+     *     order configure the custom {@link ByteBufAllocator} it is recommended to use the
+     *     following setup for Reactor Netty based transport: <br>
+     *     1. For Client: <br>
+     *     <pre>{@code
+     * TcpClient.create()
+     *          ...
+     *          .bootstrap(bootstrap -> bootstrap.option(ChannelOption.ALLOCATOR, clientAllocator))
+     * }</pre>
+     *     <br>
+     *     2. For server: <br>
+     *     <pre>{@code
+     * TcpServer.create()
+     *          ...
+     *          .bootstrap(serverBootstrap -> serverBootstrap.childOption(ChannelOption.ALLOCATOR, serverAllocator))
+     * }</pre>
+     *     Or in case of local transport, to use corresponding factory method {@code
+     *     LocalClientTransport.creat(String, ByteBufAllocator)}
+     * @param allocator instance of {@link ByteBufAllocator}
+     * @return this factory instance
+     */
+    @Deprecated
     public ServerRSocketFactory byteBufAllocator(ByteBufAllocator allocator) {
-      server.byteBufAllocator(allocator);
       return this;
     }
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -71,7 +71,7 @@ public class RSocketConnector {
   private PayloadDecoder payloadDecoder = PayloadDecoder.DEFAULT;
 
   private Consumer<Throwable> errorConsumer = Throwable::printStackTrace;
-  private ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+  private ByteBufAllocator allocator = null;
 
   private RSocketConnector() {}
 
@@ -245,6 +245,7 @@ public class RSocketConnector {
    * @deprecated this is deprecated with no replacement and will be removed after {@link
    *     io.rsocket.RSocketFactory} is removed.
    */
+  @Deprecated
   public RSocketConnector byteBufAllocator(ByteBufAllocator allocator) {
     Objects.requireNonNull(allocator);
     this.allocator = allocator;
@@ -304,7 +305,7 @@ public class RSocketConnector {
 
               ByteBuf setupFrame =
                   SetupFrameFlyweight.encode(
-                      allocator,
+                      allocator == null ? wrappedConnection.alloc() : allocator,
                       leaseEnabled,
                       (int) keepAliveInterval.toMillis(),
                       (int) keepAliveMaxLifeTime.toMillis(),
@@ -326,7 +327,7 @@ public class RSocketConnector {
                             leaseEnabled
                                 ? new ResponderLeaseHandler.Impl<>(
                                     CLIENT_TAG,
-                                    allocator,
+                                    allocator == null ? wrappedConnection.alloc() : allocator,
                                     leases.sender(),
                                     errorConsumer,
                                     leases.stats())
@@ -364,7 +365,6 @@ public class RSocketConnector {
     ClientRSocketSession session =
         new ClientRSocketSession(
             connection,
-            allocator,
             resume.getSessionDuration(),
             resume.getResumeStrategySupplier(),
             resume.getStoreFactory(CLIENT_TAG).apply(resumeToken),

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -117,33 +117,8 @@ class RSocketRequester implements RSocket {
       int keepAliveAckTimeout,
       @Nullable KeepAliveHandler keepAliveHandler,
       RequesterLeaseHandler leaseHandler) {
-    this(
-        null,
-        connection,
-        payloadDecoder,
-        errorConsumer,
-        streamIdSupplier,
-        mtu,
-        keepAliveTickPeriod,
-        keepAliveAckTimeout,
-        keepAliveHandler,
-        leaseHandler);
-  }
-
-  @Deprecated
-  RSocketRequester(
-      @Nullable ByteBufAllocator allocator,
-      DuplexConnection connection,
-      PayloadDecoder payloadDecoder,
-      Consumer<Throwable> errorConsumer,
-      StreamIdSupplier streamIdSupplier,
-      int mtu,
-      int keepAliveTickPeriod,
-      int keepAliveAckTimeout,
-      @Nullable KeepAliveHandler keepAliveHandler,
-      RequesterLeaseHandler leaseHandler) {
     this.connection = connection;
-    this.allocator = allocator == null ? connection.alloc() : allocator;
+    this.allocator = connection.alloc();
     this.payloadDecoder = payloadDecoder;
     this.errorConsumer = errorConsumer;
     this.streamIdSupplier = streamIdSupplier;

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -108,7 +108,6 @@ class RSocketRequester implements RSocket {
   private volatile Throwable terminationError;
 
   RSocketRequester(
-      ByteBufAllocator allocator,
       DuplexConnection connection,
       PayloadDecoder payloadDecoder,
       Consumer<Throwable> errorConsumer,
@@ -118,8 +117,33 @@ class RSocketRequester implements RSocket {
       int keepAliveAckTimeout,
       @Nullable KeepAliveHandler keepAliveHandler,
       RequesterLeaseHandler leaseHandler) {
-    this.allocator = allocator;
+    this(
+        null,
+        connection,
+        payloadDecoder,
+        errorConsumer,
+        streamIdSupplier,
+        mtu,
+        keepAliveTickPeriod,
+        keepAliveAckTimeout,
+        keepAliveHandler,
+        leaseHandler);
+  }
+
+  @Deprecated
+  RSocketRequester(
+      @Nullable ByteBufAllocator allocator,
+      DuplexConnection connection,
+      PayloadDecoder payloadDecoder,
+      Consumer<Throwable> errorConsumer,
+      StreamIdSupplier streamIdSupplier,
+      int mtu,
+      int keepAliveTickPeriod,
+      int keepAliveAckTimeout,
+      @Nullable KeepAliveHandler keepAliveHandler,
+      RequesterLeaseHandler leaseHandler) {
     this.connection = connection;
+    this.allocator = allocator == null ? connection.alloc() : allocator;
     this.payloadDecoder = payloadDecoder;
     this.errorConsumer = errorConsumer;
     this.streamIdSupplier = streamIdSupplier;
@@ -141,7 +165,7 @@ class RSocketRequester implements RSocket {
 
     if (keepAliveTickPeriod != 0 && keepAliveHandler != null) {
       KeepAliveSupport keepAliveSupport =
-          new ClientKeepAliveSupport(allocator, keepAliveTickPeriod, keepAliveAckTimeout);
+          new ClientKeepAliveSupport(this.allocator, keepAliveTickPeriod, keepAliveAckTimeout);
       this.keepAliveFramesAcceptor =
           keepAliveHandler.start(
               keepAliveSupport, sendProcessor::onNextPrioritized, this::tryTerminateOnKeepAlive);

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -75,15 +75,26 @@ class RSocketResponder implements ResponderRSocket {
   private final ByteBufAllocator allocator;
 
   RSocketResponder(
-      ByteBufAllocator allocator,
       DuplexConnection connection,
       RSocket requestHandler,
       PayloadDecoder payloadDecoder,
       Consumer<Throwable> errorConsumer,
       ResponderLeaseHandler leaseHandler,
       int mtu) {
-    this.allocator = allocator;
+    this(null, connection, requestHandler, payloadDecoder, errorConsumer, leaseHandler, mtu);
+  }
+
+  @Deprecated
+  RSocketResponder(
+      @Nullable ByteBufAllocator allocator,
+      DuplexConnection connection,
+      RSocket requestHandler,
+      PayloadDecoder payloadDecoder,
+      Consumer<Throwable> errorConsumer,
+      ResponderLeaseHandler leaseHandler,
+      int mtu) {
     this.connection = connection;
+    this.allocator = allocator == null ? connection.alloc() : allocator;
     this.mtu = mtu;
 
     this.requestHandler = requestHandler;

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -81,20 +81,8 @@ class RSocketResponder implements ResponderRSocket {
       Consumer<Throwable> errorConsumer,
       ResponderLeaseHandler leaseHandler,
       int mtu) {
-    this(null, connection, requestHandler, payloadDecoder, errorConsumer, leaseHandler, mtu);
-  }
-
-  @Deprecated
-  RSocketResponder(
-      @Nullable ByteBufAllocator allocator,
-      DuplexConnection connection,
-      RSocket requestHandler,
-      PayloadDecoder payloadDecoder,
-      Consumer<Throwable> errorConsumer,
-      ResponderLeaseHandler leaseHandler,
-      int mtu) {
     this.connection = connection;
-    this.allocator = allocator == null ? connection.alloc() : allocator;
+    this.allocator = connection.alloc();
     this.mtu = mtu;
 
     this.requestHandler = requestHandler;

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
@@ -17,7 +17,6 @@
 package io.rsocket.core;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.AbstractRSocket;
 import io.rsocket.Closeable;
 import io.rsocket.ConnectionSetupPayload;
@@ -55,7 +54,6 @@ public final class RSocketServer {
 
   private Consumer<Throwable> errorConsumer = Throwable::printStackTrace;
   private PayloadDecoder payloadDecoder = PayloadDecoder.DEFAULT;
-  private ByteBufAllocator allocator = null;
 
   private RSocketServer() {}
 
@@ -111,17 +109,6 @@ public final class RSocketServer {
   @Deprecated
   public RSocketServer errorConsumer(Consumer<Throwable> errorConsumer) {
     this.errorConsumer = errorConsumer;
-    return this;
-  }
-
-  /**
-   * @deprecated this is deprecated with no replacement and will be removed after {@link
-   *     io.rsocket.RSocketFactory} is removed.
-   */
-  @Deprecated
-  public RSocketServer byteBufAllocator(ByteBufAllocator allocator) {
-    Objects.requireNonNull(allocator);
-    this.allocator = allocator;
     return this;
   }
 
@@ -228,7 +215,6 @@ public final class RSocketServer {
 
           RSocket rSocketRequester =
               new RSocketRequester(
-                  allocator,
                   wrappedMultiplexer.asServerConnection(),
                   payloadDecoder,
                   errorConsumer,
@@ -258,7 +244,7 @@ public final class RSocketServer {
                         leaseEnabled
                             ? new ResponderLeaseHandler.Impl<>(
                                 SERVER_TAG,
-                                allocator == null ? connection.alloc() : allocator,
+                                connection.alloc(),
                                 leases.sender(),
                                 errorConsumer,
                                 leases.stats())
@@ -266,7 +252,6 @@ public final class RSocketServer {
 
                     RSocket rSocketResponder =
                         new RSocketResponder(
-                            allocator,
                             connection,
                             wrappedRSocketHandler,
                             payloadDecoder,

--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/ReassemblyDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/ReassemblyDuplexConnection.java
@@ -37,13 +37,11 @@ public class ReassemblyDuplexConnection implements DuplexConnection {
   private final FrameReassembler frameReassembler;
   private final boolean decodeLength;
 
-  public ReassemblyDuplexConnection(
-      DuplexConnection delegate, ByteBufAllocator allocator, boolean decodeLength) {
+  public ReassemblyDuplexConnection(DuplexConnection delegate, boolean decodeLength) {
     Objects.requireNonNull(delegate, "delegate must not be null");
-    Objects.requireNonNull(allocator, "byteBufAllocator must not be null");
     this.decodeLength = decodeLength;
     this.delegate = delegate;
-    this.frameReassembler = new FrameReassembler(allocator);
+    this.frameReassembler = new FrameReassembler(delegate.alloc());
 
     delegate.onClose().doFinally(s -> frameReassembler.dispose()).subscribe();
   }
@@ -75,6 +73,11 @@ public class ReassemblyDuplexConnection implements DuplexConnection {
               ByteBuf decode = decode(byteBuf);
               frameReassembler.reassembleFrame(decode, sink);
             });
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return delegate.alloc();
   }
 
   @Override

--- a/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
@@ -17,6 +17,7 @@
 package io.rsocket.internal;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Closeable;
 import io.rsocket.DuplexConnection;
 import io.rsocket.frame.FrameHeaderFlyweight;
@@ -199,6 +200,11 @@ public class ClientServerInputMultiplexer implements Closeable {
                           return f;
                         }
                       }));
+    }
+
+    @Override
+    public ByteBufAllocator alloc() {
+      return source.alloc();
     }
 
     @Override

--- a/rsocket-core/src/main/java/io/rsocket/resume/ClientRSocketSession.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ClientRSocketSession.java
@@ -41,13 +41,12 @@ public class ClientRSocketSession implements RSocketSession<Mono<DuplexConnectio
 
   public ClientRSocketSession(
       DuplexConnection duplexConnection,
-      ByteBufAllocator allocator,
       Duration resumeSessionDuration,
       Supplier<ResumeStrategy> resumeStrategy,
       ResumableFramesStore resumableFramesStore,
       Duration resumeStreamTimeout,
       boolean cleanupStoreOnKeepAlive) {
-    this.allocator = allocator;
+    this.allocator = duplexConnection.alloc();
     this.resumableConnection =
         new ResumableDuplexConnection(
             "client",

--- a/rsocket-core/src/main/java/io/rsocket/resume/ResumableDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ResumableDuplexConnection.java
@@ -17,6 +17,7 @@
 package io.rsocket.resume;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Closeable;
 import io.rsocket.DuplexConnection;
 import io.rsocket.frame.FrameHeaderFlyweight;
@@ -103,6 +104,11 @@ public class ResumableDuplexConnection implements DuplexConnection, ResumeStateH
             .cache();
 
     reconnect(duplexConnection);
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return curConnection.alloc();
   }
 
   public void disconnect() {

--- a/rsocket-core/src/main/java/io/rsocket/resume/ServerRSocketSession.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ServerRSocketSession.java
@@ -43,13 +43,12 @@ public class ServerRSocketSession implements RSocketSession<DuplexConnection> {
 
   public ServerRSocketSession(
       DuplexConnection duplexConnection,
-      ByteBufAllocator allocator,
       Duration resumeSessionDuration,
       Duration resumeStreamTimeout,
       Function<? super ByteBuf, ? extends ResumableFramesStore> resumeStoreFactory,
       ByteBuf resumeToken,
       boolean cleanupStoreOnKeepAlive) {
-    this.allocator = allocator;
+    this.allocator = duplexConnection.alloc();
     this.resumeToken = resumeToken;
     this.resumableConnection =
         new ResumableDuplexConnection(

--- a/rsocket-core/src/main/java/io/rsocket/util/DuplexConnectionProxy.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/DuplexConnectionProxy.java
@@ -17,6 +17,7 @@
 package io.rsocket.util;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -42,6 +43,11 @@ public class DuplexConnectionProxy implements DuplexConnection {
   @Override
   public double availability() {
     return connection.availability();
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return connection.alloc();
   }
 
   @Override

--- a/rsocket-core/src/test/java/io/rsocket/core/AbstractSocketRule.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/AbstractSocketRule.java
@@ -41,10 +41,10 @@ public abstract class AbstractSocketRule<T extends RSocket> extends ExternalReso
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {
-        connection = new TestDuplexConnection();
+        allocator = LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
+        connection = new TestDuplexConnection(allocator);
         connectSub = TestSubscriber.create();
         errors = new ConcurrentLinkedQueue<>();
-        allocator = LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
         init();
         base.evaluate();
       }
@@ -52,10 +52,10 @@ public abstract class AbstractSocketRule<T extends RSocket> extends ExternalReso
   }
 
   protected void init() {
-    socket = newRSocket(allocator);
+    socket = newRSocket();
   }
 
-  protected abstract T newRSocket(LeaksTrackingByteBufAllocator allocator);
+  protected abstract T newRSocket();
 
   public void assertNoConnectionErrors() {
     if (errors.size() > 1) {

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
@@ -19,6 +19,7 @@ package io.rsocket.core;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.RSocket;
+import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.frame.FrameHeaderFlyweight;
 import io.rsocket.frame.FrameType;
 import io.rsocket.frame.decoder.PayloadDecoder;
@@ -52,15 +53,16 @@ class RSocketRequesterSubscribersTest {
               FrameType.REQUEST_STREAM,
               FrameType.REQUEST_CHANNEL));
 
+  private LeaksTrackingByteBufAllocator allocator;
   private RSocket rSocketRequester;
   private TestDuplexConnection connection;
 
   @BeforeEach
   void setUp() {
-    connection = new TestDuplexConnection();
+    allocator = LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
+    connection = new TestDuplexConnection(allocator);
     rSocketRequester =
         new RSocketRequester(
-            ByteBufAllocator.DEFAULT,
             connection,
             PayloadDecoder.DEFAULT,
             err -> {},

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -41,7 +41,6 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCounted;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
-import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.exceptions.ApplicationErrorException;
 import io.rsocket.exceptions.CustomRSocketException;
 import io.rsocket.exceptions.RejectedSetupException;
@@ -741,9 +740,8 @@ public class RSocketRequesterTest {
 
   public static class ClientSocketRule extends AbstractSocketRule<RSocketRequester> {
     @Override
-    protected RSocketRequester newRSocket(LeaksTrackingByteBufAllocator allocator) {
+    protected RSocketRequester newRSocket() {
       return new RSocketRequester(
-          allocator,
           connection,
           PayloadDecoder.ZERO_COPY,
           throwable -> errors.add(throwable),

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
@@ -38,7 +38,6 @@ import io.netty.util.ReferenceCounted;
 import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
-import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.frame.CancelFrameFlyweight;
 import io.rsocket.frame.ErrorFrameFlyweight;
 import io.rsocket.frame.FrameHeaderFlyweight;
@@ -735,7 +734,7 @@ public class RSocketResponderTest {
 
     public void setAcceptingSocket(RSocket acceptingSocket) {
       this.acceptingSocket = acceptingSocket;
-      connection = new TestDuplexConnection();
+      connection = new TestDuplexConnection(alloc());
       connectSub = TestSubscriber.create();
       errors = new ConcurrentLinkedQueue<>();
       this.prefetch = Integer.MAX_VALUE;
@@ -744,7 +743,7 @@ public class RSocketResponderTest {
 
     public void setAcceptingSocket(RSocket acceptingSocket, int prefetch) {
       this.acceptingSocket = acceptingSocket;
-      connection = new TestDuplexConnection();
+      connection = new TestDuplexConnection(alloc());
       connectSub = TestSubscriber.create();
       errors = new ConcurrentLinkedQueue<>();
       this.prefetch = prefetch;
@@ -752,9 +751,8 @@ public class RSocketResponderTest {
     }
 
     @Override
-    protected RSocketResponder newRSocket(LeaksTrackingByteBufAllocator allocator) {
+    protected RSocketResponder newRSocket() {
       return new RSocketResponder(
-          allocator,
           connection,
           acceptingSocket,
           PayloadDecoder.ZERO_COPY,

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/ReassembleDuplexConnectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/ReassembleDuplexConnectionTest.java
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.rsocket.DuplexConnection;
+import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.frame.CancelFrameFlyweight;
 import io.rsocket.frame.FrameHeaderFlyweight;
 import io.rsocket.frame.FrameType;
@@ -51,7 +52,8 @@ final class ReassembleDuplexConnectionTest {
 
   private final DuplexConnection delegate = mock(DuplexConnection.class, RETURNS_SMART_NULLS);
 
-  private ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+  private LeaksTrackingByteBufAllocator allocator =
+      LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
 
   @DisplayName("reassembles data")
   @Test
@@ -82,8 +84,9 @@ final class ReassembleDuplexConnectionTest {
 
     when(delegate.receive()).thenReturn(Flux.fromIterable(byteBufs));
     when(delegate.onClose()).thenReturn(Mono.never());
+    when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, allocator, false)
+    new ReassemblyDuplexConnection(delegate, false)
         .receive()
         .as(StepVerifier::create)
         .assertNext(
@@ -146,8 +149,9 @@ final class ReassembleDuplexConnectionTest {
 
     when(delegate.receive()).thenReturn(Flux.fromIterable(byteBufs));
     when(delegate.onClose()).thenReturn(Mono.never());
+    when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, allocator, false)
+    new ReassemblyDuplexConnection(delegate, false)
         .receive()
         .as(StepVerifier::create)
         .assertNext(
@@ -213,8 +217,9 @@ final class ReassembleDuplexConnectionTest {
 
     when(delegate.receive()).thenReturn(Flux.fromIterable(byteBufs));
     when(delegate.onClose()).thenReturn(Mono.never());
+    when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, allocator, false)
+    new ReassemblyDuplexConnection(delegate, false)
         .receive()
         .as(StepVerifier::create)
         .assertNext(
@@ -234,8 +239,9 @@ final class ReassembleDuplexConnectionTest {
 
     when(delegate.receive()).thenReturn(Flux.just(encode));
     when(delegate.onClose()).thenReturn(Mono.never());
+    when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, allocator, false)
+    new ReassemblyDuplexConnection(delegate, false)
         .receive()
         .as(StepVerifier::create)
         .assertNext(
@@ -253,8 +259,9 @@ final class ReassembleDuplexConnectionTest {
 
     when(delegate.receive()).thenReturn(Flux.just(encode));
     when(delegate.onClose()).thenReturn(Mono.never());
+    when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, allocator, false)
+    new ReassemblyDuplexConnection(delegate, false)
         .receive()
         .as(StepVerifier::create)
         .assertNext(

--- a/rsocket-core/src/test/java/io/rsocket/internal/ClientServerInputMultiplexerTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/ClientServerInputMultiplexerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.frame.*;
 import io.rsocket.plugins.InitializingInterceptorRegistry;
 import io.rsocket.test.util.TestDuplexConnection;
@@ -32,12 +33,13 @@ import org.junit.Test;
 public class ClientServerInputMultiplexerTest {
   private TestDuplexConnection source;
   private ClientServerInputMultiplexer clientMultiplexer;
-  private ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+  private LeaksTrackingByteBufAllocator allocator =
+      LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
   private ClientServerInputMultiplexer serverMultiplexer;
 
   @Before
   public void setup() {
-    source = new TestDuplexConnection();
+    source = new TestDuplexConnection(allocator);
     clientMultiplexer =
         new ClientServerInputMultiplexer(source, new InitializingInterceptorRegistry(), true);
     serverMultiplexer =

--- a/rsocket-core/src/test/java/io/rsocket/test/util/LocalDuplexConnection.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/LocalDuplexConnection.java
@@ -17,6 +17,7 @@
 package io.rsocket.test.util;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.DirectProcessor;
@@ -25,17 +26,22 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 
 public class LocalDuplexConnection implements DuplexConnection {
+  private final ByteBufAllocator allocator;
   private final DirectProcessor<ByteBuf> send;
   private final DirectProcessor<ByteBuf> receive;
   private final MonoProcessor<Void> onClose;
   private final String name;
 
   public LocalDuplexConnection(
-      String name, DirectProcessor<ByteBuf> send, DirectProcessor<ByteBuf> receive) {
+      String name,
+      ByteBufAllocator allocator,
+      DirectProcessor<ByteBuf> send,
+      DirectProcessor<ByteBuf> receive) {
     this.name = name;
+    this.allocator = allocator;
     this.send = send;
     this.receive = receive;
-    onClose = MonoProcessor.create();
+    this.onClose = MonoProcessor.create();
   }
 
   @Override
@@ -50,6 +56,11 @@ public class LocalDuplexConnection implements DuplexConnection {
   @Override
   public Flux<ByteBuf> receive() {
     return receive.doOnNext(f -> System.out.println(name + " - " + f.toString()));
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return allocator;
   }
 
   @Override

--- a/rsocket-core/src/test/java/io/rsocket/test/util/TestClientTransport.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/TestClientTransport.java
@@ -1,12 +1,15 @@
 package io.rsocket.test.util;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
+import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.transport.ClientTransport;
 import reactor.core.publisher.Mono;
 
 public class TestClientTransport implements ClientTransport {
-
-  private final TestDuplexConnection testDuplexConnection = new TestDuplexConnection();
+  private final LeaksTrackingByteBufAllocator allocator =
+      LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
+  private final TestDuplexConnection testDuplexConnection = new TestDuplexConnection(allocator);
 
   @Override
   public Mono<DuplexConnection> connect(int mtu) {
@@ -15,5 +18,9 @@ public class TestClientTransport implements ClientTransport {
 
   public TestDuplexConnection testConnection() {
     return testDuplexConnection;
+  }
+
+  public LeaksTrackingByteBufAllocator alloc() {
+    return allocator;
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/test/util/TestDuplexConnection.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/TestDuplexConnection.java
@@ -17,6 +17,7 @@
 package io.rsocket.test.util;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -46,17 +47,19 @@ public class TestDuplexConnection implements DuplexConnection {
   private final FluxSink<ByteBuf> receivedSink;
   private final MonoProcessor<Void> onClose;
   private final ConcurrentLinkedQueue<Subscriber<ByteBuf>> sendSubscribers;
+  private final ByteBufAllocator allocator;
   private volatile double availability = 1;
   private volatile int initialSendRequestN = Integer.MAX_VALUE;
 
-  public TestDuplexConnection() {
-    sent = new LinkedBlockingQueue<>();
-    received = DirectProcessor.create();
-    receivedSink = received.sink();
-    sentPublisher = DirectProcessor.create();
-    sendSink = sentPublisher.sink();
-    sendSubscribers = new ConcurrentLinkedQueue<>();
-    onClose = MonoProcessor.create();
+  public TestDuplexConnection(ByteBufAllocator allocator) {
+    this.allocator = allocator;
+    this.sent = new LinkedBlockingQueue<>();
+    this.received = DirectProcessor.create();
+    this.receivedSink = received.sink();
+    this.sentPublisher = DirectProcessor.create();
+    this.sendSink = sentPublisher.sink();
+    this.sendSubscribers = new ConcurrentLinkedQueue<>();
+    this.onClose = MonoProcessor.create();
   }
 
   @Override
@@ -81,6 +84,11 @@ public class TestDuplexConnection implements DuplexConnection {
   @Override
   public Flux<ByteBuf> receive() {
     return received;
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return allocator;
   }
 
   @Override

--- a/rsocket-examples/src/main/java/io/rsocket/examples/transport/ws/WebSocketHeadersSample.java
+++ b/rsocket-examples/src/main/java/io/rsocket/examples/transport/ws/WebSocketHeadersSample.java
@@ -16,7 +16,6 @@
 
 package io.rsocket.examples.transport.ws;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.rsocket.AbstractRSocket;
 import io.rsocket.ConnectionSetupPayload;
@@ -65,9 +64,7 @@ public class WebSocketHeadersSample {
                           if (in.headers().containsValue("Authorization", "test", true)) {
                             DuplexConnection connection =
                                 new ReassemblyDuplexConnection(
-                                    new WebsocketDuplexConnection((Connection) in),
-                                    ByteBufAllocator.DEFAULT,
-                                    false);
+                                    new WebsocketDuplexConnection((Connection) in), false);
                             return acceptor.apply(connection).then(out.neverComplete());
                           }
 

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerDuplexConnection.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerDuplexConnection.java
@@ -20,6 +20,7 @@ import static io.rsocket.frame.FrameType.*;
 
 import io.micrometer.core.instrument.*;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import io.rsocket.frame.FrameHeaderFlyweight;
 import io.rsocket.frame.FrameType;
@@ -80,6 +81,11 @@ final class MicrometerDuplexConnection implements DuplexConnection {
             "rsocket.duplex.connection.dispose",
             Tags.of(tags).and("connection.type", connectionType.name()));
     this.frameCounters = new FrameCounters(connectionType, meterRegistry, tags);
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return delegate.alloc();
   }
 
   @Override

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
@@ -17,6 +17,7 @@
 package io.rsocket.transport.local;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import java.util.Objects;
 import org.reactivestreams.Publisher;
@@ -28,6 +29,7 @@ import reactor.core.publisher.MonoProcessor;
 /** An implementation of {@link DuplexConnection} that connects inside the same JVM. */
 final class LocalDuplexConnection implements DuplexConnection {
 
+  private final ByteBufAllocator allocator;
   private final Flux<ByteBuf> in;
 
   private final MonoProcessor<Void> onClose;
@@ -42,7 +44,12 @@ final class LocalDuplexConnection implements DuplexConnection {
    * @param onClose the closing notifier
    * @throws NullPointerException if {@code in}, {@code out}, or {@code onClose} are {@code null}
    */
-  LocalDuplexConnection(Flux<ByteBuf> in, Subscriber<ByteBuf> out, MonoProcessor<Void> onClose) {
+  LocalDuplexConnection(
+      ByteBufAllocator allocator,
+      Flux<ByteBuf> in,
+      Subscriber<ByteBuf> out,
+      MonoProcessor<Void> onClose) {
+    this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
     this.in = Objects.requireNonNull(in, "in must not be null");
     this.out = Objects.requireNonNull(out, "out must not be null");
     this.onClose = Objects.requireNonNull(onClose, "onClose must not be null");
@@ -81,5 +88,10 @@ final class LocalDuplexConnection implements DuplexConnection {
     Objects.requireNonNull(frame, "frame must not be null");
     out.onNext(frame);
     return Mono.empty();
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return allocator;
   }
 }

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalServerTransport.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalServerTransport.java
@@ -16,7 +16,6 @@
 
 package io.rsocket.transport.local;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Closeable;
 import io.rsocket.DuplexConnection;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
@@ -167,11 +166,9 @@ public final class LocalServerTransport implements ServerTransport<Closeable> {
 
       if (mtu > 0) {
         duplexConnection =
-            new FragmentationDuplexConnection(
-                duplexConnection, ByteBufAllocator.DEFAULT, mtu, false, "server");
+            new FragmentationDuplexConnection(duplexConnection, mtu, false, "server");
       } else {
-        duplexConnection =
-            new ReassemblyDuplexConnection(duplexConnection, ByteBufAllocator.DEFAULT, false);
+        duplexConnection = new ReassemblyDuplexConnection(duplexConnection, false);
       }
 
       acceptor.apply(duplexConnection).subscribe();

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
@@ -63,6 +63,11 @@ public final class TcpDuplexConnection extends BaseDuplexConnection {
   }
 
   @Override
+  public ByteBufAllocator alloc() {
+    return connection.channel().alloc();
+  }
+
+  @Override
   protected void doOnClose() {
     if (!connection.isDisposed()) {
       connection.dispose();

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
@@ -16,6 +16,7 @@
 package io.rsocket.transport.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.rsocket.DuplexConnection;
 import io.rsocket.internal.BaseDuplexConnection;
@@ -51,6 +52,11 @@ public final class WebsocketDuplexConnection extends BaseDuplexConnection {
             future -> {
               if (!isDisposed()) dispose();
             });
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return connection.channel().alloc();
   }
 
   @Override

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
@@ -16,7 +16,6 @@
 
 package io.rsocket.transport.netty.client;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
 import io.rsocket.fragmentation.ReassemblyDuplexConnection;
@@ -105,14 +104,9 @@ public final class TcpClientTransport implements ClientTransport {
                 c -> {
                   if (mtu > 0) {
                     return new FragmentationDuplexConnection(
-                        new TcpDuplexConnection(c, false),
-                        ByteBufAllocator.DEFAULT,
-                        mtu,
-                        true,
-                        "client");
+                        new TcpDuplexConnection(c, false), mtu, true, "client");
                   } else {
-                    return new ReassemblyDuplexConnection(
-                        new TcpDuplexConnection(c), ByteBufAllocator.DEFAULT, false);
+                    return new ReassemblyDuplexConnection(new TcpDuplexConnection(c), false);
                   }
                 });
   }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
@@ -20,7 +20,6 @@ import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 import static io.rsocket.transport.netty.UriUtils.getPort;
 import static io.rsocket.transport.netty.UriUtils.isSecure;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
 import io.rsocket.fragmentation.ReassemblyDuplexConnection;
@@ -164,11 +163,9 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
                   DuplexConnection connection = new WebsocketDuplexConnection(c);
                   if (mtu > 0) {
                     connection =
-                        new FragmentationDuplexConnection(
-                            connection, ByteBufAllocator.DEFAULT, mtu, false, "client");
+                        new FragmentationDuplexConnection(connection, mtu, false, "client");
                   } else {
-                    connection =
-                        new ReassemblyDuplexConnection(connection, ByteBufAllocator.DEFAULT, false);
+                    connection = new ReassemblyDuplexConnection(connection, false);
                   }
                   return connection;
                 });

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
@@ -16,7 +16,6 @@
 
 package io.rsocket.transport.netty.server;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
 import io.rsocket.fragmentation.ReassemblyDuplexConnection;
@@ -106,15 +105,9 @@ public final class TcpServerTransport implements ServerTransport<CloseableChanne
                   if (mtu > 0) {
                     connection =
                         new FragmentationDuplexConnection(
-                            new TcpDuplexConnection(c, false),
-                            ByteBufAllocator.DEFAULT,
-                            mtu,
-                            true,
-                            "server");
+                            new TcpDuplexConnection(c, false), mtu, true, "server");
                   } else {
-                    connection =
-                        new ReassemblyDuplexConnection(
-                            new TcpDuplexConnection(c), ByteBufAllocator.DEFAULT, false);
+                    connection = new ReassemblyDuplexConnection(new TcpDuplexConnection(c), false);
                   }
                   acceptor
                       .apply(connection)

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -18,7 +18,6 @@ package io.rsocket.transport.netty.server;
 
 import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Closeable;
 import io.rsocket.DuplexConnection;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
@@ -105,11 +104,9 @@ public final class WebsocketRouteTransport extends BaseWebsocketServerTransport<
     return (in, out) -> {
       DuplexConnection connection = new WebsocketDuplexConnection((Connection) in);
       if (mtu > 0) {
-        connection =
-            new FragmentationDuplexConnection(
-                connection, ByteBufAllocator.DEFAULT, mtu, false, "server");
+        connection = new FragmentationDuplexConnection(connection, mtu, false, "server");
       } else {
-        connection = new ReassemblyDuplexConnection(connection, ByteBufAllocator.DEFAULT, false);
+        connection = new ReassemblyDuplexConnection(connection, false);
       }
       return acceptor.apply(connection).then(out.neverComplete());
     };

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
@@ -18,7 +18,6 @@ package io.rsocket.transport.netty.server;
 
 import static io.rsocket.frame.FrameLengthFlyweight.FRAME_LENGTH_MASK;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
 import io.rsocket.fragmentation.ReassemblyDuplexConnection;
@@ -129,12 +128,9 @@ public final class WebsocketServerTransport extends BaseWebsocketServerTransport
                             new WebsocketDuplexConnection((Connection) in);
                         if (mtu > 0) {
                           connection =
-                              new FragmentationDuplexConnection(
-                                  connection, ByteBufAllocator.DEFAULT, mtu, false, "server");
+                              new FragmentationDuplexConnection(connection, mtu, false, "server");
                         } else {
-                          connection =
-                              new ReassemblyDuplexConnection(
-                                  connection, ByteBufAllocator.DEFAULT, false);
+                          connection = new ReassemblyDuplexConnection(connection, false);
                         }
                         return acceptor.apply(connection).then(out.neverComplete());
                       },


### PR DESCRIPTION
Ensures that Transport setups and provides access to Allocator whereas the RSocketRequester/RSocketResponder may get access to set up allocator over DuplexConnection#alloc method

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>