### PR TITLE
optimizes stream id to be non-thread-safe

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/DuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/DuplexConnection.java
@@ -23,6 +23,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 
 /** Represents a connection with input/output that the protocol uses. */
 public interface DuplexConnection extends Availability, Closeable {
@@ -85,6 +86,14 @@ public interface DuplexConnection extends Availability, Closeable {
    * @return the {@link ByteBufAllocator}
    */
   ByteBufAllocator alloc();
+
+  /**
+   * Returns associated to this connection {@link Scheduler} that will process all submitted tasks
+   * in an ordered / serial fashion.
+   *
+   * @return events' ordered {@link Scheduler}
+   */
+  Scheduler eventLoopScheduler();
 
   @Override
   default double availability() {

--- a/rsocket-core/src/main/java/io/rsocket/core/DefaultStreamIdSupplier.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/DefaultStreamIdSupplier.java
@@ -15,17 +15,26 @@
  */
 package io.rsocket.core;
 
-interface StreamIdSupplier {
+final class DefaultStreamIdSupplier implements StreamIdSupplier {
+  private static final int MASK = 0x7FFFFFFF;
 
-  int nextStreamId();
+  private long streamId;
 
-  boolean isBeforeOrCurrent(int streamId);
-
-  static StreamIdSupplier clientSupplier() {
-    return new DefaultStreamIdSupplier(-1);
+  // Visible for testing
+  DefaultStreamIdSupplier(int streamId) {
+    this.streamId = streamId;
   }
 
-  static StreamIdSupplier serverSupplier() {
-    return new DefaultStreamIdSupplier(0);
+  public int nextStreamId() {
+    int streamId;
+    do {
+      this.streamId += 2;
+      streamId = (int) (this.streamId & MASK);
+    } while (streamId == 0);
+    return streamId;
+  }
+
+  public boolean isBeforeOrCurrent(int streamId) {
+    return this.streamId >= streamId && streamId > 0;
   }
 }

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -252,7 +252,8 @@ public class RSocketConnector {
               KeepAliveHandler keepAliveHandler;
               DuplexConnection wrappedConnection;
 
-              if (resume != null) {
+              boolean isResumeEnabled = resume != null;
+              if (isResumeEnabled) {
                 resumeToken = resume.getTokenSupplier().get();
                 ClientRSocketSession session =
                     new ClientRSocketSession(
@@ -286,6 +287,7 @@ public class RSocketConnector {
               RSocket rSocketRequester =
                   new RSocketRequester(
                       multiplexer.asClientConnection(),
+                      isResumeEnabled,
                       payloadDecoder,
                       errorConsumer,
                       StreamIdSupplier.clientSupplier(),

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -208,22 +208,23 @@ class RSocketRequester implements RSocket {
 
     final AtomicBoolean once = new AtomicBoolean();
 
-    return Mono.defer(
-        () -> {
-          if (once.getAndSet(true)) {
-            return Mono.error(
-                new IllegalStateException("FireAndForgetMono allows only a single subscriber"));
-          }
+    return Mono.<Void>defer(
+            () -> {
+              if (once.getAndSet(true)) {
+                return Mono.error(
+                    new IllegalStateException("FireAndForgetMono allows only a single subscriber"));
+              }
 
-          final int streamId = streamIdSupplier.nextStreamId(receivers);
-          final ByteBuf requestFrame =
-              RequestFireAndForgetFrameFlyweight.encodeReleasingPayload(
-                  allocator, streamId, payload);
+              final int streamId = streamIdSupplier.nextStreamId(receivers);
+              final ByteBuf requestFrame =
+                  RequestFireAndForgetFrameFlyweight.encodeReleasingPayload(
+                      allocator, streamId, payload);
 
-          sendProcessor.onNext(requestFrame);
+              sendProcessor.onNext(requestFrame);
 
-          return Mono.empty();
-        });
+              return Mono.empty();
+            })
+        .subscribeOn(connection.eventLoopScheduler());
   }
 
   private Mono<Payload> handleRequestResponse(final Payload payload) {
@@ -284,6 +285,7 @@ class RSocketRequester implements RSocket {
                               receivers.remove(streamId, receiver);
                             }
                           }))
+              .subscribeOn(connection.eventLoopScheduler())
               .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER);
         });
   }
@@ -356,6 +358,7 @@ class RSocketRequester implements RSocket {
                               receivers.remove(streamId);
                             }
                           }))
+              .subscribeOn(connection.eventLoopScheduler(), false)
               .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER);
         });
   }
