### PR TITLE
Apply FragmentationDuplexConnection from a single place

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/ReassemblyDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/ReassemblyDuplexConnection.java
@@ -19,7 +19,6 @@ package io.rsocket.fragmentation;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
-import io.rsocket.frame.FrameLengthCodec;
 import java.util.Objects;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -35,25 +34,10 @@ import reactor.core.publisher.Mono;
 public class ReassemblyDuplexConnection implements DuplexConnection {
   private final DuplexConnection delegate;
   private final FrameReassembler frameReassembler;
-  private final boolean decodeLength;
 
-  /**
-   * Constructor with the underlying delegate to receive frames from.
-   *
-   * @since 1.0.1
-   */
+  /** Constructor with the underlying delegate to receive frames from. */
   public ReassemblyDuplexConnection(DuplexConnection delegate) {
-    this(delegate, false);
-  }
-
-  /**
-   * @deprecated as of 1.0.1 in favor of {@link #ReassemblyDuplexConnection(DuplexConnection)} and
-   *     hence {@code decodeLength} should always be false.
-   */
-  @Deprecated
-  public ReassemblyDuplexConnection(DuplexConnection delegate, boolean decodeLength) {
     Objects.requireNonNull(delegate, "delegate must not be null");
-    this.decodeLength = decodeLength;
     this.delegate = delegate;
     this.frameReassembler = new FrameReassembler(delegate.alloc());
 
@@ -70,23 +54,9 @@ public class ReassemblyDuplexConnection implements DuplexConnection {
     return delegate.sendOne(frame);
   }
 
-  private ByteBuf decode(ByteBuf frame) {
-    if (decodeLength) {
-      return FrameLengthCodec.frame(frame).retain();
-    } else {
-      return frame;
-    }
-  }
-
   @Override
   public Flux<ByteBuf> receive() {
-    return delegate
-        .receive()
-        .handle(
-            (byteBuf, sink) -> {
-              ByteBuf decode = decode(byteBuf);
-              frameReassembler.reassembleFrame(decode, sink);
-            });
+    return delegate.receive().handle(frameReassembler::reassembleFrame);
   }
 
   @Override

--- a/rsocket-core/src/main/java/io/rsocket/fragmentation/ReassemblyDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/fragmentation/ReassemblyDuplexConnection.java
@@ -37,6 +37,20 @@ public class ReassemblyDuplexConnection implements DuplexConnection {
   private final FrameReassembler frameReassembler;
   private final boolean decodeLength;
 
+  /**
+   * Constructor with the underlying delegate to receive frames from.
+   *
+   * @since 1.0.1
+   */
+  public ReassemblyDuplexConnection(DuplexConnection delegate) {
+    this(delegate, false);
+  }
+
+  /**
+   * @deprecated as of 1.0.1 in favor of {@link #ReassemblyDuplexConnection(DuplexConnection)} and
+   *     hence {@code decodeLength} should always be false.
+   */
+  @Deprecated
   public ReassemblyDuplexConnection(DuplexConnection delegate, boolean decodeLength) {
     Objects.requireNonNull(delegate, "delegate must not be null");
     this.decodeLength = decodeLength;

--- a/rsocket-core/src/main/java/io/rsocket/transport/ClientTransport.java
+++ b/rsocket-core/src/main/java/io/rsocket/transport/ClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,9 @@ import reactor.core.publisher.Mono;
 public interface ClientTransport extends Transport {
 
   /**
-   * Returns a {@code Publisher}, every subscription to which returns a single {@code
-   * DuplexConnection}.
+   * Return a {@code Mono} that connects for each subscriber.
    *
-   * @param mtu The mtu used for fragmentation - if set to zero fragmentation will be disabled
-   * @return {@code Publisher}, every subscription returns a single {@code DuplexConnection}.
+   * @since 1.0.1
    */
-  Mono<DuplexConnection> connect(int mtu);
+  Mono<DuplexConnection> connect();
 }

--- a/rsocket-core/src/main/java/io/rsocket/transport/ServerTransport.java
+++ b/rsocket-core/src/main/java/io/rsocket/transport/ServerTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,14 +26,13 @@ import reactor.core.publisher.Mono;
 public interface ServerTransport<T extends Closeable> extends Transport {
 
   /**
-   * Starts this server.
+   * Start this server.
    *
-   * @param acceptor An acceptor to process a newly accepted {@code DuplexConnection}
-   * @param mtu The mtu used for fragmentation - if set to zero fragmentation will be disabled
-   * @return A handle to retrieve information about a started server.
-   * @throws NullPointerException if {@code acceptor} is {@code null}
+   * @param acceptor to process a newly accepted connections with
+   * @return A handle for information about and control over the server.
+   * @since 1.0.1
    */
-  Mono<T> start(ConnectionAcceptor acceptor, int mtu);
+  Mono<T> start(ConnectionAcceptor acceptor);
 
   /** A contract to accept a new {@code DuplexConnection}. */
   interface ConnectionAcceptor extends Function<DuplexConnection, Publisher<Void>> {

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketReconnectTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketReconnectTest.java
@@ -64,12 +64,12 @@ public class RSocketReconnectTest {
   @SuppressWarnings({"rawtype", "unchecked"})
   public void shouldBeRetrieableConnectionSharedReconnectableInstanceOfRSocketMono() {
     ClientTransport transport = Mockito.mock(ClientTransport.class);
-    Mockito.when(transport.connect(0))
+    Mockito.when(transport.connect())
         .thenThrow(UncheckedIOException.class)
         .thenThrow(UncheckedIOException.class)
         .thenThrow(UncheckedIOException.class)
         .thenThrow(UncheckedIOException.class)
-        .thenReturn(new TestClientTransport().connect(0));
+        .thenReturn(new TestClientTransport().connect());
     Mono<RSocket> rSocketMono =
         RSocketConnector.create()
             .reconnect(
@@ -93,13 +93,13 @@ public class RSocketReconnectTest {
   @SuppressWarnings({"rawtype", "unchecked"})
   public void shouldBeExaustedRetrieableConnectionSharedReconnectableInstanceOfRSocketMono() {
     ClientTransport transport = Mockito.mock(ClientTransport.class);
-    Mockito.when(transport.connect(0))
+    Mockito.when(transport.connect())
         .thenThrow(UncheckedIOException.class)
         .thenThrow(UncheckedIOException.class)
         .thenThrow(UncheckedIOException.class)
         .thenThrow(UncheckedIOException.class)
         .thenThrow(UncheckedIOException.class)
-        .thenReturn(new TestClientTransport().connect(0));
+        .thenReturn(new TestClientTransport().connect());
     Mono<RSocket> rSocketMono =
         RSocketConnector.create()
             .reconnect(

--- a/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
@@ -137,7 +137,7 @@ public class SetupRejectionTest {
     private final TestDuplexConnection conn = new TestDuplexConnection(allocator);
 
     @Override
-    public Mono<TestCloseable> start(ConnectionAcceptor acceptor, int mtu) {
+    public Mono<TestCloseable> start(ConnectionAcceptor acceptor) {
       return Mono.just(new TestCloseable(acceptor, conn));
     }
 

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationDuplexConnectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationDuplexConnectionTest.java
@@ -63,7 +63,7 @@ final class FragmentationDuplexConnectionTest {
   @Test
   void constructorInvalidMaxFragmentSize() {
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new FragmentationDuplexConnection(delegate, Integer.MIN_VALUE, false, ""))
+        .isThrownBy(() -> new FragmentationDuplexConnection(delegate, Integer.MIN_VALUE, ""))
         .withMessage("smallest allowed mtu size is 64 bytes, provided: -2147483648");
   }
 
@@ -71,7 +71,7 @@ final class FragmentationDuplexConnectionTest {
   @Test
   void constructorMtuLessThanMin() {
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new FragmentationDuplexConnection(delegate, 2, false, ""))
+        .isThrownBy(() -> new FragmentationDuplexConnection(delegate, 2, ""))
         .withMessage("smallest allowed mtu size is 64 bytes, provided: 2");
   }
 
@@ -79,7 +79,7 @@ final class FragmentationDuplexConnectionTest {
   @Test
   void constructorNullDelegate() {
     assertThatNullPointerException()
-        .isThrownBy(() -> new FragmentationDuplexConnection(null, 64, false, ""))
+        .isThrownBy(() -> new FragmentationDuplexConnection(null, 64, ""))
         .withMessage("delegate must not be null");
   }
 
@@ -93,7 +93,7 @@ final class FragmentationDuplexConnectionTest {
     when(delegate.onClose()).thenReturn(Mono.never());
     when(delegate.alloc()).thenReturn(allocator);
 
-    new FragmentationDuplexConnection(delegate, 64, false, "").sendOne(encode.retain());
+    new FragmentationDuplexConnection(delegate, 64, "").sendOne(encode.retain());
 
     verify(delegate).send(publishers.capture());
 

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationDuplexConnectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationDuplexConnectionTest.java
@@ -64,7 +64,7 @@ final class FragmentationDuplexConnectionTest {
   void constructorInvalidMaxFragmentSize() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new FragmentationDuplexConnection(delegate, Integer.MIN_VALUE, ""))
-        .withMessage("smallest allowed mtu size is 64 bytes, provided: -2147483648");
+        .withMessage("The smallest allowed mtu size is 64 bytes, provided: -2147483648");
   }
 
   @DisplayName("constructor throws IllegalArgumentException with negative maxFragmentLength")
@@ -72,7 +72,7 @@ final class FragmentationDuplexConnectionTest {
   void constructorMtuLessThanMin() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new FragmentationDuplexConnection(delegate, 2, ""))
-        .withMessage("smallest allowed mtu size is 64 bytes, provided: 2");
+        .withMessage("The smallest allowed mtu size is 64 bytes, provided: 2");
   }
 
   @DisplayName("constructor throws NullPointerException with null delegate")

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationIntegrationTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/FragmentationIntegrationTest.java
@@ -35,8 +35,7 @@ public class FragmentationIntegrationTest {
     frame.retain();
 
     Publisher<ByteBuf> fragments =
-        FrameFragmenter.fragmentFrame(
-            allocator, 64, frame, FrameHeaderCodec.frameType(frame), false);
+        FrameFragmenter.fragmentFrame(allocator, 64, frame, FrameHeaderCodec.frameType(frame));
 
     FrameReassembler reassembler = new FrameReassembler(allocator);
 

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/FrameFragmenterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/FrameFragmenterTest.java
@@ -272,7 +272,7 @@ final class FrameFragmenterTest {
         RequestResponseFrameCodec.encode(allocator, 1, true, null, Unpooled.wrappedBuffer(data));
 
     Publisher<ByteBuf> fragments =
-        FrameFragmenter.fragmentFrame(allocator, 1024, rr, FrameType.REQUEST_RESPONSE, false);
+        FrameFragmenter.fragmentFrame(allocator, 1024, rr, FrameType.REQUEST_RESPONSE);
 
     StepVerifier.create(Flux.from(fragments).doOnError(Throwable::printStackTrace))
         .expectNextCount(1)
@@ -299,7 +299,7 @@ final class FrameFragmenterTest {
             allocator, 1, true, 10, Unpooled.wrappedBuffer(metadata), Unpooled.EMPTY_BUFFER);
 
     Publisher<ByteBuf> fragments =
-        FrameFragmenter.fragmentFrame(allocator, 1024, rr, FrameType.REQUEST_STREAM, false);
+        FrameFragmenter.fragmentFrame(allocator, 1024, rr, FrameType.REQUEST_STREAM);
 
     StepVerifier.create(Flux.from(fragments).doOnError(Throwable::printStackTrace))
         .expectNextCount(1)
@@ -326,7 +326,7 @@ final class FrameFragmenterTest {
             allocator, 1, true, Unpooled.wrappedBuffer(metadata), Unpooled.wrappedBuffer(data));
 
     Publisher<ByteBuf> fragments =
-        FrameFragmenter.fragmentFrame(allocator, 1024, rr, FrameType.REQUEST_RESPONSE, false);
+        FrameFragmenter.fragmentFrame(allocator, 1024, rr, FrameType.REQUEST_RESPONSE);
 
     StepVerifier.create(Flux.from(fragments).doOnError(Throwable::printStackTrace))
         .assertNext(

--- a/rsocket-core/src/test/java/io/rsocket/fragmentation/ReassembleDuplexConnectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/fragmentation/ReassembleDuplexConnectionTest.java
@@ -86,7 +86,7 @@ final class ReassembleDuplexConnectionTest {
     when(delegate.onClose()).thenReturn(Mono.never());
     when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, false)
+    new ReassemblyDuplexConnection(delegate)
         .receive()
         .as(StepVerifier::create)
         .assertNext(
@@ -151,7 +151,7 @@ final class ReassembleDuplexConnectionTest {
     when(delegate.onClose()).thenReturn(Mono.never());
     when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, false)
+    new ReassemblyDuplexConnection(delegate)
         .receive()
         .as(StepVerifier::create)
         .assertNext(
@@ -219,7 +219,7 @@ final class ReassembleDuplexConnectionTest {
     when(delegate.onClose()).thenReturn(Mono.never());
     when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, false)
+    new ReassemblyDuplexConnection(delegate)
         .receive()
         .as(StepVerifier::create)
         .assertNext(
@@ -240,7 +240,7 @@ final class ReassembleDuplexConnectionTest {
     when(delegate.onClose()).thenReturn(Mono.never());
     when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, false)
+    new ReassemblyDuplexConnection(delegate)
         .receive()
         .as(StepVerifier::create)
         .assertNext(
@@ -260,7 +260,7 @@ final class ReassembleDuplexConnectionTest {
     when(delegate.onClose()).thenReturn(Mono.never());
     when(delegate.alloc()).thenReturn(allocator);
 
-    new ReassemblyDuplexConnection(delegate, false)
+    new ReassemblyDuplexConnection(delegate)
         .receive()
         .as(StepVerifier::create)
         .assertNext(

--- a/rsocket-core/src/test/java/io/rsocket/test/util/TestClientTransport.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/TestClientTransport.java
@@ -12,7 +12,7 @@ public class TestClientTransport implements ClientTransport {
   private final TestDuplexConnection testDuplexConnection = new TestDuplexConnection(allocator);
 
   @Override
-  public Mono<DuplexConnection> connect(int mtu) {
+  public Mono<DuplexConnection> connect() {
     return Mono.just(testDuplexConnection);
   }
 

--- a/rsocket-core/src/test/java/io/rsocket/test/util/TestServerTransport.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/TestServerTransport.java
@@ -13,7 +13,7 @@ public class TestServerTransport implements ServerTransport<Closeable> {
       LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
 
   @Override
-  public Mono<Closeable> start(ConnectionAcceptor acceptor, int mtu) {
+  public Mono<Closeable> start(ConnectionAcceptor acceptor) {
     conn.flatMap(acceptor::apply)
         .subscribe(ignored -> {}, err -> disposeConnection(), this::disposeConnection);
     return Mono.just(

--- a/rsocket-examples/src/main/java/io/rsocket/examples/transport/ws/WebSocketHeadersSample.java
+++ b/rsocket-examples/src/main/java/io/rsocket/examples/transport/ws/WebSocketHeadersSample.java
@@ -61,7 +61,7 @@ public class WebSocketHeadersSample {
                           if (in.headers().containsValue("Authorization", "test", true)) {
                             DuplexConnection connection =
                                 new ReassemblyDuplexConnection(
-                                    new WebsocketDuplexConnection((Connection) in), false);
+                                    new WebsocketDuplexConnection((Connection) in));
                             return acceptor.apply(connection).then(out.neverComplete());
                           }
 

--- a/rsocket-examples/src/test/java/io/rsocket/resume/DisconnectableClientTransport.java
+++ b/rsocket-examples/src/test/java/io/rsocket/resume/DisconnectableClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,13 +33,13 @@ class DisconnectableClientTransport implements ClientTransport {
   }
 
   @Override
-  public Mono<DuplexConnection> connect(int mtu) {
+  public Mono<DuplexConnection> connect() {
     return Mono.defer(
         () ->
             now() < nextConnectPermitMillis
                 ? Mono.error(new ClosedChannelException())
                 : clientTransport
-                    .connect(mtu)
+                    .connect()
                     .map(
                         c -> {
                           if (curConnection.compareAndSet(null, c)) {

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,9 +99,9 @@ public final class LocalClientTransport implements ClientTransport {
     return connect.map(
         duplexConnection -> {
           if (mtu > 0) {
-            return new FragmentationDuplexConnection(duplexConnection, mtu, false, "client");
+            return new FragmentationDuplexConnection(duplexConnection, mtu, "client");
           } else {
-            return new ReassemblyDuplexConnection(duplexConnection, false);
+            return new ReassemblyDuplexConnection(duplexConnection);
           }
         });
   }

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
@@ -19,12 +19,9 @@ package io.rsocket.transport.local;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
-import io.rsocket.fragmentation.FragmentationDuplexConnection;
-import io.rsocket.fragmentation.ReassemblyDuplexConnection;
 import io.rsocket.internal.UnboundedProcessor;
 import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.ServerTransport;
-import io.rsocket.transport.local.LocalServerTransport.ServerDuplexConnectionAcceptor;
 import java.util.Objects;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
@@ -72,10 +69,11 @@ public final class LocalClientTransport implements ClientTransport {
     return new LocalClientTransport(name, allocator);
   }
 
-  private Mono<DuplexConnection> connect() {
+  @Override
+  public Mono<DuplexConnection> connect() {
     return Mono.defer(
         () -> {
-          ServerDuplexConnectionAcceptor server = LocalServerTransport.findServer(name);
+          ServerTransport.ConnectionAcceptor server = LocalServerTransport.findServer(name);
           if (server == null) {
             return Mono.error(new IllegalArgumentException("Could not find server: " + name));
           }
@@ -84,25 +82,10 @@ public final class LocalClientTransport implements ClientTransport {
           UnboundedProcessor<ByteBuf> out = new UnboundedProcessor<>();
           MonoProcessor<Void> closeNotifier = MonoProcessor.create();
 
-          server.accept(new LocalDuplexConnection(allocator, out, in, closeNotifier));
+          server.apply(new LocalDuplexConnection(allocator, out, in, closeNotifier)).subscribe();
 
           return Mono.just(
               (DuplexConnection) new LocalDuplexConnection(allocator, in, out, closeNotifier));
-        });
-  }
-
-  @Override
-  public Mono<DuplexConnection> connect(int mtu) {
-    Mono<DuplexConnection> isError = FragmentationDuplexConnection.checkMtu(mtu);
-    Mono<DuplexConnection> connect = isError != null ? isError : connect();
-
-    return connect.map(
-        duplexConnection -> {
-          if (mtu > 0) {
-            return new FragmentationDuplexConnection(duplexConnection, mtu, "client");
-          } else {
-            return new ReassemblyDuplexConnection(duplexConnection);
-          }
         });
   }
 }

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalServerTransport.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalServerTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,10 +165,9 @@ public final class LocalServerTransport implements ServerTransport<Closeable> {
       Objects.requireNonNull(duplexConnection, "duplexConnection must not be null");
 
       if (mtu > 0) {
-        duplexConnection =
-            new FragmentationDuplexConnection(duplexConnection, mtu, false, "server");
+        duplexConnection = new FragmentationDuplexConnection(duplexConnection, mtu, "server");
       } else {
-        duplexConnection = new ReassemblyDuplexConnection(duplexConnection, false);
+        duplexConnection = new ReassemblyDuplexConnection(duplexConnection);
       }
 
       acceptor.apply(duplexConnection).subscribe();

--- a/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalClientTransportTest.java
+++ b/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalClientTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ final class LocalClientTransportTest {
     LocalServerTransport serverTransport = LocalServerTransport.createEphemeral();
 
     serverTransport
-        .start(duplexConnection -> Mono.empty(), 0)
-        .flatMap(closeable -> LocalClientTransport.create(serverTransport.getName()).connect(0))
+        .start(duplexConnection -> Mono.empty())
+        .flatMap(closeable -> LocalClientTransport.create(serverTransport.getName()).connect())
         .as(StepVerifier::create)
         .expectNextCount(1)
         .verifyComplete();
@@ -43,7 +43,7 @@ final class LocalClientTransportTest {
   @Test
   void connectNoServer() {
     LocalClientTransport.create("test-name")
-        .connect(0)
+        .connect()
         .as(StepVerifier::create)
         .verifyErrorMessage("Could not find server: test-name");
   }

--- a/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalServerTransportTest.java
+++ b/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalServerTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ final class LocalServerTransportTest {
     LocalServerTransport serverTransport = LocalServerTransport.createEphemeral();
 
     serverTransport
-        .start(duplexConnection -> Mono.empty(), 0)
+        .start(duplexConnection -> Mono.empty())
         .as(StepVerifier::create)
         .expectNextCount(1)
         .verifyComplete();
@@ -97,7 +97,7 @@ final class LocalServerTransportTest {
   @Test
   void start() {
     LocalServerTransport.createEphemeral()
-        .start(duplexConnection -> Mono.empty(), 0)
+        .start(duplexConnection -> Mono.empty())
         .as(StepVerifier::create)
         .expectNextCount(1)
         .verifyComplete();
@@ -107,7 +107,7 @@ final class LocalServerTransportTest {
   @Test
   void startNullAcceptor() {
     assertThatNullPointerException()
-        .isThrownBy(() -> LocalServerTransport.createEphemeral().start(null, 0))
+        .isThrownBy(() -> LocalServerTransport.createEphemeral().start(null))
         .withMessage("acceptor must not be null");
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,10 @@ public final class TcpDuplexConnection extends BaseDuplexConnection {
    *
    * @param encodeLength indicates if this connection should encode the length or not.
    * @param connection the {@link Connection} to for managing the server
+   * @deprecated as of 1.0.1 in favor of using {@link #TcpDuplexConnection(Connection)} and hence
+   *     {@code encodeLength} should always be true.
    */
+  @Deprecated
   public TcpDuplexConnection(Connection connection, boolean encodeLength) {
     this.encodeLength = encodeLength;
     this.connection = Objects.requireNonNull(connection, "connection must not be null");

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,11 +102,11 @@ public final class TcpClientTransport implements ClientTransport {
             .connect()
             .map(
                 c -> {
+                  TcpDuplexConnection connection = new TcpDuplexConnection(c);
                   if (mtu > 0) {
-                    return new FragmentationDuplexConnection(
-                        new TcpDuplexConnection(c, false), mtu, true, "client");
+                    return new FragmentationDuplexConnection(connection, mtu, "client");
                   } else {
-                    return new ReassemblyDuplexConnection(new TcpDuplexConnection(c), false);
+                    return new ReassemblyDuplexConnection(connection);
                   }
                 });
   }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
@@ -21,8 +21,6 @@ import static io.rsocket.transport.netty.UriUtils.getPort;
 import static io.rsocket.transport.netty.UriUtils.isSecure;
 
 import io.rsocket.DuplexConnection;
-import io.rsocket.fragmentation.FragmentationDuplexConnection;
-import io.rsocket.fragmentation.ReassemblyDuplexConnection;
 import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.ServerTransport;
 import io.rsocket.transport.TransportHeaderAware;
@@ -150,31 +148,18 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
   }
 
   @Override
-  public Mono<DuplexConnection> connect(int mtu) {
-    Mono<DuplexConnection> isError = FragmentationDuplexConnection.checkMtu(mtu);
-    return isError != null
-        ? isError
-        : client
-            .headers(headers -> transportHeaders.get().forEach(headers::set))
-            .websocket(
-                WebsocketClientSpec.builder().maxFramePayloadLength(FRAME_LENGTH_MASK).build())
-            .uri(path)
-            .connect()
-            .map(
-                c -> {
-                  DuplexConnection connection = new WebsocketDuplexConnection(c);
-                  if (mtu > 0) {
-                    connection = new FragmentationDuplexConnection(connection, mtu, "client");
-                  } else {
-                    connection = new ReassemblyDuplexConnection(connection);
-                  }
-                  return connection;
-                });
-  }
-
-  @Override
   public void setTransportHeaders(Supplier<Map<String, String>> transportHeaders) {
     this.transportHeaders =
         Objects.requireNonNull(transportHeaders, "transportHeaders must not be null");
+  }
+
+  @Override
+  public Mono<DuplexConnection> connect() {
+    return client
+        .headers(headers -> transportHeaders.get().forEach(headers::set))
+        .websocket(WebsocketClientSpec.builder().maxFramePayloadLength(FRAME_LENGTH_MASK).build())
+        .uri(path)
+        .connect()
+        .map(WebsocketDuplexConnection::new);
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,10 +164,9 @@ public final class WebsocketClientTransport implements ClientTransport, Transpor
                 c -> {
                   DuplexConnection connection = new WebsocketDuplexConnection(c);
                   if (mtu > 0) {
-                    connection =
-                        new FragmentationDuplexConnection(connection, mtu, false, "client");
+                    connection = new FragmentationDuplexConnection(connection, mtu, "client");
                   } else {
-                    connection = new ReassemblyDuplexConnection(connection, false);
+                    connection = new ReassemblyDuplexConnection(connection);
                   }
                   return connection;
                 });

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,13 +101,11 @@ public final class TcpServerTransport implements ServerTransport<CloseableChanne
             .doOnConnection(
                 c -> {
                   c.addHandlerLast(new RSocketLengthCodec());
-                  DuplexConnection connection;
+                  DuplexConnection connection = new TcpDuplexConnection(c);
                   if (mtu > 0) {
-                    connection =
-                        new FragmentationDuplexConnection(
-                            new TcpDuplexConnection(c, false), mtu, true, "server");
+                    connection = new FragmentationDuplexConnection(connection, mtu, "server");
                   } else {
-                    connection = new ReassemblyDuplexConnection(new TcpDuplexConnection(c), false);
+                    connection = new ReassemblyDuplexConnection(connection);
                   }
                   acceptor
                       .apply(connection)

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
@@ -16,9 +16,6 @@
 
 package io.rsocket.transport.netty.server;
 
-import io.rsocket.DuplexConnection;
-import io.rsocket.fragmentation.FragmentationDuplexConnection;
-import io.rsocket.fragmentation.ReassemblyDuplexConnection;
 import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.ServerTransport;
 import io.rsocket.transport.netty.RSocketLengthCodec;
@@ -60,7 +57,6 @@ public final class TcpServerTransport implements ServerTransport<CloseableChanne
    */
   public static TcpServerTransport create(String bindAddress, int port) {
     Objects.requireNonNull(bindAddress, "bindAddress must not be null");
-
     TcpServer server = TcpServer.create().host(bindAddress).port(port);
     return create(server);
   }
@@ -74,7 +70,6 @@ public final class TcpServerTransport implements ServerTransport<CloseableChanne
    */
   public static TcpServerTransport create(InetSocketAddress address) {
     Objects.requireNonNull(address, "address must not be null");
-
     return create(address.getHostName(), address.getPort());
   }
 
@@ -87,32 +82,22 @@ public final class TcpServerTransport implements ServerTransport<CloseableChanne
    */
   public static TcpServerTransport create(TcpServer server) {
     Objects.requireNonNull(server, "server must not be null");
-
     return new TcpServerTransport(server);
   }
 
   @Override
-  public Mono<CloseableChannel> start(ConnectionAcceptor acceptor, int mtu) {
+  public Mono<CloseableChannel> start(ConnectionAcceptor acceptor) {
     Objects.requireNonNull(acceptor, "acceptor must not be null");
-    Mono<CloseableChannel> isError = FragmentationDuplexConnection.checkMtu(mtu);
-    return isError != null
-        ? isError
-        : server
-            .doOnConnection(
-                c -> {
-                  c.addHandlerLast(new RSocketLengthCodec());
-                  DuplexConnection connection = new TcpDuplexConnection(c);
-                  if (mtu > 0) {
-                    connection = new FragmentationDuplexConnection(connection, mtu, "server");
-                  } else {
-                    connection = new ReassemblyDuplexConnection(connection);
-                  }
-                  acceptor
-                      .apply(connection)
-                      .then(Mono.<Void>never())
-                      .subscribe(c.disposeSubscriber());
-                })
-            .bind()
-            .map(CloseableChannel::new);
+    return server
+        .doOnConnection(
+            c -> {
+              c.addHandlerLast(new RSocketLengthCodec());
+              acceptor
+                  .apply(new TcpDuplexConnection(c))
+                  .then(Mono.<Void>never())
+                  .subscribe(c.disposeSubscriber());
+            })
+        .bind()
+        .map(CloseableChannel::new);
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,9 +104,9 @@ public final class WebsocketRouteTransport extends BaseWebsocketServerTransport<
     return (in, out) -> {
       DuplexConnection connection = new WebsocketDuplexConnection((Connection) in);
       if (mtu > 0) {
-        connection = new FragmentationDuplexConnection(connection, mtu, false, "server");
+        connection = new FragmentationDuplexConnection(connection, mtu, "server");
       } else {
-        connection = new ReassemblyDuplexConnection(connection, false);
+        connection = new ReassemblyDuplexConnection(connection);
       }
       return acceptor.apply(connection).then(out.neverComplete());
     };

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,10 +127,9 @@ public final class WebsocketServerTransport extends BaseWebsocketServerTransport
                         DuplexConnection connection =
                             new WebsocketDuplexConnection((Connection) in);
                         if (mtu > 0) {
-                          connection =
-                              new FragmentationDuplexConnection(connection, mtu, false, "server");
+                          connection = new FragmentationDuplexConnection(connection, mtu, "server");
                         } else {
-                          connection = new ReassemblyDuplexConnection(connection, false);
+                          connection = new ReassemblyDuplexConnection(connection);
                         }
                         return acceptor.apply(connection).then(out.neverComplete());
                       },

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
@@ -18,9 +18,6 @@ package io.rsocket.transport.netty.server;
 
 import static io.rsocket.frame.FrameLengthCodec.FRAME_LENGTH_MASK;
 
-import io.rsocket.DuplexConnection;
-import io.rsocket.fragmentation.FragmentationDuplexConnection;
-import io.rsocket.fragmentation.ReassemblyDuplexConnection;
 import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.ServerTransport;
 import io.rsocket.transport.TransportHeaderAware;
@@ -74,7 +71,6 @@ public final class WebsocketServerTransport extends BaseWebsocketServerTransport
    */
   public static WebsocketServerTransport create(String bindAddress, int port) {
     Objects.requireNonNull(bindAddress, "bindAddress must not be null");
-
     HttpServer httpServer = HttpServer.create().host(bindAddress).port(port);
     return create(httpServer);
   }
@@ -88,7 +84,6 @@ public final class WebsocketServerTransport extends BaseWebsocketServerTransport
    */
   public static WebsocketServerTransport create(InetSocketAddress address) {
     Objects.requireNonNull(address, "address must not be null");
-
     return create(address.getHostName(), address.getPort());
   }
 
@@ -101,7 +96,6 @@ public final class WebsocketServerTransport extends BaseWebsocketServerTransport
    */
   public static WebsocketServerTransport create(final HttpServer server) {
     Objects.requireNonNull(server, "server must not be null");
-
     return new WebsocketServerTransport(server);
   }
 
@@ -112,32 +106,20 @@ public final class WebsocketServerTransport extends BaseWebsocketServerTransport
   }
 
   @Override
-  public Mono<CloseableChannel> start(ConnectionAcceptor acceptor, int mtu) {
+  public Mono<CloseableChannel> start(ConnectionAcceptor acceptor) {
     Objects.requireNonNull(acceptor, "acceptor must not be null");
-
-    Mono<CloseableChannel> isError = FragmentationDuplexConnection.checkMtu(mtu);
-    return isError != null
-        ? isError
-        : server
-            .handle(
-                (request, response) -> {
-                  transportHeaders.get().forEach(response::addHeader);
-                  return response.sendWebsocket(
-                      (in, out) -> {
-                        DuplexConnection connection =
-                            new WebsocketDuplexConnection((Connection) in);
-                        if (mtu > 0) {
-                          connection = new FragmentationDuplexConnection(connection, mtu, "server");
-                        } else {
-                          connection = new ReassemblyDuplexConnection(connection);
-                        }
-                        return acceptor.apply(connection).then(out.neverComplete());
-                      },
-                      WebsocketServerSpec.builder()
-                          .maxFramePayloadLength(FRAME_LENGTH_MASK)
-                          .build());
-                })
-            .bind()
-            .map(CloseableChannel::new);
+    return server
+        .handle(
+            (request, response) -> {
+              transportHeaders.get().forEach(response::addHeader);
+              return response.sendWebsocket(
+                  (in, out) ->
+                      acceptor
+                          .apply(new WebsocketDuplexConnection((Connection) in))
+                          .then(out.neverComplete()),
+                  WebsocketServerSpec.builder().maxFramePayloadLength(FRAME_LENGTH_MASK).build());
+            })
+        .bind()
+        .map(CloseableChannel::new);
   }
 }

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/client/TcpClientTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/client/TcpClientTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ final class TcpClientTransportTest {
     TcpServerTransport serverTransport = TcpServerTransport.create(address);
 
     serverTransport
-        .start(duplexConnection -> Mono.empty(), 0)
-        .flatMap(context -> TcpClientTransport.create(context.address()).connect(0))
+        .start(duplexConnection -> Mono.empty())
+        .flatMap(context -> TcpClientTransport.create(context.address()).connect())
         .as(StepVerifier::create)
         .expectNextCount(1)
         .verifyComplete();
@@ -47,7 +47,7 @@ final class TcpClientTransportTest {
   @DisplayName("create generates error if server not started")
   @Test
   void connectNoServer() {
-    TcpClientTransport.create(8000).connect(0).as(StepVerifier::create).verifyError();
+    TcpClientTransport.create(8000).connect().as(StepVerifier::create).verifyError();
   }
 
   @DisplayName("creates client with BindAddress")

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/TcpServerTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/TcpServerTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ final class TcpServerTransportTest {
     TcpServerTransport serverTransport = TcpServerTransport.create(address);
 
     serverTransport
-        .start(duplexConnection -> Mono.empty(), 0)
+        .start(duplexConnection -> Mono.empty())
         .as(StepVerifier::create)
         .expectNextCount(1)
         .verifyComplete();
@@ -97,7 +97,7 @@ final class TcpServerTransportTest {
   @Test
   void startNullAcceptor() {
     assertThatNullPointerException()
-        .isThrownBy(() -> TcpServerTransport.create("localhost", 8000).start(null, 0))
+        .isThrownBy(() -> TcpServerTransport.create("localhost", 8000).start(null))
         .withMessage("acceptor must not be null");
   }
 }

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketRouteTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketRouteTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ final class WebsocketRouteTransportTest {
         new WebsocketRouteTransport(HttpServer.create(), routes -> {}, "/test-path");
 
     serverTransport
-        .start(duplexConnection -> Mono.empty(), 0)
+        .start(duplexConnection -> Mono.empty())
         .as(StepVerifier::create)
         .expectNextCount(1)
         .verifyComplete();
@@ -76,7 +76,7 @@ final class WebsocketRouteTransportTest {
         .isThrownBy(
             () ->
                 new WebsocketRouteTransport(HttpServer.create(), routes -> {}, "/test-path")
-                    .start(null, 0))
+                    .start(null))
         .withMessage("acceptor must not be null");
   }
 }

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/server/WebsocketServerTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,50 +44,7 @@ final class WebsocketServerTransportTest {
 
     WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
 
-    serverTransport.start(c -> Mono.empty(), 0).subscribe();
-
-    HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
-    HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
-
-    captor.getValue().apply(httpServerRequest, httpServerResponse);
-
-    Mockito.verify(httpServerResponse)
-        .sendWebsocket(
-            Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
-  }
-
-  // @Test
-  public void testThatSetupWithSpecifiedFrameSizeButLowerThanWsDefaultShouldSetToWsDefault() {
-    ArgumentCaptor<BiFunction> captor = ArgumentCaptor.forClass(BiFunction.class);
-    HttpServer httpServer = Mockito.spy(HttpServer.create());
-    Mockito.doAnswer(a -> httpServer).when(httpServer).handle(captor.capture());
-    Mockito.doAnswer(a -> Mono.empty()).when(httpServer).bind();
-
-    WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
-
-    serverTransport.start(c -> Mono.empty(), 1000).subscribe();
-
-    HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
-    HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
-
-    captor.getValue().apply(httpServerRequest, httpServerResponse);
-
-    Mockito.verify(httpServerResponse)
-        .sendWebsocket(
-            Mockito.nullable(String.class), Mockito.eq(FRAME_LENGTH_MASK), Mockito.any());
-  }
-
-  // @Test
-  public void
-      testThatSetupWithSpecifiedFrameSizeButHigherThanWsDefaultShouldSetToSpecifiedFrameSize() {
-    ArgumentCaptor<BiFunction> captor = ArgumentCaptor.forClass(BiFunction.class);
-    HttpServer httpServer = Mockito.spy(HttpServer.create());
-    Mockito.doAnswer(a -> httpServer).when(httpServer).handle(captor.capture());
-    Mockito.doAnswer(a -> Mono.empty()).when(httpServer).bind();
-
-    WebsocketServerTransport serverTransport = WebsocketServerTransport.create(httpServer);
-
-    serverTransport.start(c -> Mono.empty(), 65536 + 1000).subscribe();
+    serverTransport.start(c -> Mono.empty()).subscribe();
 
     HttpServerRequest httpServerRequest = Mockito.mock(HttpServerRequest.class);
     HttpServerResponse httpServerResponse = Mockito.mock(HttpServerResponse.class);
@@ -172,7 +129,7 @@ final class WebsocketServerTransportTest {
     WebsocketServerTransport serverTransport = WebsocketServerTransport.create(address);
 
     serverTransport
-        .start(duplexConnection -> Mono.empty(), 0)
+        .start(duplexConnection -> Mono.empty())
         .as(StepVerifier::create)
         .expectNextCount(1)
         .verifyComplete();
@@ -182,7 +139,7 @@ final class WebsocketServerTransportTest {
   @Test
   void startNullAcceptor() {
     assertThatNullPointerException()
-        .isThrownBy(() -> WebsocketServerTransport.create(8000).start(null, 0))
+        .isThrownBy(() -> WebsocketServerTransport.create(8000).start(null))
         .withMessage("acceptor must not be null");
   }
 }


### PR DESCRIPTION
In b15a1fccae8a482dbf1a7e0d5cbdb538785b7e5e transports started applying ` FragmentationDuplexConnection`. This was probably done so that TCP transports can give up control of dealing with the frame length to the fragmentation layer. However on closer look there is no obvious reason to not leave the frame length to transports to deal with.

The two commits here restore fragmentation being applied from a single place and make transports unaware of that logic eliminating duplication in the process.
