### PR TITLE
Send root-cause errors from connection to onClose of RSocket

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/Closeable.java
+++ b/rsocket-core/src/main/java/io/rsocket/Closeable.java
@@ -16,17 +16,19 @@
 
 package io.rsocket;
 
+import org.reactivestreams.Subscriber;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 
-/** */
+/** An interface which allows listening to when a specific instance of this interface is closed */
 public interface Closeable extends Disposable {
   /**
-   * Returns a {@code Publisher} that completes when this {@code RSocket} is closed. A {@code
-   * RSocket} can be closed by explicitly calling {@link RSocket#dispose()} or when the underlying
-   * transport connection is closed.
+   * Returns a {@link Mono} that terminates when the instance is terminated by any reason. Note, in
+   * case of error termination, the cause of error will be propagated as an error signal through
+   * {@link org.reactivestreams.Subscriber#onError(Throwable)}. Otherwise, {@link
+   * Subscriber#onComplete()} will be called.
    *
-   * @return A {@code Publisher} that completes when this {@code RSocket} close is complete.
+   * @return a closable instance of {@link Mono}.
    */
   Mono<Void> onClose();
 }

--- a/rsocket-core/src/main/java/io/rsocket/Closeable.java
+++ b/rsocket-core/src/main/java/io/rsocket/Closeable.java
@@ -28,7 +28,9 @@ public interface Closeable extends Disposable {
    * {@link org.reactivestreams.Subscriber#onError(Throwable)}. Otherwise, {@link
    * Subscriber#onComplete()} will be called.
    *
-   * @return a {@link Mono} to track completion with success or error of the underlying resource. When the underlying resource is an `RSocket`, the {@code Mono} exposes stream 0 (i.e. connection level) errors.
+   * @return a {@link Mono} to track completion with success or error of the underlying resource.
+   *     When the underlying resource is an `RSocket`, the {@code Mono} exposes stream 0 (i.e.
+   *     connection level) errors.
    */
   Mono<Void> onClose();
 }

--- a/rsocket-core/src/main/java/io/rsocket/Closeable.java
+++ b/rsocket-core/src/main/java/io/rsocket/Closeable.java
@@ -28,7 +28,7 @@ public interface Closeable extends Disposable {
    * {@link org.reactivestreams.Subscriber#onError(Throwable)}. Otherwise, {@link
    * Subscriber#onComplete()} will be called.
    *
-   * @return a closable instance of {@link Mono}.
+   * @return a {@link Mono} to track completion with success or error of the underlying resource. When the underlying resource is an `RSocket`, the {@code Mono} exposes stream 0 (i.e. connection level) errors.
    */
   Mono<Void> onClose();
 }

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -50,7 +50,7 @@ public class RSocketConnector {
   private static final int MIN_MTU_SIZE = 64;
 
   private static final BiConsumer<RSocket, Invalidatable> INVALIDATE_FUNCTION =
-      (r, i) -> r.onClose().subscribe(null, null, i::invalidate);
+      (r, i) -> r.onClose().subscribe(null, __ -> i.invalidate(), i::invalidate);
 
   private Payload setupPayload = EmptyPayload.INSTANCE;
   private String metadataMimeType = "application/binary";

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -137,7 +137,7 @@ class RSocketRequester implements RSocket {
     connection
         .onClose()
         .or(onClose)
-        .subscribe(null, this::tryTerminateOnConnectionClose, this::tryTerminateOnConnectionClose);
+        .subscribe(null, this::tryTerminateOnConnectionError, this::tryTerminateOnConnectionClose);
     connection.send(sendProcessor).subscribe(null, this::handleSendProcessorError);
 
     connection.receive().subscribe(this::handleIncomingFrames, errorConsumer);
@@ -623,7 +623,7 @@ class RSocketRequester implements RSocket {
                 String.format("No keep-alive acks for %d ms", keepAlive.getTimeout().toMillis())));
   }
 
-  private void tryTerminateOnConnectionClose(Throwable e) {
+  private void tryTerminateOnConnectionError(Throwable e) {
     tryTerminate(() -> e);
   }
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -120,7 +120,7 @@ class RSocketResponder implements ResponderRSocket {
     this.connection
         .onClose()
         .or(onClose)
-        .subscribe(null, this::tryTerminateOnConnectionClose, this::tryTerminateOnConnectionClose);
+        .subscribe(null, this::tryTerminateOnConnectionError, this::tryTerminateOnConnectionClose);
   }
 
   private void handleSendProcessorError(Throwable t) {
@@ -147,7 +147,7 @@ class RSocketResponder implements ResponderRSocket {
             });
   }
 
-  private void tryTerminateOnConnectionClose(Throwable e) {
+  private void tryTerminateOnConnectionError(Throwable e) {
     tryTerminate(() -> e);
   }
 
@@ -275,13 +275,14 @@ class RSocketResponder implements ResponderRSocket {
   private synchronized void cleanUpChannelProcessors(Throwable e) {
     channelProcessors
         .values()
-        .forEach(payloadPayloadProcessor -> {
-          try {
-            payloadPayloadProcessor.onError(e);
-          } catch (Throwable t) {
-            // noops
-          }
-        });
+        .forEach(
+            payloadPayloadProcessor -> {
+              try {
+                payloadPayloadProcessor.onError(e);
+              } catch (Throwable t) {
+                // noops
+              }
+            });
     channelProcessors.clear();
   }
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -34,8 +34,12 @@ import io.rsocket.frame.decoder.PayloadDecoder;
 import io.rsocket.internal.SynchronizedIntObjectHashMap;
 import io.rsocket.internal.UnboundedProcessor;
 import io.rsocket.lease.ResponderLeaseHandler;
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
@@ -58,6 +62,7 @@ class RSocketResponder implements ResponderRSocket {
           }
         }
       };
+  private static final Exception CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
 
   private final DuplexConnection connection;
   private final RSocket requestHandler;
@@ -65,6 +70,13 @@ class RSocketResponder implements ResponderRSocket {
   private final PayloadDecoder payloadDecoder;
   private final Consumer<Throwable> errorConsumer;
   private final ResponderLeaseHandler leaseHandler;
+  private final Disposable leaseHandlerDisposable;
+  private final MonoProcessor<Void> onClose;
+
+  private volatile Throwable terminationError;
+  private static final AtomicReferenceFieldUpdater<RSocketResponder, Throwable> TERMINATION_ERROR =
+      AtomicReferenceFieldUpdater.newUpdater(
+          RSocketResponder.class, Throwable.class, "terminationError");
 
   private final int mtu;
 
@@ -94,28 +106,21 @@ class RSocketResponder implements ResponderRSocket {
     this.leaseHandler = leaseHandler;
     this.sendingSubscriptions = new SynchronizedIntObjectHashMap<>();
     this.channelProcessors = new SynchronizedIntObjectHashMap<>();
+    this.onClose = MonoProcessor.create();
 
     // DO NOT Change the order here. The Send processor must be subscribed to before receiving
     // connections
     this.sendProcessor = new UnboundedProcessor<>();
 
-    connection
-        .send(sendProcessor)
-        .doFinally(this::handleSendProcessorCancel)
-        .subscribe(null, this::handleSendProcessorError);
+    connection.send(sendProcessor).subscribe(null, this::handleSendProcessorError);
 
-    Disposable receiveDisposable = connection.receive().subscribe(this::handleFrame, errorConsumer);
-    Disposable sendLeaseDisposable = leaseHandler.send(sendProcessor::onNextPrioritized);
+    connection.receive().subscribe(this::handleFrame, errorConsumer);
+    leaseHandlerDisposable = leaseHandler.send(sendProcessor::onNextPrioritized);
 
     this.connection
         .onClose()
-        .doFinally(
-            s -> {
-              cleanup();
-              receiveDisposable.dispose();
-              sendLeaseDisposable.dispose();
-            })
-        .subscribe(null, errorConsumer);
+        .or(onClose)
+        .subscribe(null, this::tryTerminateOnConnectionClose, this::tryTerminateOnConnectionClose);
   }
 
   private void handleSendProcessorError(Throwable t) {
@@ -142,32 +147,21 @@ class RSocketResponder implements ResponderRSocket {
             });
   }
 
-  private void handleSendProcessorCancel(SignalType t) {
-    if (SignalType.ON_ERROR == t) {
-      return;
+  private void tryTerminateOnConnectionClose(Throwable e) {
+    tryTerminate(() -> e);
+  }
+
+  private void tryTerminateOnConnectionClose() {
+    tryTerminate(() -> CLOSED_CHANNEL_EXCEPTION);
+  }
+
+  private void tryTerminate(Supplier<Throwable> errorSupplier) {
+    if (terminationError == null) {
+      Throwable e = errorSupplier.get();
+      if (TERMINATION_ERROR.compareAndSet(this, null, e)) {
+        cleanup(e);
+      }
     }
-
-    sendingSubscriptions
-        .values()
-        .forEach(
-            subscription -> {
-              try {
-                subscription.cancel();
-              } catch (Throwable e) {
-                errorConsumer.accept(e);
-              }
-            });
-
-    channelProcessors
-        .values()
-        .forEach(
-            subscription -> {
-              try {
-                subscription.onComplete();
-              } catch (Throwable e) {
-                errorConsumer.accept(e);
-              }
-            });
   }
 
   @Override
@@ -250,23 +244,25 @@ class RSocketResponder implements ResponderRSocket {
 
   @Override
   public void dispose() {
-    connection.dispose();
+    tryTerminate(() -> new CancellationException("Disposed"));
   }
 
   @Override
   public boolean isDisposed() {
-    return connection.isDisposed();
+    return onClose.isDisposed();
   }
 
   @Override
   public Mono<Void> onClose() {
-    return connection.onClose();
+    return onClose;
   }
 
-  private void cleanup() {
+  private void cleanup(Throwable e) {
     cleanUpSendingSubscriptions();
-    cleanUpChannelProcessors();
+    cleanUpChannelProcessors(e);
 
+    connection.dispose();
+    leaseHandlerDisposable.dispose();
     requestHandler.dispose();
     sendProcessor.dispose();
   }
@@ -276,8 +272,16 @@ class RSocketResponder implements ResponderRSocket {
     sendingSubscriptions.clear();
   }
 
-  private synchronized void cleanUpChannelProcessors() {
-    channelProcessors.values().forEach(Processor::onComplete);
+  private synchronized void cleanUpChannelProcessors(Throwable e) {
+    channelProcessors
+        .values()
+        .forEach(payloadPayloadProcessor -> {
+          try {
+            payloadPayloadProcessor.onError(e);
+          } catch (Throwable t) {
+            // noops
+          }
+        });
     channelProcessors.clear();
   }
 

--- a/rsocket-examples/src/test/java/io/rsocket/resume/ResumeIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/resume/ResumeIntegrationTest.java
@@ -35,7 +35,6 @@ import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;

--- a/rsocket-examples/src/test/java/io/rsocket/resume/ResumeIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/resume/ResumeIntegrationTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.ReplayProcessor;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
@@ -105,7 +104,6 @@ public class ResumeIntegrationTest {
 
     DisconnectableClientTransport clientTransport =
         new DisconnectableClientTransport(clientTransport(closeable.address()));
-    ErrorConsumer errorConsumer = new ErrorConsumer();
     int clientSessionDurationSeconds = 10;
 
     RSocket rSocket = newClientRSocket(clientTransport, clientSessionDurationSeconds).block();
@@ -118,12 +116,11 @@ public class ResumeIntegrationTest {
         .expectError()
         .verify(Duration.ofSeconds(5));
 
-    StepVerifier.create(errorConsumer.errors().next())
-        .expectNextMatches(
+    StepVerifier.create(rSocket.onClose())
+        .expectErrorMatches(
             err ->
                 err instanceof RejectedResumeException
                     && "unknown resume token".equals(err.getMessage()))
-        .expectComplete()
         .verify(Duration.ofSeconds(5));
   }
 
@@ -134,23 +131,19 @@ public class ResumeIntegrationTest {
             .bind(serverTransport(SERVER_HOST, SERVER_PORT))
             .block();
 
-    ErrorConsumer errorConsumer = new ErrorConsumer();
-
     RSocket rSocket =
         RSocketConnector.create()
             .resume(new Resume())
             .connect(clientTransport(closeableChannel.address()))
             .block();
 
-    StepVerifier.create(errorConsumer.errors().next().doFinally(s -> closeableChannel.dispose()))
-        .expectNextMatches(
+    StepVerifier.create(rSocket.onClose().doFinally(s -> closeableChannel.dispose()))
+        .expectErrorMatches(
             err ->
                 err instanceof UnsupportedSetupException
                     && "resume not supported".equals(err.getMessage()))
-        .expectComplete()
         .verify(Duration.ofSeconds(5));
 
-    StepVerifier.create(rSocket.onClose()).expectComplete().verify(Duration.ofSeconds(5));
     Assertions.assertThat(rSocket.isDisposed()).isTrue();
   }
 
@@ -160,19 +153,6 @@ public class ResumeIntegrationTest {
 
   static ServerTransport<CloseableChannel> serverTransport(String host, int port) {
     return TcpServerTransport.create(host, port);
-  }
-
-  private static class ErrorConsumer implements Consumer<Throwable> {
-    private final ReplayProcessor<Throwable> errors = ReplayProcessor.create();
-
-    public Flux<Throwable> errors() {
-      return errors;
-    }
-
-    @Override
-    public void accept(Throwable throwable) {
-      errors.onNext(throwable);
-    }
   }
 
   private static Flux<Payload> testRequest() {


### PR DESCRIPTION
This PR is a followup to previous `RSocketFactory#errorConsumer` deprecation and future removal. 
That said, we have to have access to the reason of RSocket termination and right now it would be the best to enhance `Mono<Void> onClose` and propagate the root-cause error (e.g Stream ID 0 errors which are terminal) over that API

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>