### PR TITLE
provides `bindNow` shortcut for the server

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
@@ -291,6 +291,14 @@ public final class RSocketServer {
   }
 
   /**
+   * Start the server on the given transport. Effectively is a shortcut for {@code
+   * .bind(ServerTransport).block()}
+   */
+  public <T extends Closeable> T bindNow(ServerTransport<T> transport) {
+    return bind(transport).block();
+  }
+
+  /**
    * An alternative to {@link #bind(ServerTransport)} that is useful for installing RSocket on a
    * server that is started independently.
    *


### PR DESCRIPTION
This PR provides `bindNow` for the RSocketServer which provides a shortcut for `bind().block` which pretty common start for the server-side

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>