### PR TITLE
Add option to provide Mono<Payload> for the SETUP payload

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -47,6 +47,7 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.annotation.Nullable;
+import reactor.util.function.Tuples;
 import reactor.util.retry.Retry;
 
 /**
@@ -77,7 +78,7 @@ public class RSocketConnector {
   private static final BiConsumer<RSocket, Invalidatable> INVALIDATE_FUNCTION =
       (r, i) -> r.onClose().subscribe(null, __ -> i.invalidate(), i::invalidate);
 
-  private Payload setupPayload = EmptyPayload.INSTANCE;
+  private Mono<Payload> setupPayloadMono = Mono.empty();
   private String metadataMimeType = "application/binary";
   private String dataMimeType = "application/binary";
   private Duration keepAliveInterval = Duration.ofSeconds(20);
@@ -118,22 +119,38 @@ public class RSocketConnector {
   }
 
   /**
-   * Provide a {@code Payload} with data and/or metadata for the initial {@code SETUP} frame. Data
-   * and metadata should be formatted according to the MIME types specified via {@link
+   * Provide a {@code Mono} from which to obtain the {@code Payload} for the initial SETUP frame.
+   * Data and metadata should be formatted according to the MIME types specified via {@link
    * #dataMimeType(String)} and {@link #metadataMimeType(String)}.
    *
-   * @param payload the payload containing data and/or metadata for the {@code SETUP} frame. Note,
-   *     if the instance of the given payload is not a {@link DefaultPayload}, its content will be
-   *     copied
+   * @param setupPayloadMono the payload with data and/or metadata for the {@code SETUP} frame.
+   * @return the same instance for method chaining
+   * @since 1.0.2
+   * @see <a href="https://github.com/rsocket/rsocket/blob/master/Protocol.md#frame-setup">SETUP
+   *     Frame</a>
+   */
+  public RSocketConnector setupPayload(Mono<Payload> setupPayloadMono) {
+    this.setupPayloadMono = setupPayloadMono;
+    return this;
+  }
+
+  /**
+   * Variant of {@link #setupPayload(Mono)} that accepts a {@code Payload} instance.
+   *
+   * <p>Note: if the given payload is {@link io.rsocket.util.ByteBufPayload}, it is copied to a
+   * {@link DefaultPayload} and released immediately. This ensures it can re-used to obtain a
+   * connection more than once.
+   *
+   * @param payload the payload with data and/or metadata for the {@code SETUP} frame.
    * @return the same instance for method chaining
    * @see <a href="https://github.com/rsocket/rsocket/blob/master/Protocol.md#frame-setup">SETUP
    *     Frame</a>
    */
   public RSocketConnector setupPayload(Payload payload) {
     if (payload instanceof DefaultPayload) {
-      this.setupPayload = payload;
+      this.setupPayloadMono = Mono.just(payload);
     } else {
-      this.setupPayload = DefaultPayload.create(Objects.requireNonNull(payload));
+      this.setupPayloadMono = Mono.just(DefaultPayload.create(Objects.requireNonNull(payload)));
       payload.release();
     }
     return this;
@@ -479,9 +496,20 @@ public class RSocketConnector {
                     mtu > 0
                         ? new FragmentationDuplexConnection(connection, mtu, "client")
                         : new ReassemblyDuplexConnection(connection));
+
     return connectionMono
         .flatMap(
-            connection -> {
+            connection ->
+                setupPayloadMono
+                    .defaultIfEmpty(EmptyPayload.INSTANCE)
+                    .map(setupPayload -> Tuples.of(connection, setupPayload))
+                    .doOnError(ex -> connection.dispose())
+                    .doOnCancel(connection::dispose))
+        .flatMap(
+            tuple -> {
+              DuplexConnection connection = tuple.getT1();
+              Payload setupPayload = tuple.getT2();
+
               ByteBuf resumeToken;
               KeepAliveHandler keepAliveHandler;
               DuplexConnection wrappedConnection;


### PR DESCRIPTION
Currently `RSocketConnector` expects a `Payload` instance for the SETUP frame. However, if the input is from a higher level object, it may be serialized to `Mono<Payload>`. So that needs to be resolved first, then the `setupPayload` can be set on `RSocketConnector`, and only then can `connect` be called. This makes it difficult to avoid re-creating the `Mono<RSocket>` from the connect method per subscriber, which in turn precludes use of the reconnect feature.

This change adds an extra option on `RSocketConnector` to accept a `Mono<Payload>`.