### PR TITLE
ensures lease is used exactly on request frame sending

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -230,6 +230,7 @@ class RSocketRequester implements RSocket {
 
               RequesterLeaseHandler lh = leaseHandler;
               if (!lh.useLease()) {
+                payload.release();
                 return Mono.error(lh.leaseError());
               }
 
@@ -290,6 +291,7 @@ class RSocketRequester implements RSocket {
 
                               RequesterLeaseHandler lh = leaseHandler;
                               if (!lh.useLease()) {
+                                payload.release();
                                 receiver.onError(lh.leaseError());
                                 return;
                               }
@@ -368,6 +370,7 @@ class RSocketRequester implements RSocket {
 
                               RequesterLeaseHandler lh = leaseHandler;
                               if (!lh.useLease()) {
+                                payload.release();
                                 receiver.onError(lh.leaseError());
                                 return;
                               }
@@ -524,6 +527,7 @@ class RSocketRequester implements RSocket {
 
                         RequesterLeaseHandler lh = leaseHandler;
                         if (!lh.useLease()) {
+                          initialPayload.release();
                           receiver.onError(lh.leaseError());
                           return;
                         }

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketLeaseTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketLeaseTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.when;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCounted;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.TestScheduler;
@@ -33,6 +35,7 @@ import io.rsocket.exceptions.Exceptions;
 import io.rsocket.frame.FrameHeaderCodec;
 import io.rsocket.frame.FrameType;
 import io.rsocket.frame.LeaseFrameCodec;
+import io.rsocket.frame.PayloadFrameCodec;
 import io.rsocket.frame.SetupFrameCodec;
 import io.rsocket.frame.decoder.PayloadDecoder;
 import io.rsocket.internal.ClientServerInputMultiplexer;
@@ -43,6 +46,7 @@ import io.rsocket.plugins.InitializingInterceptorRegistry;
 import io.rsocket.test.util.TestClientTransport;
 import io.rsocket.test.util.TestDuplexConnection;
 import io.rsocket.test.util.TestServerTransport;
+import io.rsocket.util.ByteBufPayload;
 import io.rsocket.util.DefaultPayload;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -50,7 +54,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +62,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
@@ -69,9 +74,10 @@ class RSocketLeaseTest {
 
   private RSocket rSocketRequester;
   private ResponderLeaseHandler responderLeaseHandler;
-  private ByteBufAllocator byteBufAllocator;
+  private LeaksTrackingByteBufAllocator byteBufAllocator;
   private TestDuplexConnection connection;
   private RSocketResponder rSocketResponder;
+  private RSocket mockRSocketHandler;
 
   private EmitterProcessor<Lease> leaseSender = EmitterProcessor.create();
   private Flux<Lease> leaseReceiver;
@@ -102,12 +108,43 @@ class RSocketLeaseTest {
             requesterLeaseHandler,
             TestScheduler.INSTANCE);
 
-    RSocket mockRSocketHandler = mock(RSocket.class);
-    when(mockRSocketHandler.metadataPush(any())).thenReturn(Mono.empty());
-    when(mockRSocketHandler.fireAndForget(any())).thenReturn(Mono.empty());
-    when(mockRSocketHandler.requestResponse(any())).thenReturn(Mono.empty());
-    when(mockRSocketHandler.requestStream(any())).thenReturn(Flux.empty());
-    when(mockRSocketHandler.requestChannel(any())).thenReturn(Flux.empty());
+    mockRSocketHandler = mock(RSocket.class);
+    when(mockRSocketHandler.metadataPush(any()))
+        .then(
+            a -> {
+              Payload payload = a.getArgument(0);
+              payload.release();
+              return Mono.empty();
+            });
+    when(mockRSocketHandler.fireAndForget(any()))
+        .then(
+            a -> {
+              Payload payload = a.getArgument(0);
+              payload.release();
+              return Mono.empty();
+            });
+    when(mockRSocketHandler.requestResponse(any()))
+        .then(
+            a -> {
+              Payload payload = a.getArgument(0);
+              payload.release();
+              return Mono.empty();
+            });
+    when(mockRSocketHandler.requestStream(any()))
+        .then(
+            a -> {
+              Payload payload = a.getArgument(0);
+              payload.release();
+              return Flux.empty();
+            });
+    when(mockRSocketHandler.requestChannel(any()))
+        .then(
+            a -> {
+              Publisher<Payload> payloadPublisher = a.getArgument(0);
+              return Flux.from(payloadPublisher)
+                  .doOnNext(ReferenceCounted::release)
+                  .thenMany(Flux.empty());
+            });
 
     rSocketResponder =
         new RSocketResponder(
@@ -159,38 +196,67 @@ class RSocketLeaseTest {
 
   @ParameterizedTest
   @MethodSource("interactions")
-  void requesterMissingLeaseRequestsAreRejected(Function<RSocket, Publisher<?>> interaction) {
+  void requesterMissingLeaseRequestsAreRejected(
+      BiFunction<RSocket, Payload, Publisher<?>> interaction) {
     Assertions.assertThat(rSocketRequester.availability()).isCloseTo(0.0, offset(1e-2));
-
-    StepVerifier.create(interaction.apply(rSocketRequester))
+    ByteBuf buffer = byteBufAllocator.buffer();
+    buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload1 = ByteBufPayload.create(buffer);
+    StepVerifier.create(interaction.apply(rSocketRequester, payload1))
         .expectError(MissingLeaseException.class)
         .verify(Duration.ofSeconds(5));
+
+    byteBufAllocator.assertHasNoLeaks();
   }
 
   @ParameterizedTest
   @MethodSource("interactions")
-  void requesterPresentLeaseRequestsAreAccepted(Function<RSocket, Publisher<?>> interaction) {
-    requesterLeaseHandler.receive(leaseFrame(5_000, 2, Unpooled.EMPTY_BUFFER));
+  void requesterPresentLeaseRequestsAreAccepted(
+      BiFunction<RSocket, Payload, Publisher<?>> interaction, FrameType frameType) {
+    ByteBuf frame = leaseFrame(5_000, 2, Unpooled.EMPTY_BUFFER);
+    requesterLeaseHandler.receive(frame);
 
     Assertions.assertThat(rSocketRequester.availability()).isCloseTo(1.0, offset(1e-2));
-
-    Flux.from(interaction.apply(rSocketRequester))
-        .take(Duration.ofMillis(500))
+    ByteBuf buffer = byteBufAllocator.buffer();
+    buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload1 = ByteBufPayload.create(buffer);
+    Flux.from(interaction.apply(rSocketRequester, payload1))
         .as(StepVerifier::create)
+        .then(
+            () -> {
+              if (frameType != REQUEST_FNF) {
+                connection.addToReceivedBuffer(
+                    PayloadFrameCodec.encodeComplete(byteBufAllocator, 1));
+              }
+            })
         .expectComplete()
         .verify(Duration.ofSeconds(5));
+
+    Assertions.assertThat(connection.getSent())
+        .hasSize(1)
+        .first()
+        .matches(ReferenceCounted::release);
+
     Assertions.assertThat(rSocketRequester.availability()).isCloseTo(0.5, offset(1e-2));
+
+    Assertions.assertThat(frame.release()).isTrue();
+
+    byteBufAllocator.assertHasNoLeaks();
   }
 
   @ParameterizedTest
   @MethodSource("interactions")
   @SuppressWarnings({"rawtypes", "unchecked"})
   void requesterDepletedAllowedLeaseRequestsAreRejected(
-      Function<RSocket, Publisher<?>> interaction, FrameType interactionType) {
-    requesterLeaseHandler.receive(leaseFrame(5_000, 1, Unpooled.EMPTY_BUFFER));
+      BiFunction<RSocket, Payload, Publisher<?>> interaction, FrameType interactionType) {
+    ByteBuf buffer = byteBufAllocator.buffer();
+    buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload1 = ByteBufPayload.create(buffer);
+    ByteBuf leaseFrame = leaseFrame(5_000, 1, Unpooled.EMPTY_BUFFER);
+    requesterLeaseHandler.receive(leaseFrame);
 
     double initialAvailability = requesterLeaseHandler.availability();
-    Publisher<?> request = interaction.apply(rSocketRequester);
+    Publisher<?> request = interaction.apply(rSocketRequester, payload1);
 
     // ensures that lease is not used until the frame is sent
     Assertions.assertThat(initialAvailability).isEqualTo(requesterLeaseHandler.availability());
@@ -213,24 +279,42 @@ class RSocketLeaseTest {
     Assertions.assertThat(connection.getSent())
         .hasSize(1)
         .first()
-        .matches(bb -> FrameHeaderCodec.frameType(bb) == interactionType);
+        .matches(bb -> FrameHeaderCodec.frameType(bb) == interactionType)
+        .matches(ReferenceCounted::release);
 
-    Flux.from(interaction.apply(rSocketRequester))
+    ByteBuf buffer2 = byteBufAllocator.buffer();
+    buffer2.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload2 = ByteBufPayload.create(buffer2);
+    Flux.from(interaction.apply(rSocketRequester, payload2))
         .as(StepVerifier::create)
         .expectError(MissingLeaseException.class)
         .verify(Duration.ofSeconds(5));
+
+    Assertions.assertThat(leaseFrame.release()).isTrue();
+
+    byteBufAllocator.assertHasNoLeaks();
   }
 
   @ParameterizedTest
   @MethodSource("interactions")
-  void requesterExpiredLeaseRequestsAreRejected(Function<RSocket, Publisher<?>> interaction) {
-    requesterLeaseHandler.receive(leaseFrame(50, 1, Unpooled.EMPTY_BUFFER));
+  void requesterExpiredLeaseRequestsAreRejected(
+      BiFunction<RSocket, Payload, Publisher<?>> interaction) {
+    ByteBuf frame = leaseFrame(50, 1, Unpooled.EMPTY_BUFFER);
+    requesterLeaseHandler.receive(frame);
 
-    Flux.defer(() -> interaction.apply(rSocketRequester))
+    ByteBuf buffer = byteBufAllocator.buffer();
+    buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload1 = ByteBufPayload.create(buffer);
+
+    Flux.defer(() -> interaction.apply(rSocketRequester, payload1))
         .delaySubscription(Duration.ofMillis(200))
         .as(StepVerifier::create)
         .expectError(MissingLeaseException.class)
         .verify(Duration.ofSeconds(5));
+
+    Assertions.assertThat(frame.release()).isTrue();
+
+    byteBufAllocator.assertHasNoLeaks();
   }
 
   @Test
@@ -243,33 +327,80 @@ class RSocketLeaseTest {
 
   @ParameterizedTest
   @MethodSource("interactions")
-  void responderMissingLeaseRequestsAreRejected(Function<RSocket, Publisher<?>> interaction) {
-    StepVerifier.create(interaction.apply(rSocketResponder))
+  void responderMissingLeaseRequestsAreRejected(
+      BiFunction<RSocket, Payload, Publisher<?>> interaction) {
+    ByteBuf buffer = byteBufAllocator.buffer();
+    buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload1 = ByteBufPayload.create(buffer);
+
+    StepVerifier.create(interaction.apply(rSocketResponder, payload1))
         .expectError(MissingLeaseException.class)
         .verify(Duration.ofSeconds(5));
   }
 
   @ParameterizedTest
   @MethodSource("interactions")
-  void responderPresentLeaseRequestsAreAccepted(Function<RSocket, Publisher<?>> interaction) {
+  void responderPresentLeaseRequestsAreAccepted(
+      BiFunction<RSocket, Payload, Publisher<?>> interaction, FrameType frameType) {
     leaseSender.onNext(Lease.create(5_000, 2));
 
-    Flux.from(interaction.apply(rSocketResponder))
-        .take(Duration.ofMillis(500))
+    ByteBuf buffer = byteBufAllocator.buffer();
+    buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload1 = ByteBufPayload.create(buffer);
+
+    Flux.from(interaction.apply(rSocketResponder, payload1))
         .as(StepVerifier::create)
         .expectComplete()
         .verify(Duration.ofSeconds(5));
+
+    switch (frameType) {
+      case REQUEST_FNF:
+        Mockito.verify(mockRSocketHandler).fireAndForget(any());
+        break;
+      case REQUEST_RESPONSE:
+        Mockito.verify(mockRSocketHandler).requestResponse(any());
+        break;
+      case REQUEST_STREAM:
+        Mockito.verify(mockRSocketHandler).requestStream(any());
+        break;
+      case REQUEST_CHANNEL:
+        Mockito.verify(mockRSocketHandler).requestChannel(any());
+        break;
+    }
+
+    Assertions.assertThat(connection.getSent())
+        .hasSize(1)
+        .first()
+        .matches(bb -> FrameHeaderCodec.frameType(bb) == LEASE)
+        .matches(ReferenceCounted::release);
+
+    byteBufAllocator.assertHasNoLeaks();
   }
 
   @ParameterizedTest
   @MethodSource("interactions")
   void responderDepletedAllowedLeaseRequestsAreRejected(
-      Function<RSocket, Publisher<?>> interaction) {
+      BiFunction<RSocket, Payload, Publisher<?>> interaction) {
     leaseSender.onNext(Lease.create(5_000, 1));
 
-    Flux<?> responder = Flux.from(interaction.apply(rSocketResponder));
+    ByteBuf buffer = byteBufAllocator.buffer();
+    buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload1 = ByteBufPayload.create(buffer);
+
+    Flux<?> responder = Flux.from(interaction.apply(rSocketResponder, payload1));
     responder.subscribe();
-    Flux.from(interaction.apply(rSocketResponder))
+
+    Assertions.assertThat(connection.getSent())
+        .hasSize(1)
+        .first()
+        .matches(bb -> FrameHeaderCodec.frameType(bb) == LEASE)
+        .matches(ReferenceCounted::release);
+
+    ByteBuf buffer2 = byteBufAllocator.buffer();
+    buffer2.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload2 = ByteBufPayload.create(buffer2);
+
+    Flux.from(interaction.apply(rSocketResponder, payload2))
         .as(StepVerifier::create)
         .expectError(MissingLeaseException.class)
         .verify(Duration.ofSeconds(5));
@@ -277,14 +408,26 @@ class RSocketLeaseTest {
 
   @ParameterizedTest
   @MethodSource("interactions")
-  void expiredLeaseRequestsAreRejected(Function<RSocket, Publisher<?>> interaction) {
+  void expiredLeaseRequestsAreRejected(BiFunction<RSocket, Payload, Publisher<?>> interaction) {
     leaseSender.onNext(Lease.create(50, 1));
 
-    Flux.from(interaction.apply(rSocketRequester))
+    ByteBuf buffer = byteBufAllocator.buffer();
+    buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+    Payload payload1 = ByteBufPayload.create(buffer);
+
+    Flux.from(interaction.apply(rSocketRequester, payload1))
         .delaySubscription(Duration.ofMillis(100))
         .as(StepVerifier::create)
         .expectError(MissingLeaseException.class)
         .verify(Duration.ofSeconds(5));
+
+    Assertions.assertThat(connection.getSent())
+        .hasSize(1)
+        .first()
+        .matches(bb -> FrameHeaderCodec.frameType(bb) == LEASE)
+        .matches(ReferenceCounted::release);
+
+    byteBufAllocator.assertHasNoLeaks();
   }
 
   @Test
@@ -341,20 +484,17 @@ class RSocketLeaseTest {
   static Stream<Arguments> interactions() {
     return Stream.of(
         Arguments.of(
-            (Function<RSocket, Publisher<?>>)
-                rSocket -> rSocket.fireAndForget(DefaultPayload.create("test")),
+            (BiFunction<RSocket, Payload, Publisher<?>>) RSocket::fireAndForget,
             FrameType.REQUEST_FNF),
         Arguments.of(
-            (Function<RSocket, Publisher<?>>)
-                rSocket -> rSocket.requestResponse(DefaultPayload.create("test")),
+            (BiFunction<RSocket, Payload, Publisher<?>>) RSocket::requestResponse,
             FrameType.REQUEST_RESPONSE),
         Arguments.of(
-            (Function<RSocket, Publisher<?>>)
-                rSocket -> rSocket.requestStream(DefaultPayload.create("test")),
+            (BiFunction<RSocket, Payload, Publisher<?>>) RSocket::requestStream,
             FrameType.REQUEST_STREAM),
         Arguments.of(
-            (Function<RSocket, Publisher<?>>)
-                rSocket -> rSocket.requestChannel(Mono.just(DefaultPayload.create("test"))),
+            (BiFunction<RSocket, Payload, Publisher<?>>)
+                (rSocket, payload) -> rSocket.requestChannel(Mono.just(payload)),
             FrameType.REQUEST_CHANNEL));
   }
 }


### PR DESCRIPTION
This PR ensures that lease is used right before when the actual request frame is being sent.

That said that right now lease is used even though the `Publisher` given as the result of the `requestXXX` method execution is not subscribed (which of course may break lease counting on the client- vs server-side)

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>