### PR TITLE
improves ref-counting by eliminating redundant retain/release

### DIFF
--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterSubscribersTest.java
@@ -82,7 +82,7 @@ class RSocketRequesterSubscribersTest {
 
   @ParameterizedTest
   @MethodSource("allInteractions")
-  void singleSubscriber(Function<RSocket, Publisher<?>> interaction) {
+  void singleSubscriber(Function<RSocket, Publisher<?>> interaction, FrameType requestType) {
     Flux<?> response = Flux.from(interaction.apply(rSocketRequester));
 
     AssertSubscriber assertSubscriberA = AssertSubscriber.create();
@@ -91,7 +91,9 @@ class RSocketRequesterSubscribersTest {
     response.subscribe(assertSubscriberA);
     response.subscribe(assertSubscriberB);
 
-    connection.addToReceivedBuffer(PayloadFrameCodec.encodeComplete(connection.alloc(), 1));
+    if (requestType != FrameType.REQUEST_FNF && requestType != FrameType.METADATA_PUSH) {
+      connection.addToReceivedBuffer(PayloadFrameCodec.encodeComplete(connection.alloc(), 1));
+    }
 
     assertSubscriberA.assertTerminated();
     assertSubscriberB.assertTerminated();
@@ -111,7 +113,9 @@ class RSocketRequesterSubscribersTest {
       RaceTestUtils.race(
           () -> response.subscribe(assertSubscriberA), () -> response.subscribe(assertSubscriberB));
 
-      connection.addToReceivedBuffer(PayloadFrameCodec.encodeComplete(connection.alloc(), i));
+      if (requestType != FrameType.REQUEST_FNF && requestType != FrameType.METADATA_PUSH) {
+        connection.addToReceivedBuffer(PayloadFrameCodec.encodeComplete(connection.alloc(), i));
+      }
 
       assertSubscriberA.assertTerminated();
       assertSubscriberB.assertTerminated();

--- a/rsocket-core/src/test/java/io/rsocket/internal/ClientServerInputMultiplexerTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/ClientServerInputMultiplexerTest.java
@@ -68,52 +68,52 @@ public class ClientServerInputMultiplexerTest {
         .doOnNext(f -> setupFrames.incrementAndGet())
         .subscribe();
 
-    source.addToReceivedBuffer(errorFrame(1));
+    source.addToReceivedBuffer(errorFrame(1).retain());
     assertEquals(1, clientFrames.get());
     assertEquals(0, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(errorFrame(1));
+    source.addToReceivedBuffer(errorFrame(1).retain());
     assertEquals(2, clientFrames.get());
     assertEquals(0, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(leaseFrame());
+    source.addToReceivedBuffer(leaseFrame().retain());
     assertEquals(3, clientFrames.get());
     assertEquals(0, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(keepAliveFrame());
+    source.addToReceivedBuffer(keepAliveFrame().retain());
     assertEquals(4, clientFrames.get());
     assertEquals(0, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(errorFrame(2));
+    source.addToReceivedBuffer(errorFrame(2).retain());
     assertEquals(4, clientFrames.get());
     assertEquals(1, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(errorFrame(0));
+    source.addToReceivedBuffer(errorFrame(0).retain());
     assertEquals(5, clientFrames.get());
     assertEquals(1, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(metadataPushFrame());
+    source.addToReceivedBuffer(metadataPushFrame().retain());
     assertEquals(5, clientFrames.get());
     assertEquals(2, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(setupFrame());
+    source.addToReceivedBuffer(setupFrame().retain());
     assertEquals(5, clientFrames.get());
     assertEquals(2, serverFrames.get());
     assertEquals(1, setupFrames.get());
 
-    source.addToReceivedBuffer(resumeFrame());
+    source.addToReceivedBuffer(resumeFrame().retain());
     assertEquals(5, clientFrames.get());
     assertEquals(2, serverFrames.get());
     assertEquals(2, setupFrames.get());
 
-    source.addToReceivedBuffer(resumeOkFrame());
+    source.addToReceivedBuffer(resumeOkFrame().retain());
     assertEquals(5, clientFrames.get());
     assertEquals(2, serverFrames.get());
     assertEquals(3, setupFrames.get());
@@ -141,52 +141,52 @@ public class ClientServerInputMultiplexerTest {
         .doOnNext(f -> setupFrames.incrementAndGet())
         .subscribe();
 
-    source.addToReceivedBuffer(errorFrame(1));
+    source.addToReceivedBuffer(errorFrame(1).retain());
     assertEquals(1, clientFrames.get());
     assertEquals(0, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(errorFrame(1));
+    source.addToReceivedBuffer(errorFrame(1).retain());
     assertEquals(2, clientFrames.get());
     assertEquals(0, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(leaseFrame());
+    source.addToReceivedBuffer(leaseFrame().retain());
     assertEquals(2, clientFrames.get());
     assertEquals(1, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(keepAliveFrame());
+    source.addToReceivedBuffer(keepAliveFrame().retain());
     assertEquals(2, clientFrames.get());
     assertEquals(2, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(errorFrame(2));
+    source.addToReceivedBuffer(errorFrame(2).retain());
     assertEquals(2, clientFrames.get());
     assertEquals(3, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(errorFrame(0));
+    source.addToReceivedBuffer(errorFrame(0).retain());
     assertEquals(2, clientFrames.get());
     assertEquals(4, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(metadataPushFrame());
+    source.addToReceivedBuffer(metadataPushFrame().retain());
     assertEquals(3, clientFrames.get());
     assertEquals(4, serverFrames.get());
     assertEquals(0, setupFrames.get());
 
-    source.addToReceivedBuffer(setupFrame());
+    source.addToReceivedBuffer(setupFrame().retain());
     assertEquals(3, clientFrames.get());
     assertEquals(4, serverFrames.get());
     assertEquals(1, setupFrames.get());
 
-    source.addToReceivedBuffer(resumeFrame());
+    source.addToReceivedBuffer(resumeFrame().retain());
     assertEquals(3, clientFrames.get());
     assertEquals(4, serverFrames.get());
     assertEquals(2, setupFrames.get());
 
-    source.addToReceivedBuffer(resumeOkFrame());
+    source.addToReceivedBuffer(resumeOkFrame().retain());
     assertEquals(3, clientFrames.get());
     assertEquals(4, serverFrames.get());
     assertEquals(3, setupFrames.get());

--- a/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalTransportWithFragmentationTest.java
+++ b/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalTransportWithFragmentationTest.java
@@ -16,11 +16,11 @@
 
 package io.rsocket.transport.local;
 
-import io.rsocket.test.TransportTest;
+import io.rsocket.test.FragmentationTransportTest;
 import java.time.Duration;
 import java.util.UUID;
 
-final class LocalTransportTest implements TransportTest {
+final class LocalTransportWithFragmentationTest implements FragmentationTransportTest {
 
   private final TransportPair transportPair =
       new TransportPair<>(

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
@@ -68,7 +68,7 @@ public final class WebsocketDuplexConnection extends BaseDuplexConnection {
 
   @Override
   public Flux<ByteBuf> receive() {
-    return connection.inbound().receive().map(ByteBuf::retain);
+    return connection.inbound().receive();
   }
 
   @Override


### PR DESCRIPTION
improves ref counting and performance subsequently by eliminating redundant `retain` on the transport level hence we do not need to `release` this frame on the `RSocketRequester`/`RSocketResponder` `handleFrame` level anymore

Fixes all duplex connections to follow that strategy

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>