### PR TITLE
provides extra @NonNullApi annotation for all packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ subprojects {
 
         dependencies {
             dependency "ch.qos.logback:logback-classic:${ext['logback.version']}"
-            dependency "com.google.code.findbugs:jsr305:${ext['findbugs.version']}"
             dependency "io.netty:netty-tcnative-boringssl-static:${ext['netty-boringssl.version']}"
             dependency "io.micrometer:micrometer-core:${ext['micrometer.version']}"
             dependency "org.assertj:assertj-core:${ext['assertj.version']}"

--- a/rsocket-core/build.gradle
+++ b/rsocket-core/build.gradle
@@ -29,8 +29,6 @@ dependencies {
 
     implementation 'org.slf4j:slf4j-api'
 
-    compileOnly 'com.google.code.findbugs:jsr305'
-
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/rsocket-core/src/main/java/io/rsocket/ConnectionSetupPayload.java
+++ b/rsocket-core/src/main/java/io/rsocket/ConnectionSetupPayload.java
@@ -19,7 +19,7 @@ package io.rsocket;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.AbstractReferenceCounted;
 import io.rsocket.core.DefaultConnectionSetupPayload;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * Exposes information from the {@code SETUP} frame to a server, as well as to client responders.

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -41,10 +41,10 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.annotation.Nullable;
 import reactor.util.retry.Retry;
 
 /**

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -55,7 +55,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -68,6 +67,7 @@ import reactor.core.publisher.Operators;
 import reactor.core.publisher.SignalType;
 import reactor.core.publisher.UnicastProcessor;
 import reactor.core.scheduler.Scheduler;
+import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 
 /**

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -47,6 +46,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.publisher.*;
+import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 
 /** Responder side of RSocket. Receives {@link ByteBuf}s from a peer's {@link RSocketRequester} */

--- a/rsocket-core/src/main/java/io/rsocket/core/StreamIdSupplier.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/StreamIdSupplier.java
@@ -16,7 +16,9 @@
 package io.rsocket.core;
 
 import io.netty.util.collection.IntObjectMap;
+import javax.annotation.concurrent.NotThreadSafe;
 
+@NotThreadSafe
 final class StreamIdSupplier {
   private static final int MASK = 0x7FFFFFFF;
 

--- a/rsocket-core/src/main/java/io/rsocket/core/StreamIdSupplier.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/StreamIdSupplier.java
@@ -16,9 +16,8 @@
 package io.rsocket.core;
 
 import io.netty.util.collection.IntObjectMap;
-import javax.annotation.concurrent.NotThreadSafe;
 
-@NotThreadSafe
+/** This API is not thread-safe and must be strictly used in serialized fashion */
 final class StreamIdSupplier {
   private static final int MASK = 0x7FFFFFFF;
 

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/ApplicationErrorException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/ApplicationErrorException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * Application layer logic generating a Reactive Streams {@code onError} event.

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/CanceledException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/CanceledException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * The Responder canceled the request but may have started processing it (similar to REJECTED but

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/ConnectionCloseException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/ConnectionCloseException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * The connection is being terminated. Sender or Receiver of this frame MUST wait for outstanding

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/ConnectionErrorException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/ConnectionErrorException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * The connection is being terminated. Sender or Receiver of this frame MAY close the connection

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/CustomRSocketException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/CustomRSocketException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 public class CustomRSocketException extends RSocketException {
   private static final long serialVersionUID = 7873267740343446585L;

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/InvalidException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/InvalidException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * The request is invalid.

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/InvalidSetupException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/InvalidSetupException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * The Setup frame is invalid for the server (it could be that the client is too recent for the old

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/RejectedException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/RejectedException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * Despite being a valid request, the Responder decided to reject it. The Responder guarantees that

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/RejectedResumeException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/RejectedResumeException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * The server rejected the resume, it can specify the reason in the payload.

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/RejectedSetupException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/RejectedSetupException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * The server rejected the setup, it can specify the reason in the payload.

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/SetupException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/SetupException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /** The root of the setup exception hierarchy. */
 public abstract class SetupException extends RSocketException {

--- a/rsocket-core/src/main/java/io/rsocket/exceptions/UnsupportedSetupException.java
+++ b/rsocket-core/src/main/java/io/rsocket/exceptions/UnsupportedSetupException.java
@@ -17,7 +17,7 @@
 package io.rsocket.exceptions;
 
 import io.rsocket.frame.ErrorFrameCodec;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * Some (or all) of the parameters specified by the client are unsupported by the server.

--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/FragmentationDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/FragmentationDuplexConnection.java
@@ -25,12 +25,12 @@ import io.rsocket.frame.FrameHeaderCodec;
 import io.rsocket.frame.FrameLengthCodec;
 import io.rsocket.frame.FrameType;
 import java.util.Objects;
-import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
 
 /**
  * A {@link DuplexConnection} implementation that fragments and reassembles {@link ByteBuf}s.

--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/FrameReassembler.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/FrameReassembler.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.publisher.SynchronousSink;
+import reactor.util.annotation.Nullable;
 
 /**
  * The implementation of the RSocket reassembly behavior.
@@ -83,6 +84,7 @@ final class FrameReassembler extends AtomicBoolean implements Disposable {
     return get();
   }
 
+  @Nullable
   synchronized ByteBuf getHeader(int streamId) {
     return headers.get(streamId);
   }
@@ -109,14 +111,17 @@ final class FrameReassembler extends AtomicBoolean implements Disposable {
     return byteBuf;
   }
 
+  @Nullable
   synchronized ByteBuf removeHeader(int streamId) {
     return headers.remove(streamId);
   }
 
+  @Nullable
   synchronized CompositeByteBuf removeMetadata(int streamId) {
     return metadata.remove(streamId);
   }
 
+  @Nullable
   synchronized CompositeByteBuf removeData(int streamId) {
     return data.remove(streamId);
   }
@@ -236,7 +241,6 @@ final class FrameReassembler extends AtomicBoolean implements Disposable {
         case CANCEL:
         case ERROR:
           cancelAssemble(streamId);
-        default:
       }
 
       if (!frameType.isFragmentable()) {
@@ -270,7 +274,7 @@ final class FrameReassembler extends AtomicBoolean implements Disposable {
         metadata = PayloadFrameCodec.metadata(frame).retain();
       }
     } else {
-      metadata = cm != null ? cm : null;
+      metadata = cm;
     }
 
     ByteBuf data = assembleData(frame, streamId);

--- a/rsocket-core/src/main/java/io/rsocket/frame/ExtensionFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/ExtensionFrameCodec.java
@@ -2,7 +2,7 @@ package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 public class ExtensionFrameCodec {
   private ExtensionFrameCodec() {}
@@ -49,6 +49,7 @@ public class ExtensionFrameCodec {
     return data;
   }
 
+  @Nullable
   public static ByteBuf metadata(ByteBuf byteBuf) {
     FrameHeaderCodec.ensureFrameType(FrameType.EXT, byteBuf);
 

--- a/rsocket-core/src/main/java/io/rsocket/frame/FrameBodyCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/FrameBodyCodec.java
@@ -3,6 +3,7 @@ package io.rsocket.frame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import reactor.util.annotation.Nullable;
 
 class FrameBodyCodec {
   public static final int FRAME_LENGTH_MASK = 0xFFFFFF;
@@ -33,9 +34,9 @@ class FrameBodyCodec {
   static ByteBuf encode(
       ByteBufAllocator allocator,
       final ByteBuf header,
-      ByteBuf metadata,
+      @Nullable ByteBuf metadata,
       boolean hasMetadata,
-      ByteBuf data) {
+      @Nullable ByteBuf data) {
 
     final boolean addData;
     if (data != null) {

--- a/rsocket-core/src/main/java/io/rsocket/frame/GenericFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/GenericFrameCodec.java
@@ -4,7 +4,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.IllegalReferenceCountException;
 import io.rsocket.Payload;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 class GenericFrameCodec {
 
@@ -75,7 +75,7 @@ class GenericFrameCodec {
       boolean next,
       int requestN,
       @Nullable ByteBuf metadata,
-      ByteBuf data) {
+      @Nullable ByteBuf data) {
 
     final boolean hasMetadata = metadata != null;
 
@@ -115,6 +115,7 @@ class GenericFrameCodec {
     return data;
   }
 
+  @Nullable
   static ByteBuf metadata(ByteBuf byteBuf) {
     boolean hasMetadata = FrameHeaderCodec.hasMetadata(byteBuf);
     if (!hasMetadata) {
@@ -136,6 +137,7 @@ class GenericFrameCodec {
     return data;
   }
 
+  @Nullable
   static ByteBuf metadataWithRequestN(ByteBuf byteBuf) {
     boolean hasMetadata = FrameHeaderCodec.hasMetadata(byteBuf);
     if (!hasMetadata) {

--- a/rsocket-core/src/main/java/io/rsocket/frame/LeaseFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/LeaseFrameCodec.java
@@ -2,8 +2,7 @@ package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 public class LeaseFrameCodec {
 
@@ -67,6 +66,7 @@ public class LeaseFrameCodec {
     return numRequests;
   }
 
+  @Nullable
   public static ByteBuf metadata(final ByteBuf byteBuf) {
     FrameHeaderCodec.ensureFrameType(FrameType.LEASE, byteBuf);
     if (FrameHeaderCodec.hasMetadata(byteBuf)) {
@@ -77,7 +77,7 @@ public class LeaseFrameCodec {
       byteBuf.resetReaderIndex();
       return metadata;
     } else {
-      return Unpooled.EMPTY_BUFFER;
+      return null;
     }
   }
 }

--- a/rsocket-core/src/main/java/io/rsocket/frame/MetadataPushFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/MetadataPushFrameCodec.java
@@ -8,6 +8,10 @@ import io.rsocket.Payload;
 public class MetadataPushFrameCodec {
 
   public static ByteBuf encodeReleasingPayload(ByteBufAllocator allocator, Payload payload) {
+    if (!payload.hasMetadata()) {
+      throw new IllegalStateException(
+          "Metadata  push requires to have metadata present" + " in the given Payload");
+    }
     final ByteBuf metadata = payload.metadata().retain();
     // releasing payload safely since it can be already released wheres we have to release retained
     // data and metadata as well

--- a/rsocket-core/src/main/java/io/rsocket/frame/PayloadFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/PayloadFrameCodec.java
@@ -3,6 +3,7 @@ package io.rsocket.frame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Payload;
+import reactor.util.annotation.Nullable;
 
 public class PayloadFrameCodec {
 
@@ -37,8 +38,8 @@ public class PayloadFrameCodec {
       boolean fragmentFollows,
       boolean complete,
       boolean next,
-      ByteBuf metadata,
-      ByteBuf data) {
+      @Nullable ByteBuf metadata,
+      @Nullable ByteBuf data) {
 
     return GenericFrameCodec.encode(
         allocator, FrameType.PAYLOAD, streamId, fragmentFollows, complete, next, 0, metadata, data);
@@ -48,6 +49,7 @@ public class PayloadFrameCodec {
     return GenericFrameCodec.data(byteBuf);
   }
 
+  @Nullable
   public static ByteBuf metadata(ByteBuf byteBuf) {
     return GenericFrameCodec.metadata(byteBuf);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/RequestChannelFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/RequestChannelFrameCodec.java
@@ -3,6 +3,7 @@ package io.rsocket.frame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Payload;
+import reactor.util.annotation.Nullable;
 
 public class RequestChannelFrameCodec {
 
@@ -31,7 +32,7 @@ public class RequestChannelFrameCodec {
       boolean fragmentFollows,
       boolean complete,
       long initialRequestN,
-      ByteBuf metadata,
+      @Nullable ByteBuf metadata,
       ByteBuf data) {
 
     if (initialRequestN < 1) {
@@ -56,6 +57,7 @@ public class RequestChannelFrameCodec {
     return GenericFrameCodec.dataWithRequestN(byteBuf);
   }
 
+  @Nullable
   public static ByteBuf metadata(ByteBuf byteBuf) {
     return GenericFrameCodec.metadataWithRequestN(byteBuf);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/RequestFireAndForgetFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/RequestFireAndForgetFrameCodec.java
@@ -3,6 +3,7 @@ package io.rsocket.frame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Payload;
+import reactor.util.annotation.Nullable;
 
 public class RequestFireAndForgetFrameCodec {
 
@@ -19,7 +20,7 @@ public class RequestFireAndForgetFrameCodec {
       ByteBufAllocator allocator,
       int streamId,
       boolean fragmentFollows,
-      ByteBuf metadata,
+      @Nullable ByteBuf metadata,
       ByteBuf data) {
 
     return GenericFrameCodec.encode(
@@ -30,6 +31,7 @@ public class RequestFireAndForgetFrameCodec {
     return GenericFrameCodec.data(byteBuf);
   }
 
+  @Nullable
   public static ByteBuf metadata(ByteBuf byteBuf) {
     return GenericFrameCodec.metadata(byteBuf);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/RequestResponseFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/RequestResponseFrameCodec.java
@@ -3,6 +3,7 @@ package io.rsocket.frame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Payload;
+import reactor.util.annotation.Nullable;
 
 public class RequestResponseFrameCodec {
 
@@ -19,7 +20,7 @@ public class RequestResponseFrameCodec {
       ByteBufAllocator allocator,
       int streamId,
       boolean fragmentFollows,
-      ByteBuf metadata,
+      @Nullable ByteBuf metadata,
       ByteBuf data) {
     return GenericFrameCodec.encode(
         allocator, FrameType.REQUEST_RESPONSE, streamId, fragmentFollows, metadata, data);
@@ -29,6 +30,7 @@ public class RequestResponseFrameCodec {
     return GenericFrameCodec.data(byteBuf);
   }
 
+  @Nullable
   public static ByteBuf metadata(ByteBuf byteBuf) {
     return GenericFrameCodec.metadata(byteBuf);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/RequestStreamFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/RequestStreamFrameCodec.java
@@ -3,6 +3,7 @@ package io.rsocket.frame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.Payload;
+import reactor.util.annotation.Nullable;
 
 public class RequestStreamFrameCodec {
 
@@ -26,7 +27,7 @@ public class RequestStreamFrameCodec {
       int streamId,
       boolean fragmentFollows,
       long initialRequestN,
-      ByteBuf metadata,
+      @Nullable ByteBuf metadata,
       ByteBuf data) {
 
     if (initialRequestN < 1) {
@@ -51,6 +52,7 @@ public class RequestStreamFrameCodec {
     return GenericFrameCodec.dataWithRequestN(byteBuf);
   }
 
+  @Nullable
   public static ByteBuf metadata(ByteBuf byteBuf) {
     return GenericFrameCodec.metadataWithRequestN(byteBuf);
   }

--- a/rsocket-core/src/main/java/io/rsocket/frame/SetupFrameCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/SetupFrameCodec.java
@@ -6,6 +6,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.rsocket.Payload;
 import java.nio.charset.StandardCharsets;
+import reactor.util.annotation.Nullable;
 
 public class SetupFrameCodec {
   /**
@@ -61,7 +62,7 @@ public class SetupFrameCodec {
 
     int flags = 0;
 
-    if (resumeToken != null && resumeToken.readableBytes() > 0) {
+    if (resumeToken.readableBytes() > 0) {
       flags |= FLAGS_RESUME_ENABLE;
     }
 
@@ -163,7 +164,7 @@ public class SetupFrameCodec {
       byteBuf.resetReaderIndex();
       return resumeToken;
     } else {
-      return null;
+      return Unpooled.EMPTY_BUFFER;
     }
   }
 
@@ -186,6 +187,7 @@ public class SetupFrameCodec {
     return mimeType;
   }
 
+  @Nullable
   public static ByteBuf metadata(ByteBuf byteBuf) {
     boolean hasMetadata = FrameHeaderCodec.hasMetadata(byteBuf);
     if (!hasMetadata) {

--- a/rsocket-core/src/main/java/io/rsocket/frame/decoder/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/decoder/package-info.java
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-/** Client and server transport contracts for pluggable transports. */
+/**
+ * Support for encoding and decoding of RSocket frames to and from {@link io.rsocket.Payload
+ * Payload}.
+ */
 @NonNullApi
-package io.rsocket.transport;
+package io.rsocket.frame.decoder;
 
 import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/frame/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/package-info.java
@@ -18,4 +18,7 @@
  * Support for encoding and decoding of RSocket frames to and from {@link io.rsocket.Payload
  * Payload}.
  */
+@NonNullApi
 package io.rsocket.frame;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
@@ -161,6 +161,7 @@ public class ClientServerInputMultiplexer implements Closeable {
     private final MonoProcessor<Flux<ByteBuf>>[] processors;
     private final boolean debugEnabled;
 
+    @SafeVarargs
     public InternalDuplexConnection(
         DuplexConnection source, MonoProcessor<Flux<ByteBuf>>... processors) {
       this.source = source;

--- a/rsocket-core/src/main/java/io/rsocket/internal/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/package-info.java
@@ -18,5 +18,7 @@
  * Internal package and <em>must not</em> be used outside this project. There are no guarantees for
  * API compatibility.
  */
-@javax.annotation.ParametersAreNonnullByDefault
+@NonNullApi
 package io.rsocket.internal;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/keepalive/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/keepalive/package-info.java
@@ -15,5 +15,7 @@
  */
 
 /** Support classes for sending and keeping track of KEEPALIVE frames from the remote. */
-@javax.annotation.ParametersAreNonnullByDefault
+@NonNullApi
 package io.rsocket.keepalive;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/lease/Lease.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/Lease.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.rsocket.Availability;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /** A contract for RSocket lease, which is sent by a request acceptor and is time bound. */
 public interface Lease extends Availability {

--- a/rsocket-core/src/main/java/io/rsocket/lease/Lease.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/Lease.java
@@ -19,7 +19,6 @@ package io.rsocket.lease;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.rsocket.Availability;
-import javax.annotation.Nonnull;
 import reactor.util.annotation.Nullable;
 
 /** A contract for RSocket lease, which is sent by a request acceptor and is time bound. */
@@ -78,7 +77,6 @@ public interface Lease extends Availability {
    *
    * @return Metadata for the lease.
    */
-  @Nonnull
   ByteBuf getMetadata();
 
   /**

--- a/rsocket-core/src/main/java/io/rsocket/lease/LeaseImpl.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/LeaseImpl.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 public class LeaseImpl implements Lease {
   private final int timeToLiveMillis;

--- a/rsocket-core/src/main/java/io/rsocket/lease/LeaseImpl.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/LeaseImpl.java
@@ -19,7 +19,6 @@ package io.rsocket.lease;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
 import reactor.util.annotation.Nullable;
 
 public class LeaseImpl implements Lease {
@@ -60,7 +59,6 @@ public class LeaseImpl implements Lease {
     return startingAllowedRequests;
   }
 
-  @Nonnull
   @Override
   public ByteBuf getMetadata() {
     return metadata;

--- a/rsocket-core/src/main/java/io/rsocket/lease/MissingLeaseException.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/MissingLeaseException.java
@@ -18,7 +18,7 @@ package io.rsocket.lease;
 import io.rsocket.exceptions.RejectedException;
 import java.util.Objects;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 public class MissingLeaseException extends RejectedException {
   private static final long serialVersionUID = -6169748673403858959L;

--- a/rsocket-core/src/main/java/io/rsocket/lease/MissingLeaseException.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/MissingLeaseException.java
@@ -17,17 +17,16 @@ package io.rsocket.lease;
 
 import io.rsocket.exceptions.RejectedException;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 import reactor.util.annotation.Nullable;
 
 public class MissingLeaseException extends RejectedException {
   private static final long serialVersionUID = -6169748673403858959L;
 
-  public MissingLeaseException(@Nonnull Lease lease, @Nonnull String tag) {
+  public MissingLeaseException(Lease lease, String tag) {
     super(leaseMessage(Objects.requireNonNull(lease), Objects.requireNonNull(tag)));
   }
 
-  public MissingLeaseException(@Nonnull String tag) {
+  public MissingLeaseException(String tag) {
     super(leaseMessage(null, Objects.requireNonNull(tag)));
   }
 

--- a/rsocket-core/src/main/java/io/rsocket/lease/ResponderLeaseHandler.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/ResponderLeaseHandler.java
@@ -23,10 +23,10 @@ import io.rsocket.frame.LeaseFrameCodec;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.publisher.Flux;
+import reactor.util.annotation.Nullable;
 
 public interface ResponderLeaseHandler extends Availability {
 

--- a/rsocket-core/src/main/java/io/rsocket/lease/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/package-info.java
@@ -21,5 +21,7 @@
  *     href="https://github.com/rsocket/rsocket/blob/master/Protocol.md#resuming-operation">Resuming
  *     Operation</a>
  */
-@javax.annotation.ParametersAreNonnullByDefault
+@NonNullApi
 package io.rsocket.lease;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/metadata/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/metadata/package-info.java
@@ -19,4 +19,7 @@
  * href="https://github.com/rsocket/rsocket/tree/master/Extensions">protocol extensions</a> related
  * to the use of metadata.
  */
+@NonNullApi
 package io.rsocket.metadata;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/package-info.java
@@ -23,4 +23,7 @@
  * <p>To connect to or start a server see {@link io.rsocket.core.RSocketConnector RSocketConnector}
  * and {@link io.rsocket.core.RSocketServer RSocketServer} in {@link io.rsocket.core}.
  */
+@NonNullApi
 package io.rsocket;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/plugins/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/package-info.java
@@ -15,4 +15,7 @@
  */
 
 /** Contracts for interception of transports, connections, and requests in in RSocket Java. */
+@NonNullApi
 package io.rsocket.plugins;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/resume/SessionManager.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/SessionManager.java
@@ -19,7 +19,7 @@ package io.rsocket.resume;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 public class SessionManager {
   private volatile boolean isDisposed;

--- a/rsocket-core/src/main/java/io/rsocket/resume/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/package-info.java
@@ -21,5 +21,7 @@
  *     href="https://github.com/rsocket/rsocket/blob/master/Protocol.md#resuming-operation">Resuming
  *     Operation</a>
  */
-@javax.annotation.ParametersAreNonnullByDefault
+@NonNullApi
 package io.rsocket.resume;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/main/java/io/rsocket/util/ByteBufPayload.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/ByteBufPayload.java
@@ -28,7 +28,7 @@ import io.rsocket.Payload;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 public final class ByteBufPayload extends AbstractReferenceCounted implements Payload {
   private static final Recycler<ByteBufPayload> RECYCLER =

--- a/rsocket-core/src/main/java/io/rsocket/util/DefaultPayload.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/DefaultPayload.java
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * An implementation of {@link Payload}. This implementation is <b>not</b> thread-safe, and hence

--- a/rsocket-core/src/main/java/io/rsocket/util/package-info.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/package-info.java
@@ -15,5 +15,7 @@
  */
 
 /** Shared utility classes and {@link io.rsocket.Payload} implementations. */
-@javax.annotation.ParametersAreNonnullByDefault
+@NonNullApi
 package io.rsocket.util;
+
+import reactor.util.annotation.NonNullApi;

--- a/rsocket-core/src/test/java/io/rsocket/core/ConnectionSetupPayloadTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/ConnectionSetupPayloadTest.java
@@ -82,7 +82,7 @@ class ConnectionSetupPayloadTest {
         leaseEnabled,
         KEEP_ALIVE_INTERVAL,
         KEEP_ALIVE_MAX_LIFETIME,
-        null,
+        Unpooled.EMPTY_BUFFER,
         METADATA_TYPE,
         DATA_TYPE,
         setupPayload);

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
@@ -143,6 +143,6 @@ class RSocketRequesterSubscribersTest {
         rSocket -> rSocket.requestResponse(DefaultPayload.create("test")),
         rSocket -> rSocket.requestStream(DefaultPayload.create("test")),
         //        rSocket -> rSocket.requestChannel(Mono.just(DefaultPayload.create("test"))),
-        rSocket -> rSocket.metadataPush(DefaultPayload.create("test")));
+        rSocket -> rSocket.metadataPush(DefaultPayload.create("", "test")));
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/frame/LeaseFrameCodecTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/frame/LeaseFrameCodecTest.java
@@ -32,7 +32,7 @@ public class LeaseFrameCodecTest {
     Assertions.assertFalse(FrameHeaderCodec.hasMetadata(lease));
     Assertions.assertEquals(ttl, LeaseFrameCodec.ttl(lease));
     Assertions.assertEquals(numRequests, LeaseFrameCodec.numRequests(lease));
-    Assertions.assertEquals(0, LeaseFrameCodec.metadata(lease).readableBytes());
+    Assertions.assertNull(LeaseFrameCodec.metadata(lease));
     lease.release();
   }
 

--- a/rsocket-core/src/test/java/io/rsocket/frame/SetupFrameCodecTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/frame/SetupFrameCodecTest.java
@@ -22,7 +22,7 @@ class SetupFrameCodecTest {
 
     assertEquals(FrameType.SETUP, FrameHeaderCodec.frameType(frame));
     assertFalse(SetupFrameCodec.resumeEnabled(frame));
-    assertNull(SetupFrameCodec.resumeToken(frame));
+    assertEquals(0, SetupFrameCodec.resumeToken(frame).readableBytes());
     assertEquals("metadata_type", SetupFrameCodec.metadataMimeType(frame));
     assertEquals("data_type", SetupFrameCodec.dataMimeType(frame));
     assertEquals(metadata, SetupFrameCodec.metadata(frame));

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/package-info.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/package-info.java
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-/** Client and server transport contracts for pluggable transports. */
 @NonNullApi
-package io.rsocket.transport;
+package io.rsocket.client.filter;
 
 import reactor.util.annotation.NonNullApi;

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/package-info.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/package-info.java
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-/** Client and server transport contracts for pluggable transports. */
 @NonNullApi
-package io.rsocket.transport;
+package io.rsocket.client;
 
 import reactor.util.annotation.NonNullApi;

--- a/rsocket-load-balancer/src/main/java/io/rsocket/stat/package-info.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/stat/package-info.java
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-/** Client and server transport contracts for pluggable transports. */
 @NonNullApi
-package io.rsocket.transport;
+package io.rsocket.stat;
 
 import reactor.util.annotation.NonNullApi;

--- a/rsocket-micrometer/build.gradle
+++ b/rsocket-micrometer/build.gradle
@@ -27,8 +27,6 @@ dependencies {
 
     implementation 'org.slf4j:slf4j-api'
 
-    compileOnly 'com.google.code.findbugs:jsr305'
-
     testImplementation project(':rsocket-test')
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.assertj:assertj-core'

--- a/rsocket-test/build.gradle
+++ b/rsocket-test/build.gradle
@@ -26,8 +26,6 @@ dependencies {
     api 'org.hdrhistogram:HdrHistogram'
     api 'org.junit.jupiter:junit-jupiter-api'
 
-    compileOnly  'com.google.code.findbugs:jsr305'
-
     implementation 'io.projectreactor:reactor-test'
     implementation 'org.assertj:assertj-core'
     implementation 'org.mockito:mockito-core'

--- a/rsocket-transport-local/build.gradle
+++ b/rsocket-transport-local/build.gradle
@@ -24,8 +24,6 @@ plugins {
 dependencies {
     api project(':rsocket-core')
 
-    compileOnly 'com.google.code.findbugs:jsr305'
-
     testImplementation project(':rsocket-test')
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.assertj:assertj-core'

--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -32,8 +32,6 @@ dependencies {
     api 'io.projectreactor.netty:reactor-netty'
     api 'org.slf4j:slf4j-api'
 
-    compileOnly 'com.google.code.findbugs:jsr305'
-
     testImplementation project(':rsocket-test')
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.assertj:assertj-core'

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
@@ -75,7 +75,7 @@ public final class TcpClientTransport implements ClientTransport {
   public static TcpClientTransport create(InetSocketAddress address) {
     Objects.requireNonNull(address, "address must not be null");
 
-    TcpClient tcpClient = TcpClient.create().addressSupplier(() -> address);
+    TcpClient tcpClient = TcpClient.create().remoteAddress(() -> address);
     return create(tcpClient);
   }
 

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.WebsocketClientSpec;
 import reactor.netty.tcp.TcpClient;
 
 /**
@@ -47,7 +48,7 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
 
   private final HttpClient client;
 
-  private String path;
+  private final String path;
 
   private Supplier<Map<String, String>> transportHeaders = Collections::emptyMap;
 
@@ -92,7 +93,7 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
   public static WebsocketClientTransport create(InetSocketAddress address) {
     Objects.requireNonNull(address, "address must not be null");
 
-    TcpClient client = TcpClient.create().addressSupplier(() -> address);
+    TcpClient client = TcpClient.create().remoteAddress(() -> address);
     return create(client);
   }
 
@@ -155,7 +156,8 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
         ? isError
         : client
             .headers(headers -> transportHeaders.get().forEach(headers::set))
-            .websocket(FRAME_LENGTH_MASK)
+            .websocket(
+                WebsocketClientSpec.builder().maxFramePayloadLength(FRAME_LENGTH_MASK).build())
             .uri(path)
             .connect()
             .map(

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/CloseableChannel.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/CloseableChannel.java
@@ -28,7 +28,7 @@ import reactor.netty.DisposableChannel;
  */
 public final class CloseableChannel implements Closeable {
 
-  private DisposableChannel channel;
+  private final DisposableChannel channel;
 
   /**
    * Creates a new instance

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/TcpSecureTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/TcpSecureTransportTest.java
@@ -20,7 +20,7 @@ public class TcpSecureTransportTest implements TransportTest {
           (address, server) ->
               TcpClientTransport.create(
                   TcpClient.create()
-                      .addressSupplier(server::address)
+                      .remoteAddress(server::address)
                       .secure(
                           ssl ->
                               ssl.sslContext(
@@ -31,7 +31,7 @@ public class TcpSecureTransportTest implements TransportTest {
               SelfSignedCertificate ssc = new SelfSignedCertificate();
               TcpServer server =
                   TcpServer.create()
-                      .addressSupplier(() -> address)
+                      .bindAddress(() -> address)
                       .secure(
                           ssl ->
                               ssl.sslContext(

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketSecureTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketSecureTransportTest.java
@@ -38,7 +38,7 @@ final class WebsocketSecureTransportTest implements TransportTest {
           (address, server) ->
               WebsocketClientTransport.create(
                   HttpClient.create()
-                      .addressSupplier(server::address)
+                      .remoteAddress(server::address)
                       .secure(
                           ssl ->
                               ssl.sslContext(
@@ -53,7 +53,7 @@ final class WebsocketSecureTransportTest implements TransportTest {
               HttpServer server =
                   HttpServer.from(
                       TcpServer.create()
-                          .addressSupplier(() -> address)
+                          .bindAddress(() -> address)
                           .secure(
                               ssl ->
                                   ssl.sslContext(


### PR DESCRIPTION
This PR provides some enhancement from the API documentation perspective and provides all the packages with `NonNullApi` annotation. Also, it provides fixes where it is needed to ensure that all places where `Nullability` is allowed are annotated appropriately. 
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>