### PR TITLE
Re-resolve changing dependencies every 60 min

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ subprojects {
         }
     }
 
+    configurations.all {
+        resolutionStrategy.cacheChangingModulesFor 60, "minutes"
+    }
+
     dependencyManagement {
         imports {
             mavenBom "io.projectreactor:reactor-bom:${ext['reactor-bom.version']}"


### PR DESCRIPTION
The Travis CI build is currently relying on old reactor SNAPSHOTs and fails as a result.
This PR reduces the amount of time changing dependencies are cached between builds.