### PR TITLE
provides more `ByteBuf` leaks fixes

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -54,7 +54,7 @@ import io.rsocket.lease.RequesterLeaseHandler;
 import io.rsocket.util.MonoLifecycleHandler;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
@@ -242,9 +242,14 @@ class RSocketRequester implements RSocket {
             new MonoLifecycleHandler<Payload>() {
               @Override
               public void doOnSubscribe() {
-                final ByteBuf requestFrame =
-                    RequestResponseFrameFlyweight.encodeReleasingPayload(
-                        allocator, streamId, payload);
+                final ByteBuf requestFrame;
+                try {
+                  requestFrame =
+                      RequestResponseFrameFlyweight.encodeReleasingPayload(
+                          allocator, streamId, payload);
+                } catch (IllegalReferenceCountException e) {
+                  return;
+                }
 
                 sendProcessor.onNext(requestFrame);
               }
@@ -260,6 +265,7 @@ class RSocketRequester implements RSocket {
                 removeStreamReceiver(streamId);
               }
             });
+
     receivers.put(streamId, receiver);
 
     return receiver.doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER);
@@ -281,7 +287,7 @@ class RSocketRequester implements RSocket {
 
     final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
     final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
-    final AtomicBoolean payloadReleasedFlag = new AtomicBoolean(false);
+    final AtomicInteger wip = new AtomicInteger(0);
 
     receivers.put(streamId, receiver);
 
@@ -295,30 +301,56 @@ class RSocketRequester implements RSocket {
               public void accept(long n) {
                 if (firstRequest && !receiver.isDisposed()) {
                   firstRequest = false;
-                  if (!payloadReleasedFlag.getAndSet(true)) {
-                    sendProcessor.onNext(
-                        RequestStreamFrameFlyweight.encodeReleasingPayload(
-                            allocator, streamId, n, payload));
+                  if (wip.getAndIncrement() != 0) {
+                    // no need to do anything.
+                    // stream was canceled and fist payload has already been discarded
+                    return;
                   }
-                } else if (contains(streamId) && !receiver.isDisposed()) {
+                  int missed = 1;
+                  boolean firstHasBeenSent = false;
+                  for (; ; ) {
+                    if (!firstHasBeenSent) {
+                      ByteBuf frame;
+                      try {
+                        frame =
+                            RequestStreamFrameFlyweight.encodeReleasingPayload(
+                                allocator, streamId, n, payload);
+                      } catch (IllegalReferenceCountException e) {
+                        return;
+                      }
+
+                      sendProcessor.onNext(frame);
+                      firstHasBeenSent = true;
+                    } else {
+                      // if first frame was sent but we cycling again, it means that wip was
+                      // incremented at doOnCancel
+                      sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
+                      return;
+                    }
+
+                    missed = wip.addAndGet(-missed);
+                    if (missed == 0) {
+                      return;
+                    }
+                  }
+                } else {
                   sendProcessor.onNext(RequestNFrameFlyweight.encode(allocator, streamId, n));
                 }
               }
             })
-        .doOnError(
-            t -> {
-              if (contains(streamId) && !receiver.isDisposed()) {
-                sendProcessor.onNext(ErrorFrameFlyweight.encode(allocator, streamId, t));
-              }
-            })
         .doOnCancel(
             () -> {
-              if (!payloadReleasedFlag.getAndSet(true)) {
+              if (wip.getAndIncrement() != 0) {
+                return;
+              }
+
+              // check if we need to release payload
+              // only applicable if the cancel appears earlier than actual request
+              if (payload.refCnt() > 0) {
                 payload.release();
               }
-              if (contains(streamId) && !receiver.isDisposed()) {
-                sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
-              }
+
+              sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
             })
         .doFinally(s -> removeStreamReceiver(streamId))
         .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER);
@@ -330,30 +362,32 @@ class RSocketRequester implements RSocket {
       return Flux.error(err);
     }
 
-    return request.switchOnFirst(
-        (s, flux) -> {
-          Payload payload = s.get();
-          if (payload != null) {
-            if (!PayloadValidationUtils.isValid(mtu, payload)) {
-              payload.release();
-              final IllegalArgumentException t =
-                  new IllegalArgumentException(INVALID_PAYLOAD_ERROR_MESSAGE);
-              errorConsumer.accept(t);
-              return Mono.error(t);
-            }
-            return handleChannel(payload, flux);
-          } else {
-            return flux;
-          }
-        },
-        false);
+    return request
+        .switchOnFirst(
+            (s, flux) -> {
+              Payload payload = s.get();
+              if (payload != null) {
+                if (!PayloadValidationUtils.isValid(mtu, payload)) {
+                  payload.release();
+                  final IllegalArgumentException t =
+                      new IllegalArgumentException(INVALID_PAYLOAD_ERROR_MESSAGE);
+                  errorConsumer.accept(t);
+                  return Mono.error(t);
+                }
+                return handleChannel(payload, flux);
+              } else {
+                return flux;
+              }
+            },
+            false)
+        .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER);
   }
 
   private Flux<? extends Payload> handleChannel(Payload initialPayload, Flux<Payload> inboundFlux) {
     final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
-    final AtomicBoolean payloadReleasedFlag = new AtomicBoolean(false);
     final int streamId = streamIdSupplier.nextStreamId(receivers);
 
+    final AtomicInteger wip = new AtomicInteger(0);
     final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
     final BaseSubscriber<Payload> upstreamSubscriber =
         new BaseSubscriber<Payload>() {
@@ -421,43 +455,65 @@ class RSocketRequester implements RSocket {
               public void accept(long n) {
                 if (firstRequest) {
                   firstRequest = false;
-                  senders.put(streamId, upstreamSubscriber);
-                  receivers.put(streamId, receiver);
+                  if (wip.getAndIncrement() != 0) {
+                    // no need to do anything.
+                    // stream was canceled and fist payload has already been discarded
+                    return;
+                  }
+                  int missed = 1;
+                  boolean firstHasBeenSent = false;
+                  for (; ; ) {
+                    if (!firstHasBeenSent) {
+                      ByteBuf frame;
+                      try {
+                        frame =
+                            RequestChannelFrameFlyweight.encodeReleasingPayload(
+                                allocator, streamId, false, n, initialPayload);
+                      } catch (IllegalReferenceCountException e) {
+                        return;
+                      }
 
-                  inboundFlux
-                      .limitRate(Queues.SMALL_BUFFER_SIZE)
-                      .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER)
-                      .subscribe(upstreamSubscriber);
-                  if (!payloadReleasedFlag.getAndSet(true)) {
-                    ByteBuf frame =
-                        RequestChannelFrameFlyweight.encodeReleasingPayload(
-                            allocator, streamId, false, n, initialPayload);
+                      senders.put(streamId, upstreamSubscriber);
+                      receivers.put(streamId, receiver);
 
-                    sendProcessor.onNext(frame);
+                      inboundFlux
+                          .limitRate(Queues.SMALL_BUFFER_SIZE)
+                          .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER)
+                          .subscribe(upstreamSubscriber);
+
+                      sendProcessor.onNext(frame);
+                      firstHasBeenSent = true;
+                    } else {
+                      // if first frame was sent but we cycling again, it means that wip was
+                      // incremented at doOnCancel
+                      senders.remove(streamId, upstreamSubscriber);
+                      receivers.remove(streamId, receiver);
+                      sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
+                      return;
+                    }
+
+                    missed = wip.addAndGet(-missed);
+                    if (missed == 0) {
+                      return;
+                    }
                   }
                 } else {
                   sendProcessor.onNext(RequestNFrameFlyweight.encode(allocator, streamId, n));
                 }
               }
             })
