### PR TITLE
provides ordered stream id issuing

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 
 public class RSocketConnector {
@@ -293,7 +294,8 @@ public class RSocketConnector {
                       (int) keepAliveInterval.toMillis(),
                       (int) keepAliveMaxLifeTime.toMillis(),
                       keepAliveHandler,
-                      requesterLeaseHandler);
+                      requesterLeaseHandler,
+                      Schedulers.single(Schedulers.parallel()));
 
               RSocket wrappedRSocketRequester = interceptors.initRequester(rSocketRequester);
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public final class RSocketServer {
   private static final String SERVER_TAG = "server";
@@ -222,7 +223,8 @@ public final class RSocketServer {
                   setupPayload.keepAliveInterval(),
                   setupPayload.keepAliveMaxLifetime(),
                   keepAliveHandler,
-                  requesterLeaseHandler);
+                  requesterLeaseHandler,
+                  Schedulers.single(Schedulers.parallel()));
 
           RSocket wrappedRSocketRequester = interceptors.initRequester(rSocketRequester);
 

--- a/rsocket-core/src/test/java/io/rsocket/TestScheduler.java
+++ b/rsocket-core/src/test/java/io/rsocket/TestScheduler.java
@@ -1,0 +1,80 @@
+package io.rsocket;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.Exceptions;
+import reactor.core.scheduler.Scheduler;
+import reactor.util.concurrent.Queues;
+
+/**
+ * This is an implementation of scheduler which allows task execution on the caller thread or
+ * scheduling it for thread which are currently working (with "work stealing" behaviour)
+ */
+public final class TestScheduler implements Scheduler {
+
+  public static final Scheduler INSTANCE = new TestScheduler();
+
+  volatile int wip;
+  static final AtomicIntegerFieldUpdater<TestScheduler> WIP =
+      AtomicIntegerFieldUpdater.newUpdater(TestScheduler.class, "wip");
+
+  final Worker sharedWorker = new TestWorker(this);
+  final Queue<Runnable> tasks = Queues.<Runnable>unboundedMultiproducer().get();
+
+  private TestScheduler() {}
+
+  @Override
+  public Disposable schedule(Runnable task) {
+    tasks.offer(task);
+    if (WIP.getAndIncrement(this) != 0) {
+      return Disposables.never();
+    }
+
+    int missed = 1;
+
+    for (; ; ) {
+      for (; ; ) {
+        Runnable runnable = tasks.poll();
+
+        if (runnable == null) {
+          break;
+        }
+
+        try {
+          runnable.run();
+        } catch (Throwable t) {
+          Exceptions.throwIfFatal(t);
+        }
+      }
+
+      missed = WIP.addAndGet(this, -missed);
+      if (missed == 0) {
+        return Disposables.never();
+      }
+    }
+  }
+
+  @Override
+  public Worker createWorker() {
+    return sharedWorker;
+  }
+
+  static class TestWorker implements Worker {
+
+    final TestScheduler parent;
+
+    TestWorker(TestScheduler parent) {
+      this.parent = parent;
+    }
+
+    @Override
+    public Disposable schedule(Runnable task) {
+      return parent.schedule(task);
+    }
+
+    @Override
+    public void dispose() {}
+  }
+}

--- a/rsocket-core/src/test/java/io/rsocket/core/KeepAliveTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/KeepAliveTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.rsocket.RSocket;
+import io.rsocket.TestScheduler;
 import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.exceptions.ConnectionErrorException;
 import io.rsocket.frame.FrameHeaderFlyweight;
@@ -67,7 +68,8 @@ public class KeepAliveTest {
             tickPeriod,
             timeout,
             new DefaultKeepAliveHandler(connection),
-            RequesterLeaseHandler.None);
+            RequesterLeaseHandler.None,
+            TestScheduler.INSTANCE);
     return new RSocketState(rSocket, errors, allocator, connection);
   }
 
@@ -94,7 +96,8 @@ public class KeepAliveTest {
             tickPeriod,
             timeout,
             new ResumableKeepAliveHandler(resumableConnection),
-            RequesterLeaseHandler.None);
+            RequesterLeaseHandler.None,
+            TestScheduler.INSTANCE);
     return new ResumableRSocketState(rSocket, errors, connection, resumableConnection, allocator);
   }
 

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketLeaseTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketLeaseTest.java
@@ -28,6 +28,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.TestScheduler;
 import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.exceptions.Exceptions;
 import io.rsocket.frame.FrameHeaderFlyweight;
@@ -98,7 +99,8 @@ class RSocketLeaseTest {
             0,
             0,
             null,
-            requesterLeaseHandler);
+            requesterLeaseHandler,
+            TestScheduler.INSTANCE);
 
     RSocket mockRSocketHandler = mock(RSocket.class);
     when(mockRSocketHandler.metadataPush(any())).thenReturn(Mono.empty());

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
@@ -19,6 +19,7 @@ package io.rsocket.core;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.RSocket;
+import io.rsocket.TestScheduler;
 import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.frame.FrameHeaderFlyweight;
 import io.rsocket.frame.FrameType;