@@ -392,120 +395,125 @@ class RSocketRequester implements RSocket {
 
     final UnicastProcessor<Payload> receiver = UnicastProcessor.create();
 
-    return receiver.transform(
-        Operators.<Payload, Payload>lift(
-            (s, actual) ->
-                new RequestOperator(actual) {
+    return receiver
+        .transform(
+            Operators.<Payload, Payload>lift(
+                (s, actual) ->
+                    new RequestOperator(actual) {
 
-                  final BaseSubscriber<Payload> upstreamSubscriber =
-                      new BaseSubscriber<Payload>() {
+                      final BaseSubscriber<Payload> upstreamSubscriber =
+                          new BaseSubscriber<Payload>() {
 
-                        boolean first = true;
+                            boolean first = true;
 
-                        @Override
-                        protected void hookOnSubscribe(Subscription subscription) {
-                          // noops
+                            @Override
+                            protected void hookOnSubscribe(Subscription subscription) {
+                              // noops
+                            }
+
+                            @Override
+                            protected void hookOnNext(Payload payload) {
+                              if (first) {
+                                // need to skip first since we have already sent it
+                                // no need to release it since it was released earlier on the
+                                // request
+                                // establishment
+                                // phase
+                                first = false;
+                                request(1);
+                                return;
+                              }
+                              if (!PayloadValidationUtils.isValid(mtu, payload)) {
+                                payload.release();
+                                cancel();
+                                final IllegalArgumentException t =
+                                    new IllegalArgumentException(INVALID_PAYLOAD_ERROR_MESSAGE);
+                                errorConsumer.accept(t);
+                                // no need to send any errors.
+                                sendProcessor.onNext(
+                                    CancelFrameFlyweight.encode(allocator, streamId));
+                                receiver.onError(t);
+                                return;
+                              }
+                              final ByteBuf frame =
+                                  PayloadFrameFlyweight.encodeNextReleasingPayload(
+                                      allocator, streamId, payload);
+
+                              sendProcessor.onNext(frame);
+                            }
+
+                            @Override
+                            protected void hookOnComplete() {
+                              ByteBuf frame =
+                                  PayloadFrameFlyweight.encodeComplete(allocator, streamId);
+                              sendProcessor.onNext(frame);
+                            }
+
+                            @Override
+                            protected void hookOnError(Throwable t) {
+                              ByteBuf frame = ErrorFrameFlyweight.encode(allocator, streamId, t);
+                              sendProcessor.onNext(frame);
+                              receiver.onError(t);
+                            }
+
+                            @Override
+                            protected void hookFinally(SignalType type) {
+                              senders.remove(streamId, this);
+                            }
+                          };
+
+                      @Override
+                      void hookOnFirstRequest(long n) {
+                        final int streamId = streamIdSupplier.nextStreamId(receivers);
+                        this.streamId = streamId;
+
+                        final ByteBuf frame =
+                            RequestChannelFrameFlyweight.encodeReleasingPayload(
+                                allocator, streamId, false, n, initialPayload);
+
+                        senders.put(streamId, upstreamSubscriber);
+                        receivers.put(streamId, receiver);
+
+                        inboundFlux
+                            .limitRate(Queues.SMALL_BUFFER_SIZE)
+                            .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER)
+                            .subscribe(upstreamSubscriber);
+
+                        sendProcessor.onNext(frame);
+                      }
+
+                      @Override
+                      void hookOnRemainingRequests(long n) {
+                        if (receiver.isDisposed()) {
+                          return;
                         }
 
-                        @Override
-                        protected void hookOnNext(Payload payload) {
-                          if (first) {
-                            // need to skip first since we have already sent it
-                            // no need to release it since it was released earlier on the request
-                            // establishment
-                            // phase
-                            first = false;
-                            request(1);
-                            return;
-                          }
-                          if (!PayloadValidationUtils.isValid(mtu, payload)) {
-                            payload.release();
-                            cancel();
-                            final IllegalArgumentException t =
-                                new IllegalArgumentException(INVALID_PAYLOAD_ERROR_MESSAGE);
-                            errorConsumer.accept(t);
-                            // no need to send any errors.
-                            sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
-                            receiver.onError(t);
-                            return;
-                          }
-                          final ByteBuf frame =
-                              PayloadFrameFlyweight.encodeNextReleasingPayload(
-                                  allocator, streamId, payload);
+                        sendProcessor.onNext(RequestNFrameFlyweight.encode(allocator, streamId, n));
+                      }
 
-                          sendProcessor.onNext(frame);
+                      @Override
+                      void hookOnCancel() {
+                        senders.remove(streamId, upstreamSubscriber);
+                        if (receivers.remove(streamId, receiver)) {
+                          sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
                         }
+                      }
 
-                        @Override
-                        protected void hookOnComplete() {
-                          ByteBuf frame = PayloadFrameFlyweight.encodeComplete(allocator, streamId);
-                          sendProcessor.onNext(frame);
+                      @Override
+                      void hookOnTerminal(SignalType signalType) {
+                        if (signalType == SignalType.ON_ERROR) {
+                          upstreamSubscriber.cancel();
                         }
+                        receivers.remove(streamId, receiver);
+                      }
 
-                        @Override
-                        protected void hookOnError(Throwable t) {
-                          ByteBuf frame = ErrorFrameFlyweight.encode(allocator, streamId, t);
-                          sendProcessor.onNext(frame);
-                          receiver.onError(t);
-                        }
-
-                        @Override
-                        protected void hookFinally(SignalType type) {
-                          senders.remove(streamId, this);
-                        }
-                      };
-
-                  @Override
-                  void hookOnFirstRequest(long n) {
-                    final int streamId = streamIdSupplier.nextStreamId(receivers);
-                    this.streamId = streamId;
-
-                    final ByteBuf frame =
-                        RequestChannelFrameFlyweight.encodeReleasingPayload(
-                            allocator, streamId, false, n, initialPayload);
-
-                    senders.put(streamId, upstreamSubscriber);
-                    receivers.put(streamId, receiver);
-
-                    inboundFlux
-                        .limitRate(Queues.SMALL_BUFFER_SIZE)
-                        .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER)
-                        .subscribe(upstreamSubscriber);
-
-                    sendProcessor.onNext(frame);
-                  }
-
-                  @Override
-                  void hookOnRemainingRequests(long n) {
-                    if (receiver.isDisposed()) {
-                      return;
-                    }
-
-                    sendProcessor.onNext(RequestNFrameFlyweight.encode(allocator, streamId, n));
-                  }
-
-                  @Override
-                  void hookOnCancel() {
-                    senders.remove(streamId, upstreamSubscriber);
-                    if (receivers.remove(streamId, receiver)) {
-                      sendProcessor.onNext(CancelFrameFlyweight.encode(allocator, streamId));
-                    }
-                  }
-
-                  @Override
-                  void hookOnTerminal(SignalType signalType) {
-                    if (signalType == SignalType.ON_ERROR) {
-                      upstreamSubscriber.cancel();
-                    }
-                    receivers.remove(streamId, receiver);
-                  }
-
-                  @Override
-                  public void cancel() {
-                    upstreamSubscriber.cancel();
-                    super.cancel();
-                  }
-                }));
+                      @Override
+                      public void cancel() {
+                        upstreamSubscriber.cancel();
+                        super.cancel();
+                      }
+                    }))
+        .subscribeOn(connection.eventLoopScheduler(), false);
   }
 
   private Mono<Void> handleMetadataPush(Payload payload) {

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
@@ -215,6 +215,7 @@ public final class RSocketServer {
           RSocket rSocketRequester =
               new RSocketRequester(
                   wrappedMultiplexer.asServerConnection(),
+                  resume != null,
                   payloadDecoder,
                   errorConsumer,
                   StreamIdSupplier.serverSupplier(),

--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/ReassemblyDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/ReassemblyDuplexConnection.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 
 /**
  * A {@link DuplexConnection} implementation that reassembles {@link ByteBuf}s.
@@ -73,6 +74,11 @@ public class ReassemblyDuplexConnection implements DuplexConnection {
               ByteBuf decode = decode(byteBuf);
               frameReassembler.reassembleFrame(decode, sink);
             });
+  }
+
+  @Override
+  public Scheduler eventLoopScheduler() {
+    return delegate.eventLoopScheduler();
   }
 
   @Override

--- a/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
+import reactor.core.scheduler.Scheduler;
 
 /**
  * {@link DuplexConnection#receive()} is a single stream on which the following type of frames
@@ -200,6 +201,11 @@ public class ClientServerInputMultiplexer implements Closeable {
                           return f;
                         }
                       }));
+    }
+
+    @Override
+    public Scheduler eventLoopScheduler() {
+      return source.eventLoopScheduler();
     }
 
     @Override

--- a/rsocket-core/src/main/java/io/rsocket/resume/ResumableDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ResumableDuplexConnection.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.publisher.*;
+import reactor.core.scheduler.Scheduler;
 import reactor.util.concurrent.Queues;
 
 public class ResumableDuplexConnection implements DuplexConnection, ResumeStateHolder {
@@ -104,6 +105,11 @@ public class ResumableDuplexConnection implements DuplexConnection, ResumeStateH
             .cache();
 
     reconnect(duplexConnection);
+  }
+
+  @Override
+  public Scheduler eventLoopScheduler() {
+    return curConnection.eventLoopScheduler();
   }
 
   @Override

--- a/rsocket-core/src/test/java/io/rsocket/TestScheduler.java
+++ b/rsocket-core/src/test/java/io/rsocket/TestScheduler.java
@@ -1,0 +1,80 @@
+package io.rsocket;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.Exceptions;
+import reactor.core.scheduler.Scheduler;
+import reactor.util.concurrent.Queues;
+
+/**
+ * This is an implementation of scheduler which allows task execution on the caller thread or
+ * scheduling it for thread which are currently working (with "work stealing" behaviour)
+ */
+public final class TestScheduler implements Scheduler {
+
+  public static final Scheduler INSTANCE = new TestScheduler();
+
+  volatile int wip;
+  static final AtomicIntegerFieldUpdater<TestScheduler> WIP =
+      AtomicIntegerFieldUpdater.newUpdater(TestScheduler.class, "wip");
+
+  final Worker sharedWorker = new TestWorker(this);
+  final Queue<Runnable> tasks = Queues.<Runnable>unboundedMultiproducer().get();
+
+  private TestScheduler() {}
+
+  @Override
+  public Disposable schedule(Runnable task) {
+    tasks.offer(task);
+    if (WIP.getAndIncrement(this) != 0) {
+      return Disposables.never();
+    }
+
+    int missed = 1;
+
+    for (; ; ) {
+      for (; ; ) {
+        Runnable runnable = tasks.poll();
+
+        if (runnable == null) {
+          break;
+        }
+
+        try {
+          runnable.run();
+        } catch (Throwable t) {
+          Exceptions.throwIfFatal(t);
+        }
+      }
+
+      missed = WIP.addAndGet(this, -missed);
+      if (missed == 0) {
+        return Disposables.never();
+      }
+    }
+  }
+
+  @Override
+  public Worker createWorker() {
+    return sharedWorker;
+  }
+
+  static class TestWorker implements Worker {
+
+    final TestScheduler parent;
+
+    TestWorker(TestScheduler parent) {
+      this.parent = parent;
+    }
+
+    @Override
+    public Disposable schedule(Runnable task) {
+      return parent.schedule(task);
+    }
+
+    @Override
+    public void dispose() {}
+  }
+}

--- a/rsocket-core/src/test/java/io/rsocket/core/KeepAliveTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/KeepAliveTest.java
@@ -60,6 +60,7 @@ public class KeepAliveTest {
     RSocketRequester rSocket =
         new RSocketRequester(
             connection,
+            false,
             DefaultPayload::create,
             errors,
             StreamIdSupplier.clientSupplier(),
@@ -87,6 +88,7 @@ public class KeepAliveTest {
     RSocketRequester rSocket =
         new RSocketRequester(
             resumableConnection,
+            true,
             DefaultPayload::create,
             errors,
             StreamIdSupplier.clientSupplier(),

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketLeaseTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketLeaseTest.java
@@ -91,6 +91,7 @@ class RSocketLeaseTest {
     rSocketRequester =
         new RSocketRequester(
             multiplexer.asClientConnection(),
+            false,
             payloadDecoder,
             err -> {},
             StreamIdSupplier.clientSupplier(),

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
@@ -64,6 +64,7 @@ class RSocketRequesterSubscribersTest {
     rSocketRequester =
         new RSocketRequester(
             connection,
+            false,
             PayloadDecoder.DEFAULT,
             err -> {},
             StreamIdSupplier.clientSupplier(),

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -924,6 +924,50 @@ public class RSocketRequesterTest {
                 (rule, payload) -> rule.socket.requestChannel(Flux.just(payload))));
   }
 
+  @ParameterizedTest
+  @MethodSource("streamIdRacingCases")
+  public void ensuresCorrectOrderOfStreamIdIssuingInCaseOfRacing(
+      BiFunction<ClientSocketRule, Payload, Publisher<?>> interaction1,
+      BiFunction<ClientSocketRule, Payload, Publisher<?>> interaction2) {
+    for (int i = 1; i < 10000; i += 4) {
+      Payload payload = DefaultPayload.create("test");
+      Publisher<?> publisher1 = interaction1.apply(rule, payload);
+      Publisher<?> publisher2 = interaction2.apply(rule, payload);
+      RaceTestUtils.race(
+          () -> publisher1.subscribe(AssertSubscriber.create()),
+          () -> publisher2.subscribe(AssertSubscriber.create()));
+
+      Assertions.assertThat(rule.connection.getSent())
+          .extracting(FrameHeaderFlyweight::streamId)
+          .containsExactly(i, i + 2);
+      rule.connection.getSent().clear();
+    }
+  }
+
+  public static Stream<Arguments> streamIdRacingCases() {
+    return Stream.of(
+        Arguments.of(
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.fireAndForget(p),
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestResponse(p)),
+        Arguments.of(
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestResponse(p),
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestStream(p)),
+        Arguments.of(
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestStream(p),
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestChannel(Flux.just(p))),
+        Arguments.of(
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.requestChannel(Flux.just(p)),
+            (BiFunction<ClientSocketRule, Payload, Publisher<?>>)
+                (r, p) -> r.socket.fireAndForget(p)));
+  }
+
   public int sendRequestResponse(Publisher<Payload> response) {
     Subscriber<Payload> sub = TestSubscriber.create();
     response.subscribe(sub);

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -985,6 +985,7 @@ public class RSocketRequesterTest {
     protected RSocketRequester newRSocket() {
       return new RSocketRequester(
           connection,
+          false,
           PayloadDecoder.ZERO_COPY,
           throwable -> errors.add(throwable),
           StreamIdSupplier.clientSupplier(),

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
@@ -485,6 +485,7 @@ public class RSocketTest {
       crs =
           new RSocketRequester(
               clientConnection,
+              false,
               PayloadDecoder.DEFAULT,
               throwable -> clientErrors.add(throwable),
               StreamIdSupplier.clientSupplier(),

--- a/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
@@ -57,6 +57,7 @@ public class SetupRejectionTest {
     RSocketRequester rSocket =
         new RSocketRequester(
             conn,
+            false,
             DefaultPayload::create,
             errors::add,
             StreamIdSupplier.clientSupplier(),
@@ -94,6 +95,7 @@ public class SetupRejectionTest {
     RSocketRequester rSocket =
         new RSocketRequester(
             conn,
+            false,
             DefaultPayload::create,
             err -> {},
             StreamIdSupplier.clientSupplier(),

--- a/rsocket-core/src/test/java/io/rsocket/core/StreamIdSupplierTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/StreamIdSupplierTest.java
@@ -27,35 +27,33 @@ import org.junit.Test;
 public class StreamIdSupplierTest {
   @Test
   public void testClientSequence() {
-    IntObjectMap<Object> map = new SynchronizedIntObjectHashMap<>();
     StreamIdSupplier s = StreamIdSupplier.clientSupplier();
-    assertEquals(1, s.nextStreamId(map));
-    assertEquals(3, s.nextStreamId(map));
-    assertEquals(5, s.nextStreamId(map));
+    assertEquals(1, s.nextStreamId());
+    assertEquals(3, s.nextStreamId());
+    assertEquals(5, s.nextStreamId());
   }
 
   @Test
   public void testServerSequence() {
-    IntObjectMap<Object> map = new SynchronizedIntObjectHashMap<>();
     StreamIdSupplier s = StreamIdSupplier.serverSupplier();
-    assertEquals(2, s.nextStreamId(map));
-    assertEquals(4, s.nextStreamId(map));
-    assertEquals(6, s.nextStreamId(map));
+    assertEquals(2, s.nextStreamId());
+    assertEquals(4, s.nextStreamId());
+    assertEquals(6, s.nextStreamId());
   }
 
   @Test
   public void testClientIsValid() {
-    IntObjectMap<Object> map = new SynchronizedIntObjectHashMap<>();
     StreamIdSupplier s = StreamIdSupplier.clientSupplier();
 
     assertFalse(s.isBeforeOrCurrent(1));
     assertFalse(s.isBeforeOrCurrent(3));
 
-    s.nextStreamId(map);
+    s.nextStreamId();
+
     assertTrue(s.isBeforeOrCurrent(1));
     assertFalse(s.isBeforeOrCurrent(3));
 
-    s.nextStreamId(map);
+    s.nextStreamId();
     assertTrue(s.isBeforeOrCurrent(3));
 
     // negative
@@ -68,17 +66,16 @@ public class StreamIdSupplierTest {
 
   @Test
   public void testServerIsValid() {
-    IntObjectMap<Object> map = new SynchronizedIntObjectHashMap<>();
     StreamIdSupplier s = StreamIdSupplier.serverSupplier();
 
     assertFalse(s.isBeforeOrCurrent(2));
     assertFalse(s.isBeforeOrCurrent(4));
 
-    s.nextStreamId(map);
+    s.nextStreamId();
     assertTrue(s.isBeforeOrCurrent(2));
     assertFalse(s.isBeforeOrCurrent(4));
 
-    s.nextStreamId(map);
+    s.nextStreamId();
     assertTrue(s.isBeforeOrCurrent(4));
 
     // negative
@@ -91,18 +88,17 @@ public class StreamIdSupplierTest {
 
   @Test
   public void testWrap() {
-    IntObjectMap<Object> map = new SynchronizedIntObjectHashMap<>();
-    StreamIdSupplier s = new StreamIdSupplier(Integer.MAX_VALUE - 3);
+    StreamIdSupplier s = new DefaultStreamIdSupplier(Integer.MAX_VALUE - 3);
 
-    assertEquals(2147483646, s.nextStreamId(map));
-    assertEquals(2, s.nextStreamId(map));
-    assertEquals(4, s.nextStreamId(map));
+    assertEquals(2147483646, s.nextStreamId());
+    assertEquals(2, s.nextStreamId());
+    assertEquals(4, s.nextStreamId());
 
-    s = new StreamIdSupplier(Integer.MAX_VALUE - 2);
+    s = new DefaultStreamIdSupplier(Integer.MAX_VALUE - 2);
 
-    assertEquals(2147483647, s.nextStreamId(map));
-    assertEquals(1, s.nextStreamId(map));
-    assertEquals(3, s.nextStreamId(map));
+    assertEquals(2147483647, s.nextStreamId());
+    assertEquals(1, s.nextStreamId());
+    assertEquals(3, s.nextStreamId());
   }
 
   @Test
@@ -110,10 +106,10 @@ public class StreamIdSupplierTest {
     IntObjectMap<Object> map = new SynchronizedIntObjectHashMap<>();
     map.put(5, new Object());
     map.put(9, new Object());
-    StreamIdSupplier s = StreamIdSupplier.clientSupplier();
-    assertEquals(1, s.nextStreamId(map));
-    assertEquals(3, s.nextStreamId(map));
-    assertEquals(7, s.nextStreamId(map));
-    assertEquals(11, s.nextStreamId(map));
+    StreamIdSupplier s = new ResumableStreamIdSupplier(StreamIdSupplier.clientSupplier(), map);
+    assertEquals(1, s.nextStreamId());
+    assertEquals(3, s.nextStreamId());
+    assertEquals(7, s.nextStreamId());
+    assertEquals(11, s.nextStreamId());
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/test/util/LocalDuplexConnection.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/LocalDuplexConnection.java
@@ -19,11 +19,13 @@ package io.rsocket.test.util;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
+import io.rsocket.TestScheduler;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
+import reactor.core.scheduler.Scheduler;
 
 public class LocalDuplexConnection implements DuplexConnection {
   private final ByteBufAllocator allocator;
@@ -61,6 +63,11 @@ public class LocalDuplexConnection implements DuplexConnection {
   @Override
   public ByteBufAllocator alloc() {
     return allocator;
+  }
+
+  @Override
+  public Scheduler eventLoopScheduler() {
+    return TestScheduler.INSTANCE;
   }
 
   @Override

--- a/rsocket-core/src/test/java/io/rsocket/test/util/TestDuplexConnection.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/TestDuplexConnection.java
@@ -19,6 +19,7 @@ package io.rsocket.test.util;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
+import io.rsocket.TestScheduler;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -31,6 +32,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
+import reactor.core.scheduler.Scheduler;
 
 /**
  * An implementation of {@link DuplexConnection} that provides functionality to modify the behavior
@@ -84,6 +86,11 @@ public class TestDuplexConnection implements DuplexConnection {
   @Override
   public Flux<ByteBuf> receive() {
     return received;
+  }
+
+  @Override
+  public Scheduler eventLoopScheduler() {
+    return TestScheduler.INSTANCE;
   }
 
   @Override

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerDuplexConnection.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerDuplexConnection.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 
 /**
  * An implementation of {@link DuplexConnection} that intercepts frames and gathers Micrometer
@@ -81,6 +82,11 @@ final class MicrometerDuplexConnection implements DuplexConnection {
             "rsocket.duplex.connection.dispose",
             Tags.of(tags).and("connection.type", connectionType.name()));
     this.frameCounters = new FrameCounters(connectionType, meterRegistry, tags);
+  }
+
+  @Override
+  public Scheduler eventLoopScheduler() {
+    return delegate.eventLoopScheduler();
   }
 
   @Override

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
@@ -28,6 +28,8 @@ import io.rsocket.transport.local.LocalServerTransport.ServerDuplexConnectionAcc
 import java.util.Objects;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * An implementation of {@link ClientTransport} that connects to a {@link ServerTransport} in the
@@ -83,11 +85,13 @@ public final class LocalClientTransport implements ClientTransport {
           UnboundedProcessor<ByteBuf> in = new UnboundedProcessor<>();
           UnboundedProcessor<ByteBuf> out = new UnboundedProcessor<>();
           MonoProcessor<Void> closeNotifier = MonoProcessor.create();
+          Scheduler scheduler = Schedulers.single(Schedulers.parallel());
 
-          server.accept(new LocalDuplexConnection(allocator, out, in, closeNotifier));
+          server.accept(new LocalDuplexConnection(allocator, scheduler, out, in, closeNotifier));
 
           return Mono.just(
-              (DuplexConnection) new LocalDuplexConnection(allocator, in, out, closeNotifier));
+              (DuplexConnection)
+                  new LocalDuplexConnection(allocator, scheduler, in, out, closeNotifier));
         });
   }
 

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
@@ -25,11 +25,13 @@ import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
+import reactor.core.scheduler.Scheduler;
 
 /** An implementation of {@link DuplexConnection} that connects inside the same JVM. */
 final class LocalDuplexConnection implements DuplexConnection {
 
   private final ByteBufAllocator allocator;
+  private final Scheduler scheduler;
   private final Flux<ByteBuf> in;
 
   private final MonoProcessor<Void> onClose;
@@ -46,10 +48,12 @@ final class LocalDuplexConnection implements DuplexConnection {
    */
   LocalDuplexConnection(
       ByteBufAllocator allocator,
+      Scheduler scheduler,
       Flux<ByteBuf> in,
       Subscriber<ByteBuf> out,
       MonoProcessor<Void> onClose) {
     this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
+    this.scheduler = Objects.requireNonNull(scheduler, "scheduler must not be null");
     this.in = Objects.requireNonNull(in, "in must not be null");
     this.out = Objects.requireNonNull(out, "out must not be null");
     this.onClose = Objects.requireNonNull(onClose, "onClose must not be null");
@@ -93,5 +97,10 @@ final class LocalDuplexConnection implements DuplexConnection {
   @Override
   public ByteBufAllocator alloc() {
     return allocator;
+  }
+
+  @Override
+  public Scheduler eventLoopScheduler() {
+    return scheduler;
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.netty.Connection;
 
 /** An implementation of {@link DuplexConnection} that connects via TCP. */
@@ -32,6 +34,7 @@ public final class TcpDuplexConnection extends BaseDuplexConnection {
 
   private final Connection connection;
   private final boolean encodeLength;
+  private final Scheduler scheduler;
 
   /**
    * Creates a new instance
@@ -51,6 +54,7 @@ public final class TcpDuplexConnection extends BaseDuplexConnection {
   public TcpDuplexConnection(Connection connection, boolean encodeLength) {
     this.encodeLength = encodeLength;
     this.connection = Objects.requireNonNull(connection, "connection must not be null");
+    this.scheduler = Schedulers.fromExecutorService(connection.channel().eventLoop());
 
     connection
         .channel()
@@ -64,6 +68,11 @@ public final class TcpDuplexConnection extends BaseDuplexConnection {
   @Override
   public ByteBufAllocator alloc() {
     return connection.channel().alloc();
+  }
+
+  @Override
+  public Scheduler eventLoopScheduler() {
+    return scheduler;
   }
 
   @Override

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.netty.Connection;
 
 /**
@@ -36,6 +38,7 @@ import reactor.netty.Connection;
 public final class WebsocketDuplexConnection extends BaseDuplexConnection {
 
   private final Connection connection;
+  private final Scheduler scheduler;
 
   /**
    * Creates a new instance
@@ -44,6 +47,7 @@ public final class WebsocketDuplexConnection extends BaseDuplexConnection {
    */
   public WebsocketDuplexConnection(Connection connection) {
     this.connection = Objects.requireNonNull(connection, "connection must not be null");
+    this.scheduler = Schedulers.fromExecutorService(connection.channel().eventLoop());
 
     connection
         .channel()
@@ -57,6 +61,11 @@ public final class WebsocketDuplexConnection extends BaseDuplexConnection {
   @Override
   public ByteBufAllocator alloc() {
     return connection.channel().alloc();
+  }
+
+  @Override
+  public Scheduler eventLoopScheduler() {
+    return scheduler;
   }
 
   @Override


### PR DESCRIPTION
This PR is a follow up to #811 and therefore introduces a non-thread safe way to issue stream id since this class is never called in the concurrent fashion 