### PR TITLE
includes LimitRateInterceptor as a built-in interceptor

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -221,6 +221,7 @@ public class RSocketConnector {
    *
    * @param configurer a configurer to customize interception with.
    * @return the same instance for method chaining
+   * @see io.rsocket.plugins.LimitRateInterceptor
    */
   public RSocketConnector interceptors(Consumer<InterceptorRegistry> configurer) {
     configurer.accept(this.interceptors);

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
@@ -142,6 +142,7 @@ public final class RSocketServer {
    *
    * @param configurer a configurer to customize interception with.
    * @return the same instance for method chaining
+   * @see io.rsocket.plugins.LimitRateInterceptor
    */
   public RSocketServer interceptors(Consumer<InterceptorRegistry> configurer) {
     configurer.accept(this.interceptors);

--- a/rsocket-core/src/main/java/io/rsocket/plugins/LimitRateInterceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/LimitRateInterceptor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rsocket.plugins;
+
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.util.RSocketProxy;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+/**
+ * Interceptor that adds {@link Flux#limitRate(int, int)} to publishers of outbound streams that
+ * breaks down or aggregates demand values from the remote end (i.e. {@code REQUEST_N} frames) into
+ * batches of a uniform size. For example the remote may request {@code Long.MAXVALUE} or it may
+ * start requesting one at a time, in both cases with the limit set to 64, the publisher will see a
+ * demand of 64 to start and subsequent batches of 48, i.e. continuing to prefetch and refill an
+ * internal queue when it falls to 75% full. The high and low tide marks are configurable.
+ *
+ * <p>See static factory methods to create an instance for a requester or for a responder.
+ *
+ * <p><strong>Note:</strong> keep in mind that the {@code limitRate} operator always uses requests
+ * the same request values, even if the remote requests less than the limit. For example given a
+ * limit of 64, if the remote requests 4, 64 will be prefetched of which 4 will be sent and 60 will
+ * be cached.
+ *
+ * @since 1.0
+ */
+public class LimitRateInterceptor implements RSocketInterceptor {
+
+  private final int highTide;
+  private final int lowTide;
+  private final boolean requesterProxy;
+
+  private LimitRateInterceptor(int highTide, int lowTide, boolean requesterProxy) {
+    this.highTide = highTide;
+    this.lowTide = lowTide;
+    this.requesterProxy = requesterProxy;
+  }
+
+  @Override
+  public RSocket apply(RSocket socket) {
+    return requesterProxy ? new RequesterProxy(socket) : new ResponderProxy(socket);
+  }
+
+  /**
+   * Create an interceptor for an {@code RSocket} that handles request-stream and/or request-channel
+   * interactions.
+   *
+   * @param prefetchRate the prefetch rate to pass to {@link Flux#limitRate(int)}
+   * @return the created interceptor
+   */
+  public static LimitRateInterceptor forResponder(int prefetchRate) {
+    return forResponder(prefetchRate, prefetchRate);
+  }
+
+  /**
+   * Create an interceptor for an {@code RSocket} that handles request-stream and/or request-channel
+   * interactions with more control over the overall prefetch rate and replenish threshold.
+   *
+   * @param highTide the high tide value to pass to {@link Flux#limitRate(int, int)}
+   * @param lowTide the low tide value to pass to {@link Flux#limitRate(int, int)}
+   * @return the created interceptor
+   */
+  public static LimitRateInterceptor forResponder(int highTide, int lowTide) {
+    return new LimitRateInterceptor(highTide, lowTide, false);
+  }
+
+  /**
+   * Create an interceptor for an {@code RSocket} that performs request-channel interactions.
+   *
+   * @param prefetchRate the prefetch rate to pass to {@link Flux#limitRate(int)}
+   * @return the created interceptor
+   */
+  public static LimitRateInterceptor forRequester(int prefetchRate) {
+    return forRequester(prefetchRate, prefetchRate);
+  }
+
+  /**
+   * Create an interceptor for an {@code RSocket} that performs request-channel interactions with
+   * more control over the overall prefetch rate and replenish threshold.
+   *
+   * @param highTide the high tide value to pass to {@link Flux#limitRate(int, int)}
+   * @param lowTide the low tide value to pass to {@link Flux#limitRate(int, int)}
+   * @return the created interceptor
+   */
+  public static LimitRateInterceptor forRequester(int highTide, int lowTide) {
+    return new LimitRateInterceptor(highTide, lowTide, true);
+  }
+
+  /** Responder side proxy, limits response streams. */
+  private class ResponderProxy extends RSocketProxy {
+
+    ResponderProxy(RSocket source) {
+      super(source);
+    }
+
+    @Override
+    public Flux<Payload> requestStream(Payload payload) {
+      return super.requestStream(payload).limitRate(highTide, lowTide);
+    }
+
+    @Override
+    public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+      return super.requestChannel(payloads).limitRate(highTide, lowTide);
+    }
+  }
+
+  /** Requester side proxy, limits channel request stream. */
+  private class RequesterProxy extends RSocketProxy {
+
+    RequesterProxy(RSocket source) {
+      super(source);
+    }
+
+    @Override
+    public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+      return super.requestChannel(Flux.from(payloads).limitRate(highTide, lowTide));
+    }
+  }
+}

--- a/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/plugins/LimitRateInterceptorExample.java
+++ b/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/plugins/LimitRateInterceptorExample.java
@@ -5,73 +5,64 @@ import io.rsocket.RSocket;
 import io.rsocket.SocketAcceptor;
 import io.rsocket.core.RSocketConnector;
 import io.rsocket.core.RSocketServer;
-import io.rsocket.examples.transport.tcp.stream.StreamingClient;
-import io.rsocket.plugins.RSocketInterceptor;
+import io.rsocket.plugins.LimitRateInterceptor;
 import io.rsocket.transport.netty.client.TcpClientTransport;
 import io.rsocket.transport.netty.server.TcpServerTransport;
 import io.rsocket.util.DefaultPayload;
-import io.rsocket.util.RSocketProxy;
 import java.time.Duration;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.util.concurrent.Queues;
 
 public class LimitRateInterceptorExample {
 
-  private static final Logger logger = LoggerFactory.getLogger(StreamingClient.class);
+  private static final Logger logger = LoggerFactory.getLogger(LimitRateInterceptorExample.class);
 
   public static void main(String[] args) {
-    BlockingQueue<String> requests = new ArrayBlockingQueue<>(100);
     RSocketServer.create(
             SocketAcceptor.with(
                 new RSocket() {
                   @Override
                   public Flux<Payload> requestStream(Payload payload) {
                     return Flux.interval(Duration.ofMillis(100))
-                        .doOnRequest(e -> requests.add("Responder requestN(" + e + ")"))
+                        .doOnRequest(
+                            e -> logger.debug("Server publisher receives request for " + e))
                         .map(aLong -> DefaultPayload.create("Interval: " + aLong));
                   }
 
                   @Override
                   public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
                     return Flux.from(payloads)
-                        .doOnRequest(e -> requests.add("Responder requestN(" + e + ")"));
+                        .doOnRequest(
+                            e -> logger.debug("Server publisher receives request for " + e));
                   }
                 }))
-        .interceptors(
-            ir ->
-                ir.forRequester(LimitRateInterceptor.forRequester())
-                    .forResponder(LimitRateInterceptor.forResponder()))
+        .interceptors(registry -> registry.forResponder(LimitRateInterceptor.forResponder(64)))
         .bind(TcpServerTransport.create("localhost", 7000))
         .subscribe();
 
     RSocket socket =
         RSocketConnector.create()
-            .interceptors(
-                ir ->
-                    ir.forRequester(LimitRateInterceptor.forRequester())
-                        .forResponder(LimitRateInterceptor.forResponder()))
+            .interceptors(registry -> registry.forRequester(LimitRateInterceptor.forRequester(64)))
             .connect(TcpClientTransport.create("localhost", 7000))
             .block();
 
+    logger.debug(
+        "\n\nStart of requestStream interaction\n" + "----------------------------------\n");
+
     socket
         .requestStream(DefaultPayload.create("Hello"))
-        .doOnRequest(e -> requests.add("Requester requestN(" + e + ")"))
+        .doOnRequest(e -> logger.debug("Client sends requestN(" + e + ")"))
         .map(Payload::getDataUtf8)
         .doOnNext(logger::debug)
         .take(10)
         .then()
         .block();
 
-    requests.forEach(request -> logger.debug("Requested : {}", request));
-    requests.clear();
+    logger.debug(
+        "\n\nStart of requestChannel interaction\n" + "-----------------------------------\n");
 
-    logger.debug("-----------------------------------------------------------------");
-    logger.debug("Does requestChannel");
     socket
         .requestChannel(
             Flux.<Payload, Long>generate(
@@ -80,8 +71,8 @@ public class LimitRateInterceptorExample {
                       sink.next(DefaultPayload.create("Next " + s));
                       return ++s;
                     })
-                .doOnRequest(e -> requests.add("Requester Upstream requestN(" + e + ")")))
-        .doOnRequest(e -> requests.add("Requester Downstream requestN(" + e + ")"))
+                .doOnRequest(e -> logger.debug("Client publisher receives request for " + e)))
+        .doOnRequest(e -> logger.debug("Client sends requestN(" + e + ")"))
         .map(Payload::getDataUtf8)
         .doOnNext(logger::debug)
         .take(10)
@@ -89,80 +80,5 @@ public class LimitRateInterceptorExample {
         .doFinally(signalType -> socket.dispose())
         .then()
         .block();
-
-    requests.forEach(request -> logger.debug("Requested : {}", request));
-  }
-
-  static class LimitRateInterceptor implements RSocketInterceptor {
-
-    final boolean requesterSide;
-    final int highTide;
-    final int lowTide;
-
-    LimitRateInterceptor(boolean requesterSide, int highTide, int lowTide) {
-      this.requesterSide = requesterSide;
-      this.highTide = highTide;
-      this.lowTide = lowTide;
-    }
-
-    @Override
-    public RSocket apply(RSocket socket) {
-      return new LimitRateRSocket(socket, requesterSide, highTide, lowTide);
-    }
-
-    public static LimitRateInterceptor forRequester() {
-      return forRequester(Queues.SMALL_BUFFER_SIZE);
-    }
-
-    public static LimitRateInterceptor forRequester(int limit) {
-      return forRequester(limit, limit);
-    }
-
-    public static LimitRateInterceptor forRequester(int highTide, int lowTide) {
-      return new LimitRateInterceptor(true, highTide, lowTide);
-    }
-
-    public static LimitRateInterceptor forResponder() {
-      return forRequester(Queues.SMALL_BUFFER_SIZE);
-    }
-
-    public static LimitRateInterceptor forResponder(int limit) {
-      return forRequester(limit, limit);
-    }
-
-    public static LimitRateInterceptor forResponder(int highTide, int lowTide) {
-      return new LimitRateInterceptor(false, highTide, lowTide);
-    }
-  }
-
-  static class LimitRateRSocket extends RSocketProxy {
-
-    final boolean requesterSide;
-    final int highTide;
-    final int lowTide;
-
-    public LimitRateRSocket(RSocket source, boolean requesterSide, int highTide, int lowTide) {
-      super(source);
-      this.requesterSide = requesterSide;
-      this.highTide = highTide;
-      this.lowTide = lowTide;
-    }
-
-    @Override
-    public Flux<Payload> requestStream(Payload payload) {
-      Flux<Payload> flux = super.requestStream(payload);
-      if (requesterSide) {
-        return flux;
-      }
-      return flux.limitRate(highTide, lowTide);
-    }
-
-    @Override
-    public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
-      if (requesterSide) {
-        return super.requestChannel(Flux.from(payloads).limitRate(highTide, lowTide));
-      }
-      return super.requestChannel(payloads).limitRate(highTide, lowTide);
-    }
   }
 }


### PR DESCRIPTION
Promote `LimitRateInterceptor` to rsocket-core to make it more visible and available out of the box. Although it's easy to apply `limitRate` to individual streams, the interceptor is useful for doing so consistently from a single place.