@@ -28,7 +29,6 @@ import io.rsocket.internal.subscriber.AssertSubscriber;
 import io.rsocket.lease.RequesterLeaseHandler;
 import io.rsocket.test.util.TestDuplexConnection;
 import io.rsocket.util.DefaultPayload;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,7 +41,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.test.StepVerifier;
 import reactor.test.util.RaceTestUtils;
 
 class RSocketRequesterSubscribersTest {
@@ -73,21 +72,25 @@ class RSocketRequesterSubscribersTest {
             0,
             0,
             null,
-            RequesterLeaseHandler.None);
+            RequesterLeaseHandler.None,
+            TestScheduler.INSTANCE);
   }
 
   @ParameterizedTest
   @MethodSource("allInteractions")
   void singleSubscriber(Function<RSocket, Publisher<?>> interaction) {
     Flux<?> response = Flux.from(interaction.apply(rSocketRequester));
-    StepVerifier.withVirtualTime(() -> response.take(Duration.ofMillis(10)))
-        .thenAwait(Duration.ofMillis(10))
-        .expectComplete()
-        .verify(Duration.ofSeconds(5));
-    StepVerifier.withVirtualTime(() -> response.take(Duration.ofMillis(10)))
-        .thenAwait(Duration.ofMillis(10))
-        .expectError(IllegalStateException.class)
-        .verify(Duration.ofSeconds(5));
+
+    AssertSubscriber assertSubscriberA = AssertSubscriber.create();
+    AssertSubscriber assertSubscriberB = AssertSubscriber.create();
+
+    response.subscribe(assertSubscriberA);
+    response.subscribe(assertSubscriberB);
+
+    connection.addToReceivedBuffer(PayloadFrameFlyweight.encodeComplete(connection.alloc(), 1));
+
+    assertSubscriberA.assertTerminated();
+    assertSubscriberB.assertTerminated();
 
     Assertions.assertThat(requestFramesCount(connection.getSent())).isEqualTo(1);
   }

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -41,6 +41,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.TestScheduler;
 import io.rsocket.exceptions.ApplicationErrorException;
 import io.rsocket.exceptions.CustomRSocketException;
 import io.rsocket.exceptions.RejectedSetupException;
@@ -924,6 +925,50 @@ public class RSocketRequesterTest {
                 (rule, payload) -> rule.socket.requestChannel(Flux.just(payload))));
   }
 
+  @ParameterizedTest
+  @MethodSource("streamIdRacingCases")
+  public void ensuresCorrectOrderOfStreamIdIssuingInCaseOfRacing(
+      BiFunction<ClientSocketRule, Payload, Publisher<?>> interaction1,
+      BiFunction<ClientSocketRule, Payload, Publisher<?>> interaction2) {
+    for (int i = 1; i < 10000; i += 4) {
+      Payload payload = DefaultPayload.create("test");
+      Publisher<?> publisher1 = interaction1.apply(rule, payload);
+      Publisher<?> publisher2 = interaction2.apply(rule, payload);
+      RaceTestUtils.race(
+          () -> publisher1.subscribe(AssertSubscriber.create()),
+          () -> publisher2.subscribe(AssertSubscriber.create()));
+
+      Assertions.assertThat(rule.connection.getSent())
+          .extracting(FrameHeaderFlyweight::streamId)
+          .containsExactly(i, i + 2);
+      rule.connection.getSent().clear();
+    }
+  }
+
+  public static Stream<Arguments> streamIdRacingCases() {
+    return Stream.of(
+        Arguments.of(
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.fireAndForget(p),
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestResponse(p)),
+        Arguments.of(
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestResponse(p),
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestStream(p)),
+        Arguments.of(
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestStream(p),
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestChannel(Flux.just(p))),
+        Arguments.of(
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestChannel(Flux.just(p)),
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.fireAndForget(p)));
+  }
+
   public int sendRequestResponse(Publisher<Payload> response) {
     Subscriber<Payload> sub = TestSubscriber.create();
     response.subscribe(sub);
@@ -948,7 +993,8 @@ public class RSocketRequesterTest {
           0,
           0,
           null,
-          RequesterLeaseHandler.None);
+          RequesterLeaseHandler.None,
+          TestScheduler.INSTANCE);
     }
 
     public int getStreamIdForRequestType(FrameType expectedFrameType) {

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.TestScheduler;
 import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.exceptions.ApplicationErrorException;
 import io.rsocket.exceptions.CustomRSocketException;
@@ -492,7 +493,8 @@ public class RSocketTest {
               0,
               0,
               null,
-              RequesterLeaseHandler.None);
+              RequesterLeaseHandler.None,
+              TestScheduler.INSTANCE);
     }
 
     public void setRequestAcceptor(RSocket requestAcceptor) {

--- a/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
@@ -64,7 +64,8 @@ public class SetupRejectionTest {
             0,
             0,
             null,
-            RequesterLeaseHandler.None);
+            RequesterLeaseHandler.None,
+            TestScheduler.INSTANCE);
 
     String errorMsg = "error";
 
@@ -101,7 +102,8 @@ public class SetupRejectionTest {
             0,
             0,
             null,
-            RequesterLeaseHandler.None);
+            RequesterLeaseHandler.None,
+            TestScheduler.INSTANCE);
 
     conn.addToReceivedBuffer(
         ErrorFrameFlyweight.encode(


### PR DESCRIPTION
This PR ensures that stream ids are issued in order even under high racing between logical streams in the way of scheduling stream id issuing on the event loop scheduler. 

This is done on the level of RSocket because of the incorrect Transport level design and should be considered as a workaround until DuplexConnection will be revised in 1.1

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>