### PR TITLE
fixes ReconnectMono behaviour when racing invalidate and subscribe #847

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/ReconnectMono.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ReconnectMono.java
@@ -439,7 +439,7 @@ final class ReconnectMono<T> extends Mono<T> implements Invalidatable, Disposabl
       }
 
       if (value == null) {
-        p.terminate(new IllegalStateException("Unexpected empty source"));
+        p.terminate(new IllegalStateException("Source completed empty"));
       } else {
         p.complete();
       }

--- a/rsocket-core/src/main/java/io/rsocket/core/ReconnectMono.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ReconnectMono.java
@@ -401,9 +401,9 @@ final class ReconnectMono<T> extends Mono<T> implements Invalidatable, Disposabl
   }
 
   /**
-   * Subscriber that subscribes to the source {@link Mono} in order to resolve value. <br>
-   * Note, implementation of this subscribers exclude possibility to receive onComplete only and if
-   * such happens, terminates execution with an error
+   * Subscriber that subscribes to the source {@link Mono} to receive its value. <br>
+   * Note that the source is not expected to complete empty, and if this happens,
+   * execution will terminate with an {@code IllegalStateException}.
    */
   static final class ReconnectMainSubscriber<T> implements CoreSubscriber<T> {
 

--- a/rsocket-core/src/main/java/io/rsocket/core/ReconnectMono.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ReconnectMono.java
@@ -402,8 +402,8 @@ final class ReconnectMono<T> extends Mono<T> implements Invalidatable, Disposabl
 
   /**
    * Subscriber that subscribes to the source {@link Mono} to receive its value. <br>
-   * Note that the source is not expected to complete empty, and if this happens,
-   * execution will terminate with an {@code IllegalStateException}.
+   * Note that the source is not expected to complete empty, and if this happens, execution will
+   * terminate with an {@code IllegalStateException}.
    */
   static final class ReconnectMainSubscriber<T> implements CoreSubscriber<T> {
 

--- a/rsocket-core/src/test/java/io/rsocket/core/ReconnectMonoTests.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/ReconnectMonoTests.java
@@ -494,7 +494,7 @@ public class ReconnectMonoTests {
       } else {
         Assertions.assertThat(error)
             .isInstanceOf(IllegalStateException.class)
-            .hasMessage("Unexpected empty source");
+            .hasMessage("Source completed empty");
       }
 
       Assertions.assertThat(expired).isEmpty();
@@ -1023,7 +1023,7 @@ public class ReconnectMonoTests {
         .expectErrorSatisfies(
             t ->
                 Assertions.assertThat(t)
-                    .hasMessage("Unexpected empty source")
+                    .hasMessage("Source completed empty")
                     .isInstanceOf(IllegalStateException.class))
         .verify(Duration.ofSeconds(timeout));
   }


### PR DESCRIPTION
Found that there is a bug in ReconnectMono when it appears that `Reconnect#invalidate` is raced with `Reconnect#subscribe` method which is possible when e.g.

```
Mono<RSocket> rsocketMono =
  RSocketConnector.create()
        .reconnect(Retry.fixedDelay(3, Duration.ofSeconds(1)))
        .connect(transport)
        .flatMap(rSocket -> {
            return rsocket.requestStream(...);
        })
        .retryWhen(Retry.backoff(10000, Duration.ofMillis(1)))
        .subscribe();
```

subscriber retried, subscribed, resolved connection while the thread that invalidating RSocket has executed CAS operation and in the process of setting `this.value = null`.

In general, including a few more omitted cases, there can be 3 outcomes

1. The subscriber that observed state `RSocket is READY` can observe the actual value as null because of racing with invalidate
2. The subscriber may observe state e.g `INVALIDATED and need to subscribe to the source again`, hence subscribe to source, but racing between resolving value and invalidation may end up with null value after all 
3. Everything can be fine

All tests expose those case and fix is pretty straightforward

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>