### PR TITLE
Reject frames less than min MTU size

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/FireAndForgetResponderSubscriber.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/FireAndForgetResponderSubscriber.java
@@ -68,7 +68,7 @@ final class FireAndForgetResponderSubscriber
 
     this.frames =
         ReassemblyUtils.addFollowingFrame(
-            allocator.compositeBuffer(), firstFrame, maxInboundPayloadSize);
+            allocator.compositeBuffer(), firstFrame, true, maxInboundPayloadSize);
   }
 
   @Override
@@ -92,7 +92,8 @@ final class FireAndForgetResponderSubscriber
     final CompositeByteBuf frames = this.frames;
 
     try {
-      ReassemblyUtils.addFollowingFrame(frames, followingFrame, this.maxInboundPayloadSize);
+      ReassemblyUtils.addFollowingFrame(
+          frames, followingFrame, hasFollows, this.maxInboundPayloadSize);
     } catch (IllegalStateException t) {
       this.requesterResponderSupport.remove(this.streamId, this);
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RequestChannelResponderSubscriber.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RequestChannelResponderSubscriber.java
@@ -104,7 +104,7 @@ final class RequestChannelResponderSubscriber extends Flux<Payload>
 
     this.frames =
         ReassemblyUtils.addFollowingFrame(
-            allocator.compositeBuffer(), firstFrame, maxInboundPayloadSize);
+            allocator.compositeBuffer(), firstFrame, true, maxInboundPayloadSize);
     STATE.lazySet(this, REASSEMBLING_FLAG);
   }
 
@@ -491,7 +491,7 @@ final class RequestChannelResponderSubscriber extends Flux<Payload>
     if (frames == null) {
       frames =
           ReassemblyUtils.addFollowingFrame(
-              this.allocator.compositeBuffer(), frame, this.maxInboundPayloadSize);
+              this.allocator.compositeBuffer(), frame, hasFollows, this.maxInboundPayloadSize);
       this.frames = frames;
 
       long previousState = markReassembling(STATE, this);
@@ -502,7 +502,9 @@ final class RequestChannelResponderSubscriber extends Flux<Payload>
       }
     } else {
       try {
-        frames = ReassemblyUtils.addFollowingFrame(frames, frame, this.maxInboundPayloadSize);
+        frames =
+            ReassemblyUtils.addFollowingFrame(
+                frames, frame, hasFollows, this.maxInboundPayloadSize);
       } catch (IllegalStateException e) {
         if (isTerminated(this.state)) {
           return;

--- a/rsocket-core/src/main/java/io/rsocket/core/RequestResponseResponderSubscriber.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RequestResponseResponderSubscriber.java
@@ -81,7 +81,7 @@ final class RequestResponseResponderSubscriber
     this.handler = handler;
     this.frames =
         ReassemblyUtils.addFollowingFrame(
-            allocator.compositeBuffer(), firstFrame, maxInboundPayloadSize);
+            allocator.compositeBuffer(), firstFrame, true, maxInboundPayloadSize);
   }
 
   public RequestResponseResponderSubscriber(
@@ -218,7 +218,7 @@ final class RequestResponseResponderSubscriber
     }
 
     try {
-      ReassemblyUtils.addFollowingFrame(frames, frame, this.maxInboundPayloadSize);
+      ReassemblyUtils.addFollowingFrame(frames, frame, hasFollows, this.maxInboundPayloadSize);
     } catch (IllegalStateException t) {
       S.lazySet(this, Operators.cancelledSubscription());
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RequestStreamResponderSubscriber.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RequestStreamResponderSubscriber.java
@@ -84,7 +84,7 @@ final class RequestStreamResponderSubscriber
     this.handler = handler;
     this.frames =
         ReassemblyUtils.addFollowingFrame(
-            allocator.compositeBuffer(), firstFrame, maxInboundPayloadSize);
+            allocator.compositeBuffer(), firstFrame, true, maxInboundPayloadSize);
   }
 
   public RequestStreamResponderSubscriber(
@@ -258,7 +258,8 @@ final class RequestStreamResponderSubscriber
     }
 
     try {
-      ReassemblyUtils.addFollowingFrame(frames, followingFrame, this.maxInboundPayloadSize);
+      ReassemblyUtils.addFollowingFrame(
+          frames, followingFrame, hasFollows, this.maxInboundPayloadSize);
     } catch (IllegalStateException t) {
       // if subscription is null, it means that streams has not yet reassembled all the fragments
       // and fragmentation of the first frame was cancelled before


### PR DESCRIPTION
This is essentially the fix for #895 for the 1.1 code base. The logic for re-assembling is in a different class compared to 1.0 so the fix is in a different place and not a straight forward merge.
