### PR TITLE
adds missing NPE catch in order to handle rare racing cases

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -478,7 +478,7 @@ class RSocketRequester implements RSocket {
                         frame =
                             RequestChannelFrameFlyweight.encodeReleasingPayload(
                                 allocator, streamId, false, n, initialPayload);
-                      } catch (IllegalReferenceCountException e) {
+                      } catch (IllegalReferenceCountException | NullPointerException e) {
                         return;
                       }
 


### PR DESCRIPTION
The mentioned NPE case may happen rarely due to racing, thus not always can be reproduced in racing tests (or can be reproduced rarely)

Just observed that case in https://travis-ci.org/github/rsocket/rsocket-java/jobs/681587006

and figured one place which miss NPE catching

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>