### PR TITLE
reworks multiplexer and improves tests to check async interceptors #909

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/ClientServerInputMultiplexer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ClientServerInputMultiplexer.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.core;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.rsocket.Closeable;
+import io.rsocket.DuplexConnection;
+import io.rsocket.frame.FrameHeaderCodec;
+import io.rsocket.frame.FrameUtil;
+import io.rsocket.plugins.DuplexConnectionInterceptor.Type;
+import io.rsocket.plugins.InitializingInterceptorRegistry;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+
+/**
+ * {@link DuplexConnection#receive()} is a single stream on which the following type of frames
+ * arrive:
+ *
+ * <ul>
+ *   <li>Frames for streams initiated by the initiator of the connection (client).
+ *   <li>Frames for streams initiated by the acceptor of the connection (server).
+ * </ul>
+ *
+ * <p>The only way to differentiate these two frames is determining whether the stream Id is odd or
+ * even. Even IDs are for the streams initiated by server and odds are for streams initiated by the
+ * client.
+ */
+class ClientServerInputMultiplexer implements CoreSubscriber<ByteBuf>, Closeable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger("io.rsocket.FrameLogger");
+  private static final InitializingInterceptorRegistry emptyInterceptorRegistry =
+      new InitializingInterceptorRegistry();
+
+  private final InternalDuplexConnection setupReceiver;
+  private final InternalDuplexConnection serverReceiver;
+  private final InternalDuplexConnection clientReceiver;
+  private final DuplexConnection setupConnection;
+  private final DuplexConnection serverConnection;
+  private final DuplexConnection clientConnection;
+  private final DuplexConnection source;
+  private final boolean isClient;
+
+  private Subscription s;
+  private boolean setupReceived;
+
+  private Throwable t;
+
+  private volatile int state;
+  private static final AtomicIntegerFieldUpdater<ClientServerInputMultiplexer> STATE =
+      AtomicIntegerFieldUpdater.newUpdater(ClientServerInputMultiplexer.class, "state");
+
+  public ClientServerInputMultiplexer(DuplexConnection source) {
+    this(source, emptyInterceptorRegistry, false);
+  }
+
+  public ClientServerInputMultiplexer(
+      DuplexConnection source, InitializingInterceptorRegistry registry, boolean isClient) {
+    this.source = source;
+    this.isClient = isClient;
+    source = registry.initConnection(Type.SOURCE, source);
+
+    if (!isClient) {
+      setupReceiver = new InternalDuplexConnection(this, source);
+      setupConnection = registry.initConnection(Type.SETUP, setupReceiver);
+    } else {
+      setupReceiver = null;
+      setupConnection = null;
+    }
+    serverReceiver = new InternalDuplexConnection(this, source);
+    clientReceiver = new InternalDuplexConnection(this, source);
+    serverConnection = registry.initConnection(Type.SERVER, serverReceiver);
+    clientConnection = registry.initConnection(Type.CLIENT, clientReceiver);
+  }
+
+  public DuplexConnection asClientServerConnection() {
+    return source;
+  }
+
+  public DuplexConnection asServerConnection() {
+    return serverConnection;
+  }
+
+  public DuplexConnection asClientConnection() {
+    return clientConnection;
+  }
+
+  public DuplexConnection asSetupConnection() {
+    return setupConnection;
+  }
+
+  @Override
+  public void dispose() {
+    source.dispose();
+  }
+
+  @Override
+  public boolean isDisposed() {
+    return source.isDisposed();
+  }
+
+  @Override
+  public Mono<Void> onClose() {
+    return source.onClose();
+  }
+
+  @Override
+  public void onSubscribe(Subscription s) {
+    if (Operators.validate(this.s, s)) {
+      this.s = s;
+      if (isClient) {
+        s.request(Long.MAX_VALUE);
+      } else {
+        // request first SetupFrame
+        s.request(1);
+      }
+    }
+  }
+
+  @Override
+  public void onNext(ByteBuf frame) {
+    int streamId = FrameHeaderCodec.streamId(frame);
+    final Type type;
+    if (streamId == 0) {
+      switch (FrameHeaderCodec.frameType(frame)) {
+        case SETUP:
+        case RESUME:
+        case RESUME_OK:
+          type = Type.SETUP;
+          setupReceived = true;
+          break;
+        case LEASE:
+        case KEEPALIVE:
+        case ERROR:
+          type = isClient ? Type.CLIENT : Type.SERVER;
+          break;
+        default:
+          type = isClient ? Type.SERVER : Type.CLIENT;
+      }
+    } else if ((streamId & 0b1) == 0) {
+      type = Type.SERVER;
+    } else {
+      type = Type.CLIENT;
+    }
+    if (!isClient && type != Type.SETUP && !setupReceived) {
+      final IllegalStateException error =
+          new IllegalStateException("SETUP or LEASE frame must be received before any others.");
+      this.s.cancel();
+      onError(error);
+    }
+
+    switch (type) {
+      case SETUP:
+        final InternalDuplexConnection setupReceiver = this.setupReceiver;
+        setupReceiver.onNext(frame);
+        setupReceiver.onComplete();
+        break;
+      case CLIENT:
+        clientReceiver.onNext(frame);
+        break;
+      case SERVER:
+        serverReceiver.onNext(frame);
+        break;
+    }
+  }
+
+  @Override
+  public void onComplete() {
+    final int previousState = STATE.getAndSet(this, Integer.MIN_VALUE);
+    if (previousState == Integer.MIN_VALUE || previousState == 0) {
+      return;
+    }
+
+    if (!isClient) {
+      if (!setupReceived) {
+        setupReceiver.onComplete();
+      }
+
+      if (previousState == 1) {
+        return;
+      }
+    }
+
+    if (clientReceiver.isSubscribed()) {
+      clientReceiver.onComplete();
+    }
+    if (serverReceiver.isSubscribed()) {
+      serverReceiver.onComplete();
+    }
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    this.t = t;
+
+    final int previousState = STATE.getAndSet(this, Integer.MIN_VALUE);
+    if (previousState == Integer.MIN_VALUE || previousState == 0) {
+      return;
+    }
+
+    if (!isClient) {
+      if (!setupReceived) {
+        setupReceiver.onError(t);
+      }
+
+      if (previousState == 1) {
+        return;
+      }
+    }
+
+    if (clientReceiver.isSubscribed()) {
+      clientReceiver.onError(t);
+    }
+    if (serverReceiver.isSubscribed()) {
+      serverReceiver.onError(t);
+    }
+  }
+
+  boolean notifyRequested() {
+    final int currentState = incrementAndGetCheckingState();
+    if (currentState == Integer.MIN_VALUE) {
+      return false;
+    }
+
+    if (isClient) {
+      if (currentState == 2) {
+        source.receive().subscribe(this);
+      }
+    } else {
+      if (currentState == 1) {
+        source.receive().subscribe(this);
+      } else if (currentState == 3) {
+        // means setup was consumed and we got request from client and server multiplexers
+        s.request(Long.MAX_VALUE);
+      }
+    }
+
+    return true;
+  }
+
+  int incrementAndGetCheckingState() {
+    int prev, next;
+    for (; ; ) {
+      prev = this.state;
+
+      if (prev == Integer.MIN_VALUE) {
+        return prev;
+      }
+
+      next = prev + 1;
+      if (STATE.compareAndSet(this, prev, next)) {
+        return next;
+      }
+    }
+  }
+
+  private static class InternalDuplexConnection extends Flux<ByteBuf>
+      implements Subscription, DuplexConnection {
+    private final ClientServerInputMultiplexer clientServerInputMultiplexer;
+    private final DuplexConnection source;
+    private final boolean debugEnabled;
+
+    private volatile int state;
+    static final AtomicIntegerFieldUpdater<InternalDuplexConnection> STATE =
+        AtomicIntegerFieldUpdater.newUpdater(InternalDuplexConnection.class, "state");
+
+    CoreSubscriber<? super ByteBuf> actual;
+
+    public InternalDuplexConnection(
+        ClientServerInputMultiplexer clientServerInputMultiplexer, DuplexConnection source) {
+      this.clientServerInputMultiplexer = clientServerInputMultiplexer;
+      this.source = source;
+      this.debugEnabled = LOGGER.isDebugEnabled();
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super ByteBuf> actual) {
+      if (this.state == 0 && STATE.compareAndSet(this, 0, 1)) {
+        this.actual = actual;
+        actual.onSubscribe(this);
+      } else {
+        Operators.error(
+            actual,
+            new IllegalStateException("InternalDuplexConnection allows only single subscription"));
+      }
+    }
+
+    @Override
+    public void request(long n) {
+      if (this.state == 1 && STATE.compareAndSet(this, 1, 2)) {
+        final ClientServerInputMultiplexer multiplexer = clientServerInputMultiplexer;
+        if (!multiplexer.notifyRequested()) {
+          final Throwable t = multiplexer.t;
+          if (t != null) {
+            this.actual.onError(t);
+          } else {
+            this.actual.onComplete();
+          }
+        }
+      }
+    }
+
+    @Override
+    public void cancel() {
+      // no ops
+    }
+
+    void onNext(ByteBuf frame) {
+      this.actual.onNext(frame);
+    }
+
+    void onComplete() {
+      this.actual.onComplete();
+    }
+
+    void onError(Throwable t) {
+      this.actual.onError(t);
+    }
+
+    @Override
+    public Mono<Void> send(Publisher<ByteBuf> frame) {
+      if (debugEnabled) {
+        return Flux.from(frame)
+            .doOnNext(f -> LOGGER.debug("sending -> " + FrameUtil.toString(f)))
+            .as(source::send);
+      }
+
+      return source.send(frame);
+    }
+
+    @Override
+    public Mono<Void> sendOne(ByteBuf frame) {
+      if (debugEnabled) {
+        LOGGER.debug("sending -> " + FrameUtil.toString(frame));
+      }
+
+      return source.sendOne(frame);
+    }
+
+    @Override
+    public Flux<ByteBuf> receive() {
+      if (debugEnabled) {
+        return this.doOnNext(frame -> LOGGER.debug("receiving -> " + FrameUtil.toString(frame)));
+      } else {
+        return this;
+      }
+    }
+
+    @Override
+    public ByteBufAllocator alloc() {
+      return source.alloc();
+    }
+
+    @Override
+    public void dispose() {
+      source.dispose();
+    }
+
+    @Override
+    public boolean isDisposed() {
+      return source.isDisposed();
+    }
+
+    public boolean isSubscribed() {
+      return this.state != 0;
+    }
+
+    @Override
+    public Mono<Void> onClose() {
+      return source.onClose();
+    }
+
+    @Override
+    public double availability() {
+      return source.availability();
+    }
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -29,7 +29,6 @@ import io.rsocket.RSocketClient;
 import io.rsocket.SocketAcceptor;
 import io.rsocket.frame.SetupFrameCodec;
 import io.rsocket.frame.decoder.PayloadDecoder;
-import io.rsocket.internal.ClientServerInputMultiplexer;
 import io.rsocket.keepalive.KeepAliveHandler;
 import io.rsocket.lease.LeaseStats;
 import io.rsocket.lease.Leases;

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketServer.java
@@ -33,7 +33,6 @@ import io.rsocket.exceptions.RejectedSetupException;
 import io.rsocket.frame.FrameHeaderCodec;
 import io.rsocket.frame.SetupFrameCodec;
 import io.rsocket.frame.decoder.PayloadDecoder;
-import io.rsocket.internal.ClientServerInputMultiplexer;
 import io.rsocket.lease.Leases;
 import io.rsocket.lease.RequesterLeaseHandler;
 import io.rsocket.lease.ResponderLeaseHandler;

--- a/rsocket-core/src/main/java/io/rsocket/core/ServerSetup.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ServerSetup.java
@@ -25,7 +25,6 @@ import io.rsocket.exceptions.UnsupportedSetupException;
 import io.rsocket.frame.ErrorFrameCodec;
 import io.rsocket.frame.ResumeFrameCodec;
 import io.rsocket.frame.SetupFrameCodec;
-import io.rsocket.internal.ClientServerInputMultiplexer;
 import io.rsocket.keepalive.KeepAliveHandler;
 import io.rsocket.resume.*;
 import java.time.Duration;

--- a/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/ClientServerInputMultiplexer.java
@@ -43,7 +43,11 @@ import reactor.core.publisher.MonoProcessor;
  * <p>The only way to differentiate these two frames is determining whether the stream Id is odd or
  * even. Even IDs are for the streams initiated by server and odds are for streams initiated by the
  * client.
+ *
+ * @deprecated since 1.1.0-M1 in favor of package-private {@link
+ *     io.rsocket.core.ClientServerInputMultiplexer}
  */
+@Deprecated
 public class ClientServerInputMultiplexer implements Closeable {
   private static final Logger LOGGER = LoggerFactory.getLogger("io.rsocket.FrameLogger");
   private static final InitializingInterceptorRegistry emptyInterceptorRegistry =

--- a/rsocket-test/src/main/java/io/rsocket/test/ByteBufRepresentation.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/ByteBufRepresentation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rsocket.test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.util.IllegalReferenceCountException;
+import org.assertj.core.presentation.StandardRepresentation;
+
+public final class ByteBufRepresentation extends StandardRepresentation {
+
+  @Override
+  protected String fallbackToStringOf(Object object) {
+    if (object instanceof ByteBuf) {
+      try {
+        String normalBufferString = object.toString();
+        ByteBuf byteBuf = (ByteBuf) object;
+        if (byteBuf.readableBytes() <= 256) {
+          String prettyHexDump = ByteBufUtil.prettyHexDump(byteBuf);
+          return new StringBuilder()
+              .append(normalBufferString)
+              .append("\n")
+              .append(prettyHexDump)
+              .toString();
+        } else {
+          return normalBufferString;
+        }
+      } catch (IllegalReferenceCountException e) {
+        // noops
+      }
+    }
+
+    return super.fallbackToStringOf(object);
+  }
+}

--- a/rsocket-test/src/main/java/io/rsocket/test/LeaksTrackingByteBufAllocator.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/LeaksTrackingByteBufAllocator.java
@@ -1,0 +1,186 @@
+package io.rsocket.test;
+
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.assertj.core.api.Assertions;
+
+/**
+ * Additional Utils which allows to decorate a ByteBufAllocator and track/assertOnLeaks all created
+ * ByteBuffs
+ */
+class LeaksTrackingByteBufAllocator implements ByteBufAllocator {
+
+  /**
+   * Allows to instrument any given the instance of ByteBufAllocator
+   *
+   * @param allocator
+   * @return
+   */
+  public static LeaksTrackingByteBufAllocator instrument(ByteBufAllocator allocator) {
+    return new LeaksTrackingByteBufAllocator(allocator, Duration.ZERO);
+  }
+
+  /**
+   * Allows to instrument any given the instance of ByteBufAllocator
+   *
+   * @param allocator
+   * @return
+   */
+  public static LeaksTrackingByteBufAllocator instrument(
+      ByteBufAllocator allocator, Duration awaitZeroRefCntDuration) {
+    return new LeaksTrackingByteBufAllocator(allocator, awaitZeroRefCntDuration);
+  }
+
+  final ConcurrentLinkedQueue<ByteBuf> tracker = new ConcurrentLinkedQueue<>();
+
+  final ByteBufAllocator delegate;
+
+  final Duration awaitZeroRefCntDuration;
+
+  private LeaksTrackingByteBufAllocator(
+      ByteBufAllocator delegate, Duration awaitZeroRefCntDuration) {
+    this.delegate = delegate;
+    this.awaitZeroRefCntDuration = awaitZeroRefCntDuration;
+  }
+
+  public LeaksTrackingByteBufAllocator assertHasNoLeaks() {
+    try {
+      Assertions.assertThat(tracker)
+          .allSatisfy(
+              buf ->
+                  Assertions.assertThat(buf)
+                      .matches(
+                          bb -> {
+                            final Duration awaitZeroRefCntDuration = this.awaitZeroRefCntDuration;
+                            if (!awaitZeroRefCntDuration.isZero()) {
+                              long end =
+                                  awaitZeroRefCntDuration.plusNanos(System.nanoTime()).toNanos();
+                              while (bb.refCnt() != 0) {
+                                if (System.nanoTime() >= end) {
+                                  break;
+                                }
+                                parkNanos(100);
+                              }
+                            }
+                            return bb.refCnt() == 0;
+                          },
+                          "buffer should be released"));
+    } finally {
+      tracker.clear();
+    }
+    return this;
+  }
+
+  // Delegating logic with tracking of buffers
+
+  @Override
+  public ByteBuf buffer() {
+    return track(delegate.buffer());
+  }
+
+  @Override
+  public ByteBuf buffer(int initialCapacity) {
+    return track(delegate.buffer(initialCapacity));
+  }
+
+  @Override
+  public ByteBuf buffer(int initialCapacity, int maxCapacity) {
+    return track(delegate.buffer(initialCapacity, maxCapacity));
+  }
+
+  @Override
+  public ByteBuf ioBuffer() {
+    return track(delegate.ioBuffer());
+  }
+
+  @Override
+  public ByteBuf ioBuffer(int initialCapacity) {
+    return track(delegate.ioBuffer(initialCapacity));
+  }
+
+  @Override
+  public ByteBuf ioBuffer(int initialCapacity, int maxCapacity) {
+    return track(delegate.ioBuffer(initialCapacity, maxCapacity));
+  }
+
+  @Override
+  public ByteBuf heapBuffer() {
+    return track(delegate.heapBuffer());
+  }
+
+  @Override
+  public ByteBuf heapBuffer(int initialCapacity) {
+    return track(delegate.heapBuffer(initialCapacity));
+  }
+
+  @Override
+  public ByteBuf heapBuffer(int initialCapacity, int maxCapacity) {
+    return track(delegate.heapBuffer(initialCapacity, maxCapacity));
+  }
+
+  @Override
+  public ByteBuf directBuffer() {
+    return track(delegate.directBuffer());
+  }
+
+  @Override
+  public ByteBuf directBuffer(int initialCapacity) {
+    return track(delegate.directBuffer(initialCapacity));
+  }
+
+  @Override
+  public ByteBuf directBuffer(int initialCapacity, int maxCapacity) {
+    return track(delegate.directBuffer(initialCapacity, maxCapacity));
+  }
+
+  @Override
+  public CompositeByteBuf compositeBuffer() {
+    return track(delegate.compositeBuffer());
+  }
+
+  @Override
+  public CompositeByteBuf compositeBuffer(int maxNumComponents) {
+    return track(delegate.compositeBuffer(maxNumComponents));
+  }
+
+  @Override
+  public CompositeByteBuf compositeHeapBuffer() {
+    return track(delegate.compositeHeapBuffer());
+  }
+
+  @Override
+  public CompositeByteBuf compositeHeapBuffer(int maxNumComponents) {
+    return track(delegate.compositeHeapBuffer(maxNumComponents));
+  }
+
+  @Override
+  public CompositeByteBuf compositeDirectBuffer() {
+    return track(delegate.compositeDirectBuffer());
+  }
+
+  @Override
+  public CompositeByteBuf compositeDirectBuffer(int maxNumComponents) {
+    return track(delegate.compositeDirectBuffer(maxNumComponents));
+  }
+
+  @Override
+  public boolean isDirectBufferPooled() {
+    return delegate.isDirectBufferPooled();
+  }
+
+  @Override
+  public int calculateNewCapacity(int minNewCapacity, int maxCapacity) {
+    return delegate.calculateNewCapacity(minNewCapacity, maxCapacity);
+  }
+
+  <T extends ByteBuf> T track(T buffer) {
+    tracker.offer(buffer);
+
+    return buffer;
+  }
+}

--- a/rsocket-test/src/main/java/io/rsocket/test/TestRSocket.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TestRSocket.java
@@ -16,10 +16,13 @@
 
 package io.rsocket.test;
 
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
 import io.rsocket.util.ByteBufPayload;
-import io.rsocket.util.EmptyPayload;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -28,6 +31,9 @@ public class TestRSocket implements RSocket {
   private final String data;
   private final String metadata;
 
+  private final AtomicLong observedInteractions = new AtomicLong();
+  private final AtomicLong activeInteractions = new AtomicLong();
+
   public TestRSocket(String data, String metadata) {
     this.data = data;
     this.metadata = metadata;
@@ -35,30 +41,69 @@ public class TestRSocket implements RSocket {
 
   @Override
   public Mono<Payload> requestResponse(Payload payload) {
+    activeInteractions.getAndIncrement();
     payload.release();
-    return Mono.just(ByteBufPayload.create(data, metadata));
+    observedInteractions.getAndIncrement();
+    return Mono.just(ByteBufPayload.create(data, metadata))
+        .doFinally(__ -> activeInteractions.getAndDecrement());
   }
 
   @Override
   public Flux<Payload> requestStream(Payload payload) {
+    activeInteractions.getAndIncrement();
     payload.release();
-    return Flux.range(1, 10_000).flatMap(l -> requestResponse(EmptyPayload.INSTANCE));
+    observedInteractions.getAndIncrement();
+    return Flux.range(1, 10_000)
+        .map(l -> ByteBufPayload.create(data, metadata))
+        .doFinally(__ -> activeInteractions.getAndDecrement());
   }
 
   @Override
   public Mono<Void> metadataPush(Payload payload) {
+    activeInteractions.getAndIncrement();
     payload.release();
-    return Mono.empty();
+    observedInteractions.getAndIncrement();
+    return Mono.<Void>empty().doFinally(__ -> activeInteractions.getAndDecrement());
   }
 
   @Override
   public Mono<Void> fireAndForget(Payload payload) {
+    activeInteractions.getAndIncrement();
     payload.release();
-    return Mono.empty();
+    observedInteractions.getAndIncrement();
+    return Mono.<Void>empty().doFinally(__ -> activeInteractions.getAndDecrement());
   }
 
   @Override
   public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
-    return Flux.from(payloads);
+    activeInteractions.getAndIncrement();
+    observedInteractions.getAndIncrement();
+    return Flux.from(payloads).doFinally(__ -> activeInteractions.getAndDecrement());
+  }
+
+  public boolean awaitAllInteractionTermination(Duration duration) {
+    long end = duration.plusNanos(System.nanoTime()).toNanos();
+    long activeNow;
+    while ((activeNow = activeInteractions.get()) > 0) {
+      if (System.nanoTime() >= end) {
+        return false;
+      }
+      parkNanos(100);
+    }
+
+    return activeNow == 0;
+  }
+
+  public boolean awaitUntilObserved(int interactions, Duration duration) {
+    long end = duration.plusNanos(System.nanoTime()).toNanos();
+    long observed;
+    while ((observed = observedInteractions.get()) < interactions) {
+      if (System.nanoTime() >= end) {
+        return false;
+      }
+      parkNanos(100);
+    }
+
+    return observed >= interactions;
   }
 }

--- a/rsocket-test/src/main/java/io/rsocket/test/TriFunction.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TriFunction.java
@@ -1,0 +1,6 @@
+package io.rsocket.test;
+
+@FunctionalInterface
+public interface TriFunction<T1, T2, T3, R> {
+  R apply(T1 t1, T2 t2, T3 t3);
+}

--- a/rsocket-test/src/main/resources/META-INF/services/org.assertj.core.presentation.Representation
+++ b/rsocket-test/src/main/resources/META-INF/services/org.assertj.core.presentation.Representation
@@ -1,0 +1,16 @@
+#
+# Copyright 2015-2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+io.rsocket.test.ByteBufRepresentation

--- a/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalTransportTest.java
+++ b/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalTransportTest.java
@@ -25,8 +25,8 @@ final class LocalTransportTest implements TransportTest {
   private final TransportPair transportPair =
       new TransportPair<>(
           () -> "test-" + UUID.randomUUID(),
-          (address, server) -> LocalClientTransport.create(address),
-          LocalServerTransport::create);
+          (address, server, allocator) -> LocalClientTransport.create(address, allocator),
+          (address, allocator) -> LocalServerTransport.create(address));
 
   @Override
   public Duration getTimeout() {

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/TcpSecureTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/TcpSecureTransportTest.java
@@ -1,5 +1,6 @@
 package io.rsocket.transport.netty;
 
+import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -17,20 +18,22 @@ public class TcpSecureTransportTest implements TransportTest {
   private final TransportPair transportPair =
       new TransportPair<>(
           () -> new InetSocketAddress("localhost", 0),
-          (address, server) ->
+          (address, server, allocator) ->
               TcpClientTransport.create(
                   TcpClient.create()
+                      .option(ChannelOption.ALLOCATOR, allocator)
                       .remoteAddress(server::address)
                       .secure(
                           ssl ->
                               ssl.sslContext(
                                   SslContextBuilder.forClient()
                                       .trustManager(InsecureTrustManagerFactory.INSTANCE)))),
-          address -> {
+          (address, allocator) -> {
             try {
               SelfSignedCertificate ssc = new SelfSignedCertificate();
               TcpServer server =
                   TcpServer.create()
+                      .option(ChannelOption.ALLOCATOR, allocator)
                       .bindAddress(() -> address)
                       .secure(
                           ssl ->

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketSecureTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketSecureTransportTest.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.transport.netty;
 
+import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -34,9 +35,10 @@ final class WebsocketSecureTransportTest implements TransportTest {
   private final TransportPair transportPair =
       new TransportPair<>(
           () -> new InetSocketAddress("localhost", 0),
-          (address, server) ->
+          (address, server, allocator) ->
               WebsocketClientTransport.create(
                   HttpClient.create()
+                      .option(ChannelOption.ALLOCATOR, allocator)
                       .remoteAddress(server::address)
                       .secure(
                           ssl ->
@@ -46,11 +48,12 @@ final class WebsocketSecureTransportTest implements TransportTest {
                   String.format(
                       "https://%s:%d/",
                       server.address().getHostName(), server.address().getPort())),
-          address -> {
+          (address, allocator) -> {
             try {
               SelfSignedCertificate ssc = new SelfSignedCertificate();
               HttpServer server =
                   HttpServer.create()
+                      .option(ChannelOption.ALLOCATOR, allocator)
                       .bindAddress(() -> address)
                       .secure(
                           ssl ->


### PR DESCRIPTION
This PR reworks `ClientServerInputMultiplexer` to avoid async enqueueing/dequeuing of the incoming frames when interceptors offload subscription/publication on the different `Scheduler`, so frame appears released at the time of its consumption (`FluxReceiver` sends `ByteBuf` and releases it once `onNext` is returned -> https://github.com/reactor/reactor-netty/blob/master/reactor-netty-core/src/main/java/reactor/netty/channel/FluxReceive.java#L264).

Basically this PR gets rid of `groupBy` operator in favor of its drain-free version.

***FYI. This PR as well as changes related to refCoutning mechanics brake resumability***.
It can wait since there is no usage of this feature in Spring-Messaging, though we should revise the whole resumability implementation before the final 1.1 release.

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>