### PR TITLE
relaxed stream id supplement 

### DIFF
--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
@@ -55,7 +55,6 @@ import org.reactivestreams.Subscriber;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketTest.java
@@ -55,6 +55,7 @@ import org.reactivestreams.Subscriber;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 


### PR DESCRIPTION
This PR is a follow up to #811 and therefore introduces a non-thread safe way to issue stream id since this class is never called in the concurrent fashion