### PR TITLE
ensures new requests with existing stream id are handled properly

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/FireAndForgetResponderSubscriber.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/FireAndForgetResponderSubscriber.java
@@ -89,17 +89,15 @@ final class FireAndForgetResponderSubscriber
 
   @Override
   public void handleNext(ByteBuf followingFrame, boolean hasFollows, boolean isLastPayload) {
-    final CompositeByteBuf frames;
+    final CompositeByteBuf frames = this.frames;
+
     try {
-      frames =
-          ReassemblyUtils.addFollowingFrame(
-              this.frames, followingFrame, this.maxInboundPayloadSize);
+      ReassemblyUtils.addFollowingFrame(frames, followingFrame, this.maxInboundPayloadSize);
     } catch (IllegalStateException t) {
       this.requesterResponderSupport.remove(this.streamId, this);
 
-      CompositeByteBuf framesToRelease = this.frames;
       this.frames = null;
-      framesToRelease.release();
+      frames.release();
 
       logger.debug("Reassembly has failed", t);
       return;
@@ -128,8 +126,8 @@ final class FireAndForgetResponderSubscriber
   public final void handleCancel() {
     final CompositeByteBuf frames = this.frames;
     if (frames != null) {
-      this.frames = null;
       this.requesterResponderSupport.remove(this.streamId, this);
+      this.frames = null;
       frames.release();
     }
   }

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -205,6 +205,7 @@ class RSocketRequester extends RequesterResponderSupport implements RSocket {
         handleFrame(streamId, type, frame);
       }
     } catch (Throwable t) {
+      LOGGER.error("Unexpected error during frame handling", t);
       super.getSendProcessor()
           .onNext(
               ErrorFrameCodec.encode(

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -301,6 +301,7 @@ class RSocketResponder extends RequesterResponderSupport implements RSocket {
           break;
       }
     } catch (Throwable t) {
+      LOGGER.error("Unexpected error during frame handling", t);
       super.getSendProcessor()
           .onNext(
               ErrorFrameCodec.encode(

--- a/rsocket-core/src/main/java/io/rsocket/core/RequestChannelResponderSubscriber.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RequestChannelResponderSubscriber.java
@@ -309,8 +309,14 @@ final class RequestChannelResponderSubscriber extends Flux<Payload>
       this.requesterResponderSupport.remove(this.streamId, this);
 
       final CompositeByteBuf frames = this.frames;
-      this.frames = null;
-      frames.release();
+      if (frames != null) {
+        this.frames = null;
+        frames.release();
+      } else {
+        final Payload firstPayload = this.firstPayload;
+        this.firstPayload = null;
+        firstPayload.release();
+      }
       return;
     }
 


### PR DESCRIPTION
Fixes Request Handlers to ignore all further payload fragments as well as ignore request frames which stream ID clashes with an existing ongoing streams 

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>