### PR TITLE
removes limit rate operator

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -491,7 +491,6 @@ class RSocketRequester implements RSocket {
                         receivers.put(streamId, receiver);
 
                         inboundFlux
-                            .limitRate(Queues.SMALL_BUFFER_SIZE)
                             .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER)
                             .subscribe(upstreamSubscriber);
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -47,7 +47,6 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.publisher.*;
 import reactor.util.annotation.Nullable;
-import reactor.util.concurrent.Queues;
 
 /** Responder side of RSocket. Receives {@link ByteBuf}s from a peer's {@link RSocketRequester} */
 class RSocketResponder implements RSocket {
@@ -526,10 +525,7 @@ class RSocketResponder implements RSocket {
         };
 
     sendingSubscriptions.put(streamId, subscriber);
-    response
-        .limitRate(Queues.SMALL_BUFFER_SIZE)
-        .doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER)
-        .subscribe(subscriber);
+    response.doOnDiscard(ReferenceCounted.class, DROPPED_ELEMENTS_CONSUMER).subscribe(subscriber);
   }
 
   private void handleChannel(int streamId, Payload payload, long initialRequestN) {

--- a/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/plugins/LimitRateInterceptorExample.java
+++ b/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/plugins/LimitRateInterceptorExample.java
@@ -2,6 +2,7 @@ package io.rsocket.examples.transport.tcp.plugins;
 
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.SocketAcceptor;
 import io.rsocket.core.RSocketConnector;
 import io.rsocket.core.RSocketServer;
 import io.rsocket.examples.transport.tcp.stream.StreamingClient;
@@ -17,36 +18,34 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.util.concurrent.Queues;
 
-public class LimitRateInterceptoreExample {
+public class LimitRateInterceptorExample {
 
   private static final Logger logger = LoggerFactory.getLogger(StreamingClient.class);
 
   public static void main(String[] args) {
     BlockingQueue<String> requests = new ArrayBlockingQueue<>(100);
     RSocketServer.create(
-            (sp, sr) ->
-                Mono.just(
-                    new RSocket() {
-                      @Override
-                      public Flux<Payload> requestStream(Payload payload) {
-                        return Flux.interval(Duration.ofMillis(100))
-                            .doOnRequest(e -> requests.add("Responder requestN(" + e + ")"))
-                            .map(aLong -> DefaultPayload.create("Interval: " + aLong));
-                      }
+            SocketAcceptor.with(
+                new RSocket() {
+                  @Override
+                  public Flux<Payload> requestStream(Payload payload) {
+                    return Flux.interval(Duration.ofMillis(100))
+                        .doOnRequest(e -> requests.add("Responder requestN(" + e + ")"))
+                        .map(aLong -> DefaultPayload.create("Interval: " + aLong));
+                  }
 
-                      @Override
-                      public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
-                        return Flux.from(payloads)
-                            .doOnRequest(e -> requests.add("Responder requestN(" + e + ")"));
-                      }
-                    }))
+                  @Override
+                  public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+                    return Flux.from(payloads)
+                        .doOnRequest(e -> requests.add("Responder requestN(" + e + ")"));
+                  }
+                }))
         .interceptors(
             ir ->
-                ir.forRequester((RSocketInterceptor) r -> new LimitRateRSocket(r, true))
-                    .forResponder((RSocketInterceptor) r -> new LimitRateRSocket(r, false)))
+                ir.forRequester(LimitRateInterceptor.forRequester())
+                    .forResponder(LimitRateInterceptor.forResponder()))
         .bind(TcpServerTransport.create("localhost", 7000))
         .subscribe();
 
@@ -54,8 +53,8 @@ public class LimitRateInterceptoreExample {
         RSocketConnector.create()
             .interceptors(
                 ir ->
-                    ir.forRequester((RSocketInterceptor) r -> new LimitRateRSocket(r, true))
-                        .forResponder((RSocketInterceptor) r -> new LimitRateRSocket(r, false)))
+                    ir.forRequester(LimitRateInterceptor.forRequester())
+                        .forResponder(LimitRateInterceptor.forResponder()))
             .connect(TcpClientTransport.create("localhost", 7000))
             .block();
 
