### PR TITLE
Deprecate AbstractRSocket and provide alternative

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/AbstractRSocket.java
+++ b/rsocket-core/src/main/java/io/rsocket/AbstractRSocket.java
@@ -16,47 +16,20 @@
 
 package io.rsocket;
 
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 
 /**
  * An abstract implementation of {@link RSocket}. All request handling methods emit {@link
  * UnsupportedOperationException} and hence must be overridden to provide a valid implementation.
+ *
+ * @deprecated as of 1.0 in favor of implementing {@link RSocket} directly which has default
+ *     methods.
  */
+@Deprecated
 public abstract class AbstractRSocket implements RSocket {
 
   private final MonoProcessor<Void> onClose = MonoProcessor.create();
-
-  @Override
-  public Mono<Void> fireAndForget(Payload payload) {
-    payload.release();
-    return Mono.error(new UnsupportedOperationException("Fire and forget not implemented."));
-  }
-
-  @Override
-  public Mono<Payload> requestResponse(Payload payload) {
-    payload.release();
-    return Mono.error(new UnsupportedOperationException("Request-Response not implemented."));
-  }
-
-  @Override
-  public Flux<Payload> requestStream(Payload payload) {
-    payload.release();
-    return Flux.error(new UnsupportedOperationException("Request-Stream not implemented."));
-  }
-
-  @Override
-  public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
-    return Flux.error(new UnsupportedOperationException("Request-Channel not implemented."));
-  }
-
-  @Override
-  public Mono<Void> metadataPush(Payload payload) {
-    payload.release();
-    return Mono.error(new UnsupportedOperationException("Metadata-Push not implemented."));
-  }
 
   @Override
   public void dispose() {

--- a/rsocket-core/src/main/java/io/rsocket/RSocket.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocket.java
@@ -33,7 +33,10 @@ public interface RSocket extends Availability, Closeable {
    * @return {@code Publisher} that completes when the passed {@code payload} is successfully
    *     handled, otherwise errors.
    */
-  Mono<Void> fireAndForget(Payload payload);
+  default Mono<Void> fireAndForget(Payload payload) {
+    payload.release();
+    return Mono.error(new UnsupportedOperationException("Fire-and-Forget not implemented."));
+  }
 
   /**
    * Request-Response interaction model of {@code RSocket}.
@@ -42,7 +45,10 @@ public interface RSocket extends Availability, Closeable {
    * @return {@code Publisher} containing at most a single {@code Payload} representing the
    *     response.
    */
-  Mono<Payload> requestResponse(Payload payload);
+  default Mono<Payload> requestResponse(Payload payload) {
+    payload.release();
+    return Mono.error(new UnsupportedOperationException("Request-Response not implemented."));
+  }
 
   /**
    * Request-Stream interaction model of {@code RSocket}.
@@ -50,7 +56,10 @@ public interface RSocket extends Availability, Closeable {
    * @param payload Request payload.
    * @return {@code Publisher} containing the stream of {@code Payload}s representing the response.
    */
-  Flux<Payload> requestStream(Payload payload);
+  default Flux<Payload> requestStream(Payload payload) {
+    payload.release();
+    return Flux.error(new UnsupportedOperationException("Request-Stream not implemented."));
+  }
 
   /**
    * Request-Channel interaction model of {@code RSocket}.
@@ -58,7 +67,9 @@ public interface RSocket extends Availability, Closeable {
    * @param payloads Stream of request payloads.
    * @return Stream of response payloads.
    */
-  Flux<Payload> requestChannel(Publisher<Payload> payloads);
+  default Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+    return Flux.error(new UnsupportedOperationException("Request-Channel not implemented."));
+  }
 
   /**
    * Metadata-Push interaction model of {@code RSocket}.
@@ -67,10 +78,26 @@ public interface RSocket extends Availability, Closeable {
    * @return {@code Publisher} that completes when the passed {@code payload} is successfully
    *     handled, otherwise errors.
    */
-  Mono<Void> metadataPush(Payload payload);
+  default Mono<Void> metadataPush(Payload payload) {
+    payload.release();
+    return Mono.error(new UnsupportedOperationException("Metadata-Push not implemented."));
+  }
 
   @Override
   default double availability() {
     return isDisposed() ? 0.0 : 1.0;
+  }
+
+  @Override
+  default void dispose() {}
+
+  @Override
+  default boolean isDisposed() {
+    return false;
+  }
+
+  @Override
+  default Mono<Void> onClose() {
+    return Mono.never();
   }
 }

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -17,7 +17,6 @@ package io.rsocket.core;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.rsocket.AbstractRSocket;
 import io.rsocket.ConnectionSetupPayload;
 import io.rsocket.DuplexConnection;
 import io.rsocket.Payload;