-        .doOnError(
-            t -> {
-              if (receivers.remove(streamId, receiver)) {
-                upstreamSubscriber.cancel();
-              }
-            })
-        .doOnComplete(() -> receivers.remove(streamId, receiver))
+        .doOnError(t -> upstreamSubscriber.cancel())
         .doOnCancel(
             () -> {
-              if (!payloadReleasedFlag.getAndSet(true)) {
-                initialPayload.release();
+              upstreamSubscriber.cancel();
+              if (wip.getAndIncrement() != 0) {
+                return;
               }
-              if (receivers.remove(streamId, receiver)) {
-                sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
-                upstreamSubscriber.cancel();
-              }
+
+              // need to send frame only if RequestChannelFrame was sent
+              sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
             })
-        .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER);
+        .doFinally(__ -> receivers.remove(streamId, receiver));
   }
 
   private Mono<Void> handleMetadataPush(Payload payload) {

--- a/rsocket-core/src/main/java/io/rsocket/frame/DataAndMetadataFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/DataAndMetadataFlyweight.java
@@ -37,8 +37,34 @@ class DataAndMetadataFlyweight {
       boolean hasMetadata,
       ByteBuf data) {
 
-    final boolean addData = data != null && data.isReadable();
-    final boolean addMetadata = hasMetadata && metadata.isReadable();
+    final boolean addData;
+    if (data != null) {
+      if (data.isReadable()) {
+        addData = true;
+      } else {
+        // even though there is nothing to read, we still have to release here since nobody else
+        // going to do soo
+        data.release();
+        addData = false;
+      }
+    } else {
+      addData = false;
+    }
+
+    final boolean addMetadata;
+    if (hasMetadata) {
+      if (metadata.isReadable()) {
+        addMetadata = true;
+      } else {
+        // even though there is nothing to read, we still have to release here since nobody else
+        // going to do soo
+        metadata.release();
+        addMetadata = false;
+      }
+    } else {
+      // has no metadata means it is null, thus no need to release anything
+      addMetadata = false;
+    }
 
     if (hasMetadata) {
       int length = metadata.readableBytes();

--- a/rsocket-core/src/main/java/io/rsocket/frame/MetadataPushFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/MetadataPushFrameFlyweight.java
@@ -2,13 +2,21 @@ package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.IllegalReferenceCountException;
 import io.rsocket.Payload;
 
 public class MetadataPushFrameFlyweight {
 
   public static ByteBuf encodeReleasingPayload(ByteBufAllocator allocator, Payload payload) {
     final ByteBuf metadata = payload.metadata().retain();
-    payload.release();
+    // releasing payload safely since it can be already released wheres we have to release retained
+    // data and metadata as well
+    try {
+      payload.release();
+    } catch (IllegalReferenceCountException e) {
+      metadata.release();
+      throw e;
+    }
     return encode(allocator, metadata);
   }
 

--- a/rsocket-core/src/main/java/io/rsocket/frame/PayloadFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/PayloadFrameFlyweight.java
@@ -2,6 +2,7 @@ package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.IllegalReferenceCountException;
 import io.rsocket.Payload;
 
 public class PayloadFrameFlyweight {
@@ -23,11 +24,31 @@ public class PayloadFrameFlyweight {
   static ByteBuf encodeReleasingPayload(
       ByteBufAllocator allocator, int streamId, boolean complete, Payload payload) {
 
-    final boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op
+    boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op still
     final ByteBuf metadata = hasMetadata ? payload.metadata().retain() : null;
-    final ByteBuf data = payload.data().retain();
-
-    payload.release();
+    final ByteBuf data;
+    // retaining data safely. May throw either NPE or RefCntE
+    try {
+      data = payload.data().retain();
+    } catch (IllegalReferenceCountException | NullPointerException e) {
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
+    // releasing payload safely since it can be already released wheres we have to release retained
+    // data and metadata as well
+    try {
+      payload.release();
+    } catch (IllegalReferenceCountException e) {
+      data.release();
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
 
     return encode(allocator, streamId, false, complete, true, metadata, data);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/RequestChannelFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/RequestChannelFrameFlyweight.java
@@ -2,6 +2,7 @@ package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.IllegalReferenceCountException;
 import io.rsocket.Payload;
 
 public class RequestChannelFrameFlyweight {
@@ -17,11 +18,31 @@ public class RequestChannelFrameFlyweight {
       long initialRequestN,
       Payload payload) {
 
-    final boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op
+    boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op still
     final ByteBuf metadata = hasMetadata ? payload.metadata().retain() : null;
-    final ByteBuf data = payload.data().retain();
-
-    payload.release();
+    final ByteBuf data;
+    // retaining data safely. May throw either NPE or RefCntE
+    try {
+      data = payload.data().retain();
+    } catch (IllegalReferenceCountException | NullPointerException e) {
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
+    // releasing payload safely since it can be already released wheres we have to release retained
+    // data and metadata as well
+    try {
+      payload.release();
+    } catch (IllegalReferenceCountException e) {
+      data.release();
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
 
     return encode(allocator, streamId, false, complete, initialRequestN, metadata, data);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/RequestFireAndForgetFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/RequestFireAndForgetFrameFlyweight.java
@@ -2,6 +2,7 @@ package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.IllegalReferenceCountException;
 import io.rsocket.Payload;
 
 public class RequestFireAndForgetFrameFlyweight {
@@ -13,11 +14,31 @@ public class RequestFireAndForgetFrameFlyweight {
   public static ByteBuf encodeReleasingPayload(
       ByteBufAllocator allocator, int streamId, Payload payload) {
 
-    final boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op
+    boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op still
     final ByteBuf metadata = hasMetadata ? payload.metadata().retain() : null;
-    final ByteBuf data = payload.data().retain();
-
-    payload.release();
+    final ByteBuf data;
+    // retaining data safely. May throw either NPE or RefCntE
+    try {
+      data = payload.data().retain();
+    } catch (IllegalReferenceCountException | NullPointerException e) {
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
+    // releasing payload safely since it can be already released wheres we have to release retained
+    // data and metadata as well
+    try {
+      payload.release();
+    } catch (IllegalReferenceCountException e) {
+      data.release();
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
 
     return FLYWEIGHT.encode(allocator, streamId, false, metadata, data);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/RequestResponseFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/RequestResponseFrameFlyweight.java
@@ -2,6 +2,7 @@ package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.IllegalReferenceCountException;
 import io.rsocket.Payload;
 
 public class RequestResponseFrameFlyweight {
@@ -13,11 +14,31 @@ public class RequestResponseFrameFlyweight {
   public static ByteBuf encodeReleasingPayload(
       ByteBufAllocator allocator, int streamId, Payload payload) {
 
-    final boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op
+    boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op still
     final ByteBuf metadata = hasMetadata ? payload.metadata().retain() : null;
-    final ByteBuf data = payload.data().retain();
-
-    payload.release();
+    final ByteBuf data;
+    // retaining data safely. May throw either NPE or RefCntE
+    try {
+      data = payload.data().retain();
+    } catch (IllegalReferenceCountException | NullPointerException e) {
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
+    // releasing payload safely since it can be already released wheres we have to release retained
+    // data and metadata as well
+    try {
+      payload.release();
+    } catch (IllegalReferenceCountException e) {
+      data.release();
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
 
     return encode(allocator, streamId, false, metadata, data);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/RequestStreamFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/RequestStreamFrameFlyweight.java
@@ -2,6 +2,7 @@ package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.IllegalReferenceCountException;
 import io.rsocket.Payload;
 
 public class RequestStreamFrameFlyweight {
@@ -13,11 +14,31 @@ public class RequestStreamFrameFlyweight {
   public static ByteBuf encodeReleasingPayload(
       ByteBufAllocator allocator, int streamId, long initialRequestN, Payload payload) {
 
-    final boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op
+    boolean hasMetadata = payload.hasMetadata();
+    // if refCnt exceptions throws here it is safe to do no-op still
     final ByteBuf metadata = hasMetadata ? payload.metadata().retain() : null;
-    final ByteBuf data = payload.data().retain();
-
-    payload.release();
+    final ByteBuf data;
+    // retaining data safely. May throw either NPE or RefCntE
+    try {
+      data = payload.data().retain();
+    } catch (IllegalReferenceCountException | NullPointerException e) {
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
+    // releasing payload safely since it can be already released wheres we have to release retained
+    // data and metadata as well
+    try {
+      payload.release();
+    } catch (IllegalReferenceCountException e) {
+      data.release();
+      if (hasMetadata) {
+        metadata.release();
+      }
+      throw e;
+    }
 
     return encode(allocator, streamId, false, initialRequestN, metadata, data);
   }

--- a/rsocket-core/src/test/java/io/rsocket/buffer/LeaksTrackingByteBufAllocator.java
+++ b/rsocket-core/src/test/java/io/rsocket/buffer/LeaksTrackingByteBufAllocator.java
@@ -3,7 +3,6 @@ package io.rsocket.buffer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
-import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.assertj.core.api.Assertions;
 
@@ -35,22 +34,9 @@ public class LeaksTrackingByteBufAllocator implements ByteBufAllocator {
     try {
       Assertions.assertThat(tracker)
           .allSatisfy(
-              buf -> {
-                if (buf instanceof CompositeByteBuf) {
-                  if (buf.refCnt() > 0) {
-                    List<ByteBuf> decomposed =
-                        ((CompositeByteBuf) buf).decompose(0, buf.readableBytes());
-                    for (int i = 0; i < decomposed.size(); i++) {
-                      Assertions.assertThat(decomposed.get(i))
-                          .matches(bb -> bb.refCnt() == 0, "Got unreleased CompositeByteBuf");
-                    }
-                  }
-
-                } else {
+              buf ->
                   Assertions.assertThat(buf)
-                      .matches(bb -> bb.refCnt() == 0, "buffer should be released");
-                }
-              });
+                      .matches(bb -> bb.refCnt() == 0, "buffer should be released"));
     } finally {
       tracker.clear();
     }

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -510,10 +510,23 @@ public class RSocketRequesterTest {
                     Assertions.assertThat(rule.connection.getSent()).hasSize(2);
                     Assertions.assertThat(rule.connection.getSent())
                         .element(0)
-                        .matches(bb -> frameType(bb) == REQUEST_STREAM);
+                        .matches(
+                            bb -> frameType(bb) == REQUEST_STREAM,
+                            "Expected first frame matches {"
+                                + REQUEST_STREAM
+                                + "} but was {"
+                                + frameType(rule.connection.getSent().stream().findFirst().get())
+                                + "}");
                     Assertions.assertThat(rule.connection.getSent())
-                        .element(0)
-                        .matches(bb -> frameType(bb) == REQUEST_STREAM);
+                        .element(1)
+                        .matches(
+                            bb -> frameType(bb) == CANCEL,
+                            "Expected first frame matches {"
+                                + CANCEL
+                                + "} but was {"
+                                + frameType(
+                                    rule.connection.getSent().stream().skip(1).findFirst().get())
+                                + "}");
                   }
                 }),
         Arguments.of(
@@ -542,10 +555,23 @@ public class RSocketRequesterTest {
                     Assertions.assertThat(rule.connection.getSent()).hasSize(2);
                     Assertions.assertThat(rule.connection.getSent())
                         .element(0)
-                        .matches(bb -> frameType(bb) == REQUEST_CHANNEL);
+                        .matches(
+                            bb -> frameType(bb) == REQUEST_CHANNEL,
+                            "Expected first frame matches {"
+                                + REQUEST_CHANNEL
+                                + "} but was {"
+                                + frameType(rule.connection.getSent().stream().findFirst().get())
+                                + "}");
                     Assertions.assertThat(rule.connection.getSent())
-                        .element(0)
-                        .matches(bb -> frameType(bb) == REQUEST_STREAM);
+                        .element(1)
+                        .matches(
+                            bb -> frameType(bb) == CANCEL,
+                            "Expected first frame matches {"
+                                + CANCEL
+                                + "} but was {"
+                                + frameType(
+                                    rule.connection.getSent().stream().skip(1).findFirst().get())
+                                + "}");
                   }
                 }),
         Arguments.of(

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -38,6 +38,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
@@ -71,6 +72,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -84,6 +86,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.UnicastProcessor;
@@ -97,6 +100,8 @@ public class RSocketRequesterTest {
 
   @BeforeEach
   public void setUp() throws Throwable {
+    Hooks.onNextDropped(ReferenceCountUtil::safeRelease);
+    Hooks.onErrorDropped((t) -> {});
     rule = new ClientSocketRule();
     rule.apply(
             new Statement() {
@@ -105,6 +110,12 @@ public class RSocketRequesterTest {
             },
             null)
         .evaluate();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    Hooks.resetOnErrorDropped();
+    Hooks.resetOnNextDropped();
   }
 
   @Test
@@ -403,21 +414,8 @@ public class RSocketRequesterTest {
     rule.assertHasNoLeaks();
   }
 
-  @Test
-  @Disabled("Due to https://github.com/reactor/reactor-core/pull/2114")
-  @SuppressWarnings("unchecked")
-  public void checkNoLeaksOnRacingTest() {
-
-    racingCases()
-        .forEach(
-            a -> {
-              ((Runnable) a.get()[0]).run();
-              checkNoLeaksOnRacing(
-                  (Function<ClientSocketRule, Publisher<Payload>>) a.get()[1],
-                  (BiConsumer<AssertSubscriber<Payload>, ClientSocketRule>) a.get()[2]);
-            });
-  }
-
+  @ParameterizedTest
+  @MethodSource("racingCases")
   public void checkNoLeaksOnRacing(
       Function<ClientSocketRule, Publisher<Payload>> initiator,
       BiConsumer<AssertSubscriber<Payload>, ClientSocketRule> runner) {
@@ -437,7 +435,7 @@ public class RSocketRequesterTest {
       }
 
       Publisher<Payload> payloadP = initiator.apply(clientSocketRule);
-      AssertSubscriber<Payload> assertSubscriber = AssertSubscriber.create();
+      AssertSubscriber<Payload> assertSubscriber = AssertSubscriber.create(0);
 
       if (payloadP instanceof Flux) {
         ((Flux<Payload>) payloadP).doOnNext(Payload::release).subscribe(assertSubscriber);
@@ -450,14 +448,13 @@ public class RSocketRequesterTest {
       Assertions.assertThat(clientSocketRule.connection.getSent())
           .allMatch(ReferenceCounted::release);
 
-      rule.assertHasNoLeaks();
+      clientSocketRule.assertHasNoLeaks();
     }
   }
 
   private static Stream<Arguments> racingCases() {
     return Stream.of(
         Arguments.of(
-            (Runnable) () -> System.out.println("RequestStream downstream cancellation case"),
             (Function<ClientSocketRule, Publisher<Payload>>)
                 (rule) -> rule.socket.requestStream(EmptyPayload.INSTANCE),
             (BiConsumer<AssertSubscriber<Payload>, ClientSocketRule>)
@@ -467,6 +464,7 @@ public class RSocketRequesterTest {
                   metadata.writeCharSequence("abc", CharsetUtil.UTF_8);
                   ByteBuf data = allocator.buffer();
                   data.writeCharSequence("def", CharsetUtil.UTF_8);
+                  as.request(1);
                   int streamId = rule.getStreamIdForRequestType(REQUEST_STREAM);
                   ByteBuf frame =
                       PayloadFrameFlyweight.encode(
@@ -475,7 +473,6 @@ public class RSocketRequesterTest {
                   RaceTestUtils.race(as::cancel, () -> rule.connection.addToReceivedBuffer(frame));
                 }),
         Arguments.of(
-            (Runnable) () -> System.out.println("RequestChannel downstream cancellation case"),
             (Function<ClientSocketRule, Publisher<Payload>>)
                 (rule) -> rule.socket.requestChannel(Flux.just(EmptyPayload.INSTANCE)),
             (BiConsumer<AssertSubscriber<Payload>, ClientSocketRule>)
@@ -485,6 +482,7 @@ public class RSocketRequesterTest {
                   metadata.writeCharSequence("abc", CharsetUtil.UTF_8);
                   ByteBuf data = allocator.buffer();
                   data.writeCharSequence("def", CharsetUtil.UTF_8);
+                  as.request(1);
                   int streamId = rule.getStreamIdForRequestType(REQUEST_CHANNEL);
                   ByteBuf frame =
                       PayloadFrameFlyweight.encode(
@@ -493,79 +491,117 @@ public class RSocketRequesterTest {
                   RaceTestUtils.race(as::cancel, () -> rule.connection.addToReceivedBuffer(frame));
                 }),
         Arguments.of(
-            (Runnable) () -> System.out.println("RequestChannel upstream cancellation 1"),
             (Function<ClientSocketRule, Publisher<Payload>>)
                 (rule) -> {
                   ByteBufAllocator allocator = rule.alloc();
                   ByteBuf metadata = allocator.buffer();
-                  metadata.writeCharSequence("abc", CharsetUtil.UTF_8);
+                  metadata.writeCharSequence("metadata", CharsetUtil.UTF_8);
                   ByteBuf data = allocator.buffer();
-                  data.writeCharSequence("def", CharsetUtil.UTF_8);
-                  return rule.socket.requestChannel(
-                      Flux.just(ByteBufPayload.create(data, metadata)));
+                  data.writeCharSequence("data", CharsetUtil.UTF_8);
+                  final Payload payload = ByteBufPayload.create(data, metadata);
+
+                  return rule.socket.requestStream(payload);
                 },
             (BiConsumer<AssertSubscriber<Payload>, ClientSocketRule>)
                 (as, rule) -> {
-                  ByteBufAllocator allocator = rule.alloc();
-                  int streamId = rule.getStreamIdForRequestType(REQUEST_CHANNEL);
-                  ByteBuf frame = CancelFrameFlyweight.encode(allocator, streamId);
-
-                  RaceTestUtils.race(
-                      () -> as.request(1), () -> rule.connection.addToReceivedBuffer(frame));
+                  RaceTestUtils.race(() -> as.request(1), as::cancel);
+                  // ensures proper frames order
+                  if (rule.connection.getSent().size() > 0) {
+                    Assertions.assertThat(rule.connection.getSent()).hasSize(2);
+                    Assertions.assertThat(rule.connection.getSent())
+                        .element(0)
+                        .matches(bb -> frameType(bb) == REQUEST_STREAM);
+                    Assertions.assertThat(rule.connection.getSent())
+                        .element(0)
+                        .matches(bb -> frameType(bb) == REQUEST_STREAM);
+                  }
                 }),
         Arguments.of(
-            (Runnable) () -> System.out.println("RequestChannel upstream cancellation 2"),
+            (Function<ClientSocketRule, Publisher<Payload>>)
+                (rule) -> {
+                  ByteBufAllocator allocator = rule.alloc();
+                  return rule.socket.requestChannel(
+                      Flux.generate(
+                          () -> 1L,
+                          (index, sink) -> {
+                            ByteBuf metadata = allocator.buffer();
+                            metadata.writeCharSequence("metadata", CharsetUtil.UTF_8);
+                            ByteBuf data = allocator.buffer();
+                            data.writeCharSequence("data", CharsetUtil.UTF_8);
+                            final Payload payload = ByteBufPayload.create(data, metadata);
+                            sink.next(payload);
+                            sink.complete();
+                            return ++index;
+                          }));
+                },
+            (BiConsumer<AssertSubscriber<Payload>, ClientSocketRule>)
+                (as, rule) -> {
+                  RaceTestUtils.race(() -> as.request(1), as::cancel);
+                  // ensures proper frames order
+                  if (rule.connection.getSent().size() > 0) {
+                    Assertions.assertThat(rule.connection.getSent()).hasSize(2);
+                    Assertions.assertThat(rule.connection.getSent())
+                        .element(0)
+                        .matches(bb -> frameType(bb) == REQUEST_CHANNEL);
+                    Assertions.assertThat(rule.connection.getSent())
+                        .element(0)
+                        .matches(bb -> frameType(bb) == REQUEST_STREAM);
+                  }
+                }),
+        Arguments.of(
             (Function<ClientSocketRule, Publisher<Payload>>)
                 (rule) ->
                     rule.socket.requestChannel(
                         Flux.generate(
                             () -> 1L,
                             (index, sink) -> {
-                              final Payload payload =
-                                  ByteBufPayload.create("d" + index, "m" + index);
+                              ByteBuf data = rule.alloc().buffer();
+                              data.writeCharSequence("d" + index, CharsetUtil.UTF_8);
+                              ByteBuf metadata = rule.alloc().buffer();
+                              metadata.writeCharSequence("m" + index, CharsetUtil.UTF_8);
+                              final Payload payload = ByteBufPayload.create(data, metadata);
                               sink.next(payload);
                               return ++index;
                             })),
             (BiConsumer<AssertSubscriber<Payload>, ClientSocketRule>)
                 (as, rule) -> {
                   ByteBufAllocator allocator = rule.alloc();
+                  as.request(1);
                   int streamId = rule.getStreamIdForRequestType(REQUEST_CHANNEL);
                   ByteBuf frame = CancelFrameFlyweight.encode(allocator, streamId);
-
-                  as.request(1);
 
                   RaceTestUtils.race(
                       () -> as.request(Long.MAX_VALUE),
                       () -> rule.connection.addToReceivedBuffer(frame));
                 }),
         Arguments.of(
-            (Runnable) () -> System.out.println("RequestChannel remote error"),
             (Function<ClientSocketRule, Publisher<Payload>>)
                 (rule) ->
                     rule.socket.requestChannel(
                         Flux.generate(
                             () -> 1L,
                             (index, sink) -> {
-                              final Payload payload =
-                                  ByteBufPayload.create("d" + index, "m" + index);
+                              ByteBuf data = rule.alloc().buffer();
+                              data.writeCharSequence("d" + index, CharsetUtil.UTF_8);
+                              ByteBuf metadata = rule.alloc().buffer();
+                              metadata.writeCharSequence("m" + index, CharsetUtil.UTF_8);
+                              final Payload payload = ByteBufPayload.create(data, metadata);
                               sink.next(payload);
                               return ++index;
                             })),
             (BiConsumer<AssertSubscriber<Payload>, ClientSocketRule>)
                 (as, rule) -> {
                   ByteBufAllocator allocator = rule.alloc();
+                  as.request(1);
                   int streamId = rule.getStreamIdForRequestType(REQUEST_CHANNEL);
                   ByteBuf frame =
                       ErrorFrameFlyweight.encode(allocator, streamId, new RuntimeException("test"));
 
-                  as.request(1);
-
                   RaceTestUtils.race(
                       () -> as.request(Long.MAX_VALUE),
                       () -> rule.connection.addToReceivedBuffer(frame));
                 }),
         Arguments.of(
-            (Runnable) () -> System.out.println("RequestResponse downstream cancellation"),
             (Function<ClientSocketRule, Publisher<Payload>>)
                 (rule) -> rule.socket.requestResponse(EmptyPayload.INSTANCE),
             (BiConsumer<AssertSubscriber<Payload>, ClientSocketRule>)
@@ -575,6 +611,7 @@ public class RSocketRequesterTest {
                   metadata.writeCharSequence("abc", CharsetUtil.UTF_8);
                   ByteBuf data = allocator.buffer();
                   data.writeCharSequence("def", CharsetUtil.UTF_8);
+                  as.request(Long.MAX_VALUE);
                   int streamId = rule.getStreamIdForRequestType(REQUEST_RESPONSE);
                   ByteBuf frame =
                       PayloadFrameFlyweight.encode(

--- a/rsocket-core/src/test/java/io/rsocket/frame/ByteBufRepresentation.java
+++ b/rsocket-core/src/test/java/io/rsocket/frame/ByteBufRepresentation.java
@@ -26,7 +26,13 @@ public final class ByteBufRepresentation extends StandardRepresentation {
   protected String fallbackToStringOf(Object object) {
     if (object instanceof ByteBuf) {
       try {
-        return ByteBufUtil.prettyHexDump((ByteBuf) object);
+        String normalBufferString = object.toString();
+        String prettyHexDump = ByteBufUtil.prettyHexDump((ByteBuf) object);
+        return new StringBuilder()
+            .append(normalBufferString)
+            .append("\n")
+            .append(prettyHexDump)
+            .toString();
       } catch (IllegalReferenceCountException e) {
         // noops
       }


### PR DESCRIPTION
This PR provides 4 central things:

1. Ensures if there goes something during `Payload` to the frame we will not get any memory leaks in the end (first commit in the list)
2. Fixes `onDiscard` leak which did not work correctly because `actual` subscriber was nulled to early
3. Ensures that we will not have the wrong frame order in case of racing the first `Payload` sending and cancel. Also, it moves `onDiscard` hook to the very bottom in case of `requestChannel` to ensure the first payload is not leaked 
4. Enables a set of tests that ensures that #757 and #733 are fully or partially fixed.