@@ -94,19 +93,53 @@ public class LimitRateInterceptoreExample {
     requests.forEach(request -> logger.debug("Requested : {}", request));
   }
 
+  static class LimitRateInterceptor implements RSocketInterceptor {
+
+    final boolean requesterSide;
+    final int highTide;
+    final int lowTide;
+
+    LimitRateInterceptor(boolean requesterSide, int highTide, int lowTide) {
+      this.requesterSide = requesterSide;
+      this.highTide = highTide;
+      this.lowTide = lowTide;
+    }
+
+    @Override
+    public RSocket apply(RSocket socket) {
+      return new LimitRateRSocket(socket, requesterSide, highTide, lowTide);
+    }
+
+    public static LimitRateInterceptor forRequester() {
+      return forRequester(Queues.SMALL_BUFFER_SIZE);
+    }
+
+    public static LimitRateInterceptor forRequester(int limit) {
+      return forRequester(limit, limit);
+    }
+
+    public static LimitRateInterceptor forRequester(int highTide, int lowTide) {
+      return new LimitRateInterceptor(true, highTide, lowTide);
+    }
+
+    public static LimitRateInterceptor forResponder() {
+      return forRequester(Queues.SMALL_BUFFER_SIZE);
+    }
+
+    public static LimitRateInterceptor forResponder(int limit) {
+      return forRequester(limit, limit);
+    }
+
+    public static LimitRateInterceptor forResponder(int highTide, int lowTide) {
+      return new LimitRateInterceptor(false, highTide, lowTide);
+    }
+  }
+
   static class LimitRateRSocket extends RSocketProxy {
 
-    private final boolean requesterSide;
-    private final int highTide;
-    private final int lowTide;
-
-    public LimitRateRSocket(RSocket source, boolean requesterSide) {
-      this(source, requesterSide, Queues.SMALL_BUFFER_SIZE);
-    }
-
-    public LimitRateRSocket(RSocket source, boolean requesterSide, int highTide) {
-      this(source, requesterSide, highTide, highTide);
-    }
+    final boolean requesterSide;
+    final int highTide;
+    final int lowTide;
 
     public LimitRateRSocket(RSocket source, boolean requesterSide, int highTide, int lowTide) {
       super(source);

--- a/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/plugins/LimitRateInterceptoreExample.java
+++ b/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/plugins/LimitRateInterceptoreExample.java
@@ -1,0 +1,135 @@
+package io.rsocket.examples.transport.tcp.plugins;
+
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.core.RSocketConnector;
+import io.rsocket.core.RSocketServer;
+import io.rsocket.examples.transport.tcp.stream.StreamingClient;
+import io.rsocket.plugins.RSocketInterceptor;
+import io.rsocket.transport.netty.client.TcpClientTransport;
+import io.rsocket.transport.netty.server.TcpServerTransport;
+import io.rsocket.util.DefaultPayload;
+import io.rsocket.util.RSocketProxy;
+import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.concurrent.Queues;
+
+public class LimitRateInterceptoreExample {
+
+  private static final Logger logger = LoggerFactory.getLogger(StreamingClient.class);
+
+  public static void main(String[] args) {
+    BlockingQueue<String> requests = new ArrayBlockingQueue<>(100);
+    RSocketServer.create(
+            (sp, sr) ->
+                Mono.just(
+                    new RSocket() {
+                      @Override
+                      public Flux<Payload> requestStream(Payload payload) {
+                        return Flux.interval(Duration.ofMillis(100))
+                            .doOnRequest(e -> requests.add("Responder requestN(" + e + ")"))
+                            .map(aLong -> DefaultPayload.create("Interval: " + aLong));
+                      }
+
+                      @Override
+                      public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+                        return Flux.from(payloads)
+                            .doOnRequest(e -> requests.add("Responder requestN(" + e + ")"));
+                      }
+                    }))
+        .interceptors(
+            ir ->
+                ir.forRequester((RSocketInterceptor) r -> new LimitRateRSocket(r, true))
+                    .forResponder((RSocketInterceptor) r -> new LimitRateRSocket(r, false)))
+        .bind(TcpServerTransport.create("localhost", 7000))
+        .subscribe();
+
+    RSocket socket =
+        RSocketConnector.create()
+            .interceptors(
+                ir ->
+                    ir.forRequester((RSocketInterceptor) r -> new LimitRateRSocket(r, true))
+                        .forResponder((RSocketInterceptor) r -> new LimitRateRSocket(r, false)))
+            .connect(TcpClientTransport.create("localhost", 7000))
+            .block();
+
+    socket
+        .requestStream(DefaultPayload.create("Hello"))
+        .doOnRequest(e -> requests.add("Requester requestN(" + e + ")"))
+        .map(Payload::getDataUtf8)
+        .doOnNext(logger::debug)
+        .take(10)
+        .then()
+        .block();
+
+    requests.forEach(request -> logger.debug("Requested : {}", request));
+    requests.clear();
+
+    logger.debug("-----------------------------------------------------------------");
+    logger.debug("Does requestChannel");
+    socket
+        .requestChannel(
+            Flux.<Payload, Long>generate(
+                    () -> 1L,
+                    (s, sink) -> {
+                      sink.next(DefaultPayload.create("Next " + s));
+                      return ++s;
+                    })
+                .doOnRequest(e -> requests.add("Requester Upstream requestN(" + e + ")")))
+        .doOnRequest(e -> requests.add("Requester Downstream requestN(" + e + ")"))
+        .map(Payload::getDataUtf8)
+        .doOnNext(logger::debug)
+        .take(10)
+        .then()
+        .doFinally(signalType -> socket.dispose())
+        .then()
+        .block();
+
+    requests.forEach(request -> logger.debug("Requested : {}", request));
+  }
+
+  static class LimitRateRSocket extends RSocketProxy {
+
+    private final boolean requesterSide;
+    private final int highTide;
+    private final int lowTide;
+
+    public LimitRateRSocket(RSocket source, boolean requesterSide) {
+      this(source, requesterSide, Queues.SMALL_BUFFER_SIZE);
+    }
+
+    public LimitRateRSocket(RSocket source, boolean requesterSide, int highTide) {
+      this(source, requesterSide, highTide, highTide);
+    }
+
+    public LimitRateRSocket(RSocket source, boolean requesterSide, int highTide, int lowTide) {
+      super(source);
+      this.requesterSide = requesterSide;
+      this.highTide = highTide;
+      this.lowTide = lowTide;
+    }
+
+    @Override
+    public Flux<Payload> requestStream(Payload payload) {
+      Flux<Payload> flux = super.requestStream(payload);
+      if (requesterSide) {
+        return flux;
+      }
+      return flux.limitRate(highTide, lowTide);
+    }
+
+    @Override
+    public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+      if (requesterSide) {
+        return super.requestChannel(Flux.from(payloads).limitRate(highTide, lowTide));
+      }
+      return super.requestChannel(payloads).limitRate(highTide, lowTide);
+    }
+  }
+}

--- a/rsocket-test/src/main/java/io/rsocket/test/TransportTest.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TransportTest.java
@@ -237,8 +237,7 @@ public interface TransportTest {
         .expectComplete()
         .verify(getTimeout());
 
-    Assertions.assertThat(requested.get())
-        .isEqualTo(256L); // 256 because of eager behavior of limitRate
+    Assertions.assertThat(requested.get()).isEqualTo(3L);
   }
 
   @DisplayName("makes 1 requestChannel request with 512 payloads")


### PR DESCRIPTION
closes #825 

This PR removes usage of `limitRate` operator and provides an example of how one can provide `limitRate` just in case this is crucial 