@@ -56,7 +55,7 @@ public class RSocketConnector {
   private String metadataMimeType = "application/binary";
   private String dataMimeType = "application/binary";
 
-  private SocketAcceptor acceptor = (setup, sendingSocket) -> Mono.just(new AbstractRSocket() {});
+  private SocketAcceptor acceptor = SocketAcceptor.with(new RSocket() {});
   private InitializingInterceptorRegistry interceptors = new InitializingInterceptorRegistry();
 
   private Duration keepAliveInterval = Duration.ofSeconds(20);

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
@@ -17,7 +17,6 @@
 package io.rsocket.core;
 
 import io.netty.buffer.ByteBuf;
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Closeable;
 import io.rsocket.ConnectionSetupPayload;
 import io.rsocket.DuplexConnection;
@@ -45,7 +44,7 @@ public final class RSocketServer {
   private static final String SERVER_TAG = "server";
   private static final int MIN_MTU_SIZE = 64;
 
-  private SocketAcceptor acceptor = (setup, sendingSocket) -> Mono.just(new AbstractRSocket() {});
+  private SocketAcceptor acceptor = SocketAcceptor.with(new RSocket() {});
   private InitializingInterceptorRegistry interceptors = new InitializingInterceptorRegistry();
   private int mtu = 0;
 

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
@@ -35,7 +35,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.frame.CancelFrameFlyweight;
@@ -164,7 +163,7 @@ public class RSocketResponderTest {
     final int streamId = 4;
     final AtomicBoolean cancelled = new AtomicBoolean();
     rule.setAcceptingSocket(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Mono<Payload> requestResponse(Payload payload) {
             payload.release();
@@ -193,8 +192,8 @@ public class RSocketResponderTest {
     ThreadLocalRandom.current().nextBytes(metadata);
     ThreadLocalRandom.current().nextBytes(data);
     final Payload payload = DefaultPayload.create(data, metadata);
-    final AbstractRSocket acceptingSocket =
-        new AbstractRSocket() {
+    final RSocket acceptingSocket =
+        new RSocket() {
           @Override
           public Mono<Payload> requestResponse(Payload p) {
             p.release();
@@ -256,7 +255,7 @@ public class RSocketResponderTest {
       AssertSubscriber<Payload> assertSubscriber = AssertSubscriber.create();
 
       rule.setAcceptingSocket(
-          new AbstractRSocket() {
+          new RSocket() {
             @Override
             public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
               payloads.subscribe(assertSubscriber);
@@ -312,7 +311,7 @@ public class RSocketResponderTest {
       FluxSink<Payload>[] sinks = new FluxSink[1];
 
       rule.setAcceptingSocket(
-          new AbstractRSocket() {
+          new RSocket() {
             @Override
             public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
               ((Flux<Payload>) payloads)
@@ -352,7 +351,7 @@ public class RSocketResponderTest {
       FluxSink<Payload>[] sinks = new FluxSink[1];
 
       rule.setAcceptingSocket(
-          new AbstractRSocket() {
+          new RSocket() {
             @Override
             public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
               ((Flux<Payload>) payloads)
@@ -397,7 +396,7 @@ public class RSocketResponderTest {
       FluxSink<Payload>[] sinks = new FluxSink[1];
       AssertSubscriber<Payload> assertSubscriber = AssertSubscriber.create();
       rule.setAcceptingSocket(
-          new AbstractRSocket() {
+          new RSocket() {
             @Override
             public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
               payloads.subscribe(assertSubscriber);
@@ -466,7 +465,7 @@ public class RSocketResponderTest {
       FluxSink<Payload>[] sinks = new FluxSink[1];
 
       rule.setAcceptingSocket(
-          new AbstractRSocket() {
+          new RSocket() {
             @Override
             public Flux<Payload> requestStream(Payload payload) {
               payload.release();
@@ -503,7 +502,7 @@ public class RSocketResponderTest {
       Operators.MonoSubscriber<Payload, Payload>[] sources = new Operators.MonoSubscriber[1];
 
       rule.setAcceptingSocket(
-          new AbstractRSocket() {
+          new RSocket() {
             @Override
             public Mono<Payload> requestResponse(Payload payload) {
               payload.release();
@@ -540,7 +539,7 @@ public class RSocketResponderTest {
     FluxSink<Payload>[] sinks = new FluxSink[1];
 
     rule.setAcceptingSocket(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestStream(Payload payload) {
             payload.release();
@@ -569,7 +568,7 @@ public class RSocketResponderTest {
     ByteBufAllocator allocator = rule.alloc();
 
     rule.setAcceptingSocket(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
             return (Flux<Payload>) payloads;
@@ -619,7 +618,7 @@ public class RSocketResponderTest {
     TestPublisher<Payload> testPublisher = TestPublisher.create();
 
     rule.setAcceptingSocket(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Mono<Void> fireAndForget(Payload payload) {
             Mono.just(payload).subscribe(assertSubscriber);
@@ -720,7 +719,7 @@ public class RSocketResponderTest {
     @Override
     protected void init() {
       acceptingSocket =
-          new AbstractRSocket() {
+          new RSocket() {
             @Override
             public Mono<Payload> requestResponse(Payload payload) {
               return Mono.just(payload);

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
@@ -83,7 +82,7 @@ public class RSocketTest {
   @Test(timeout = 2000)
   public void testHandlerEmitsError() {
     rule.setRequestAcceptor(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Mono<Payload> requestResponse(Payload payload) {
             return Mono.error(new NullPointerException("Deliberate exception."));
@@ -102,7 +101,7 @@ public class RSocketTest {
   @Test(timeout = 2000)
   public void testHandlerEmitsCustomError() {
     rule.setRequestAcceptor(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Mono<Payload> requestResponse(Payload payload) {
             return Mono.error(
@@ -129,7 +128,7 @@ public class RSocketTest {
   @Test(timeout = 2000)
   public void testRequestPropagatesCorrectlyForRequestChannel() {
     rule.setRequestAcceptor(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
             return Flux.from(payloads)
@@ -170,7 +169,7 @@ public class RSocketTest {
   public void testErrorPropagatesCorrectly() {
     AtomicReference<Throwable> error = new AtomicReference<>();
     rule.setRequestAcceptor(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
             return Flux.from(payloads).doOnError(error::set);
@@ -291,7 +290,7 @@ public class RSocketTest {
       TestPublisher<Payload> responderPublisher,
       AssertSubscriber<Payload> responderSubscriber) {
     rule.setRequestAcceptor(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
             payloads.subscribe(responderSubscriber);
@@ -446,7 +445,7 @@ public class RSocketTest {
       requestAcceptor =
           null != requestAcceptor
               ? requestAcceptor
-              : new AbstractRSocket() {
+              : new RSocket() {
                 @Override
                 public Mono<Payload> requestResponse(Payload payload) {
                   return Mono.just(payload);

--- a/rsocket-examples/src/test/java/io/rsocket/integration/IntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.core.RSocketConnector;
@@ -124,7 +123,7 @@ public class IntegrationTest {
                       .subscribe();
 
                   return Mono.just(
-                      new AbstractRSocket() {
+                      new RSocket() {
                         @Override
                         public Mono<Payload> requestResponse(Payload payload) {
                           return Mono.just(DefaultPayload.create("RESPONSE", "METADATA"))

--- a/rsocket-examples/src/test/java/io/rsocket/integration/InteractionsLoadTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/InteractionsLoadTest.java
@@ -1,8 +1,8 @@
 package io.rsocket.integration;
 
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.SocketAcceptor;
 import io.rsocket.core.RSocketConnector;
 import io.rsocket.core.RSocketServer;
 import io.rsocket.test.SlowTest;
@@ -15,7 +15,6 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 public class InteractionsLoadTest {
 
@@ -23,7 +22,7 @@ public class InteractionsLoadTest {
   @SlowTest
   public void channel() {
     CloseableChannel server =
-        RSocketServer.create((setup, rsocket) -> Mono.just(new EchoRSocket()))
+        RSocketServer.create(SocketAcceptor.with(new EchoRSocket()))
             .bind(TcpServerTransport.create("localhost", 0))
             .block(Duration.ofSeconds(10));
 
@@ -66,7 +65,8 @@ public class InteractionsLoadTest {
     return interval;
   }
 
-  private static class EchoRSocket extends AbstractRSocket {
+  private static class EchoRSocket implements RSocket {
+
     @Override
     public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
       return Flux.from(payloads)

--- a/rsocket-examples/src/test/java/io/rsocket/integration/TcpIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/TcpIntegrationTest.java
@@ -19,7 +19,6 @@ package io.rsocket.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.core.RSocketConnector;
@@ -41,7 +40,7 @@ import reactor.core.publisher.UnicastProcessor;
 import reactor.core.scheduler.Schedulers;
 
 public class TcpIntegrationTest {
-  private AbstractRSocket handler;
+  private RSocket handler;
 
   private CloseableChannel server;
 
@@ -65,7 +64,7 @@ public class TcpIntegrationTest {
   @Test(timeout = 15_000L)
   public void testCompleteWithoutNext() {
     handler =
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestStream(Payload payload) {
             return Flux.empty();
@@ -81,7 +80,7 @@ public class TcpIntegrationTest {
   @Test(timeout = 15_000L)
   public void testSingleStream() {
     handler =
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestStream(Payload payload) {
             return Flux.just(DefaultPayload.create("RESPONSE", "METADATA"));
@@ -98,7 +97,7 @@ public class TcpIntegrationTest {
   @Test(timeout = 15_000L)
   public void testZeroPayload() {
     handler =
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestStream(Payload payload) {
             return Flux.just(EmptyPayload.INSTANCE);
@@ -115,7 +114,7 @@ public class TcpIntegrationTest {
   @Test(timeout = 15_000L)
   public void testRequestResponseErrors() {
     handler =
-        new AbstractRSocket() {
+        new RSocket() {
           boolean first = true;
 
           @Override
@@ -155,7 +154,7 @@ public class TcpIntegrationTest {
     map.put("REQUEST2", processor2);
 
     handler =
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestStream(Payload payload) {
             return map.get(payload.getDataUtf8());

--- a/rsocket-examples/src/test/java/io/rsocket/resume/ResumeIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/resume/ResumeIntegrationTest.java
@@ -16,9 +16,9 @@
 
 package io.rsocket.resume;
 
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.SocketAcceptor;
 import io.rsocket.core.RSocketConnector;
 import io.rsocket.core.RSocketServer;
 import io.rsocket.core.Resume;
@@ -127,7 +127,7 @@ public class ResumeIntegrationTest {
   @Test
   void serverMissingResume() {
     CloseableChannel closeableChannel =
-        RSocketServer.create((setupPayload, rSocket) -> Mono.just(new TestResponderRSocket()))
+        RSocketServer.create(SocketAcceptor.with(new TestResponderRSocket()))
             .bind(serverTransport(SERVER_HOST, SERVER_PORT))
             .block();
 
@@ -194,7 +194,7 @@ public class ResumeIntegrationTest {
   }
 
   private static Mono<CloseableChannel> newServerRSocket(int sessionDurationSeconds) {
-    return RSocketServer.create((setup, rsocket) -> Mono.just(new TestResponderRSocket()))
+    return RSocketServer.create(SocketAcceptor.with(new TestResponderRSocket()))
         .resume(
             new Resume()
                 .sessionDuration(Duration.ofSeconds(sessionDurationSeconds))
@@ -203,7 +203,7 @@ public class ResumeIntegrationTest {
         .bind(serverTransport(SERVER_HOST, SERVER_PORT));
   }
 
-  private static class TestResponderRSocket extends AbstractRSocket {
+  private static class TestResponderRSocket implements RSocket {
 
     AtomicInteger counter = new AtomicInteger();
 

--- a/rsocket-test/src/main/java/io/rsocket/test/PingHandler.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/PingHandler.java
@@ -16,7 +16,6 @@
 
 package io.rsocket.test;
 
-import io.rsocket.AbstractRSocket;
 import io.rsocket.ConnectionSetupPayload;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
@@ -43,7 +42,7 @@ public class PingHandler implements SocketAcceptor {
   @Override
   public Mono<RSocket> accept(ConnectionSetupPayload setup, RSocket sendingSocket) {
     return Mono.just(
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Mono<Payload> requestResponse(Payload payload) {
             payload.release();

--- a/rsocket-test/src/main/java/io/rsocket/test/TestRSocket.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TestRSocket.java
@@ -16,14 +16,14 @@
 
 package io.rsocket.test;
 
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
+import io.rsocket.RSocket;
 import io.rsocket.util.DefaultPayload;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public class TestRSocket extends AbstractRSocket {
+public class TestRSocket implements RSocket {
   private final String data;
   private final String metadata;
 

--- a/rsocket-transport-netty/src/test/java/io/rsocket/integration/FragmentTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/integration/FragmentTest.java
@@ -18,7 +18,6 @@ package io.rsocket.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.core.RSocketConnector;
@@ -38,7 +37,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class FragmentTest {
-  private AbstractRSocket handler;
+  private RSocket handler;
   private CloseableChannel server;
   private String message = null;
   private String metaData = null;
@@ -89,7 +88,7 @@ public class FragmentTest {
     System.out.println(
         "-------------------------------------------------testFragmentNoMetaData-------------------------------------------------");
     handler =
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestStream(Payload payload) {
             String request = payload.getDataUtf8();
@@ -119,7 +118,7 @@ public class FragmentTest {
     System.out.println(
         "-------------------------------------------------testFragmentRequestMetaDataOnly-------------------------------------------------");
     handler =
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestStream(Payload payload) {
             String request = payload.getDataUtf8();
@@ -150,7 +149,7 @@ public class FragmentTest {
     System.out.println(
         "-------------------------------------------------testFragmentBothMetaData-------------------------------------------------");
     handler =
-        new AbstractRSocket() {
+        new RSocket() {
           @Override
           public Flux<Payload> requestStream(Payload payload) {
             String request = payload.getDataUtf8();

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebSocketTransportIntegrationTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebSocketTransportIntegrationTest.java
@@ -1,8 +1,7 @@
 package io.rsocket.transport.netty;
 
-import io.rsocket.AbstractRSocket;
-import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.SocketAcceptor;
 import io.rsocket.core.RSocketConnector;
 import io.rsocket.core.RSocketServer;
 import io.rsocket.transport.ServerTransport;
@@ -14,7 +13,6 @@ import java.net.URI;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
 import reactor.test.StepVerifier;
@@ -25,16 +23,9 @@ public class WebSocketTransportIntegrationTest {
   public void sendStreamOfDataWithExternalHttpServerTest() {
     ServerTransport.ConnectionAcceptor acceptor =
         RSocketServer.create(
-                (setupPayload, sendingRSocket) -> {
-                  return Mono.just(
-                      new AbstractRSocket() {
-                        @Override
-                        public Flux<Payload> requestStream(Payload payload) {
-                          return Flux.range(0, 10)
-                              .map(i -> DefaultPayload.create(String.valueOf(i)));
-                        }
-                      });
-                })
+                SocketAcceptor.forRequestStream(
+                    payload ->
+                        Flux.range(0, 10).map(i -> DefaultPayload.create(String.valueOf(i)))))
             .asConnectionAcceptor();
 
     DisposableServer server =

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketPingPongIntegrationTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketPingPongIntegrationTest.java
@@ -8,10 +8,9 @@ import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.util.ReferenceCountUtil;
-import io.rsocket.AbstractRSocket;
 import io.rsocket.Closeable;
-import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.SocketAcceptor;
 import io.rsocket.core.RSocketConnector;
 import io.rsocket.core.RSocketServer;
 import io.rsocket.transport.ServerTransport;
@@ -47,7 +46,7 @@ public class WebsocketPingPongIntegrationTest {
   @MethodSource("provideServerTransport")
   void webSocketPingPong(ServerTransport<Closeable> serverTransport) {
     server =
-        RSocketServer.create((setup, sendingSocket) -> Mono.just(new EchoRSocket()))
+        RSocketServer.create(SocketAcceptor.forRequestResponse(Mono::just))
             .bind(serverTransport)
             .block();
 
@@ -98,13 +97,6 @@ public class WebsocketPingPongIntegrationTest {
         Arguments.of(
             new WebsocketRouteTransport(
                 HttpServer.create().host(host).port(port), routes -> {}, "/")));
-  }
-
-  private static class EchoRSocket extends AbstractRSocket {
-    @Override
-    public Mono<Payload> requestResponse(Payload payload) {
-      return Mono.just(payload);
-    }
   }
 
   private static class PingSender extends ChannelInboundHandlerAdapter {


### PR DESCRIPTION
This change deprecates `AbstractRSocket` in favor of implementing `RSocket` directly. In turn RSocket has default methods for the basic interactions while `onClose()` now returns `Mono.never()` by default and has to be implemented anyway if it is to do something more meaningful.

In addition `SocketAcceptor` provides static factory methods as shortcuts for handling one type of interaction with a lambda syntax.