### PR TITLE
Default errorConsumer to no-op in the new API

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -111,7 +111,7 @@ public final class RSocketFactory {
     private Resume resume;
 
     public ClientRSocketFactory() {
-      this(RSocketConnector.create());
+      this(RSocketConnector.create().errorConsumer(Throwable::printStackTrace));
     }
 
     public ClientRSocketFactory(RSocketConnector connector) {
@@ -393,6 +393,7 @@ public final class RSocketFactory {
       return this;
     }
 
+    /** @deprecated this is deprecated with no replacement. */
     public ClientRSocketFactory errorConsumer(Consumer<Throwable> errorConsumer) {
       connector.errorConsumer(errorConsumer);
       return this;
@@ -416,7 +417,7 @@ public final class RSocketFactory {
     private Resume resume;
 
     public ServerRSocketFactory() {
-      this(RSocketServer.create());
+      this(RSocketServer.create().errorConsumer(Throwable::printStackTrace));
     }
 
     public ServerRSocketFactory(RSocketServer server) {
@@ -496,6 +497,7 @@ public final class RSocketFactory {
       return this;
     }
 
+    /** @deprecated this is deprecated with no replacement. */
     public ServerRSocketFactory errorConsumer(Consumer<Throwable> errorConsumer) {
       server.errorConsumer(errorConsumer);
       return this;

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -69,7 +69,7 @@ public class RSocketConnector {
   private int mtu = 0;
   private PayloadDecoder payloadDecoder = PayloadDecoder.DEFAULT;
 
-  private Consumer<Throwable> errorConsumer = Throwable::printStackTrace;
+  private Consumer<Throwable> errorConsumer = ex -> {};
 
   private RSocketConnector() {}
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
@@ -52,7 +52,7 @@ public final class RSocketServer {
   private Resume resume;
   private Supplier<Leases<?>> leasesSupplier = null;
 
-  private Consumer<Throwable> errorConsumer = Throwable::printStackTrace;
+  private Consumer<Throwable> errorConsumer = ex -> {};
   private PayloadDecoder payloadDecoder = PayloadDecoder.DEFAULT;
 
   private RSocketServer() {}


### PR DESCRIPTION
`RSocketConnector` and `RSocketServer` now default to a no-op errorConsumer since that's deprecated with no replacement. `RSocketFactory` retains its current default of printing the stacktrace. 

