### PR TITLE
Make LoadbalanceStrategy implementations public

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/loadbalance/LoadbalanceRSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/loadbalance/LoadbalanceRSocketClient.java
@@ -146,7 +146,7 @@ public class LoadbalanceRSocketClient implements RSocketClient {
      * Switch to using a strategy that assigns a weight to each pooled {@code RSocket} based on
      * actual usage stats, and uses that to make a choice.
      *
-     * <p>By default this strategy is not used.
+     * <p>By default, {@link RoundRobinLoadbalanceStrategy} is used.
      */
     public Builder weightedLoadbalanceStrategy() {
       this.loadbalanceStrategy = new WeightedLoadbalanceStrategy();
@@ -154,11 +154,11 @@ public class LoadbalanceRSocketClient implements RSocketClient {
     }
 
     /**
-     * Switch to using a custom strategy for loadbalancing.
+     * Provide the {@link LoadbalanceStrategy} to use.
      *
-     * @see #roundRobinLoadbalanceStrategy()
+     * <p>By default, {@link RoundRobinLoadbalanceStrategy} is used.
      */
-    public Builder customLoadbalanceStrategy(LoadbalanceStrategy strategy) {
+    public Builder loadbalanceStrategy(LoadbalanceStrategy strategy) {
       this.loadbalanceStrategy = strategy;
       return this;
     }

--- a/rsocket-core/src/main/java/io/rsocket/loadbalance/RoundRobinLoadbalanceStrategy.java
+++ b/rsocket-core/src/main/java/io/rsocket/loadbalance/RoundRobinLoadbalanceStrategy.java
@@ -19,7 +19,12 @@ import io.rsocket.RSocket;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-class RoundRobinLoadbalanceStrategy implements LoadbalanceStrategy {
+/**
+ * Simple {@link LoadbalanceStrategy} that selects the {@code RSocket} to use in round-robin order.
+ *
+ * @since 1.1
+ */
+public class RoundRobinLoadbalanceStrategy implements LoadbalanceStrategy {
 
   volatile int nextIndex;
 

--- a/rsocket-core/src/main/java/io/rsocket/loadbalance/WeightedLoadbalanceStrategy.java
+++ b/rsocket-core/src/main/java/io/rsocket/loadbalance/WeightedLoadbalanceStrategy.java
@@ -20,18 +20,22 @@ import io.rsocket.RSocket;
 import java.util.List;
 import java.util.SplittableRandom;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Supplier;
 import reactor.util.annotation.Nullable;
 
-class WeightedLoadbalanceStrategy implements LoadbalanceStrategy {
+/**
+ * {@link LoadbalanceStrategy} that assigns a weight to each {@code RSocket} based on usage
+ * statistics, and uses this weight to select the {@code RSocket} to use.
+ *
+ * @since 1.1
+ */
+public class WeightedLoadbalanceStrategy implements LoadbalanceStrategy {
 
   private static final double EXP_FACTOR = 4.0;
 
   private static final int EFFORT = 5;
 
-  final SplittableRandom splittableRandom;
   final int effort;
-  final Supplier<Stats> statsSupplier;
+  final SplittableRandom splittableRandom;
 
   public WeightedLoadbalanceStrategy() {
     this(EFFORT);
@@ -42,14 +46,8 @@ class WeightedLoadbalanceStrategy implements LoadbalanceStrategy {
   }
 
   public WeightedLoadbalanceStrategy(int effort, SplittableRandom splittableRandom) {
-    this(effort, splittableRandom, Stats::create);
-  }
-
-  public WeightedLoadbalanceStrategy(
-      int effort, SplittableRandom splittableRandom, Supplier<Stats> statsSupplier) {
-    this.splittableRandom = splittableRandom;
     this.effort = effort;
-    this.statsSupplier = statsSupplier;
+    this.splittableRandom = splittableRandom;
   }
 
   @Override


### PR DESCRIPTION
The `LoadbalanceClient` builder provides methods to switch the strategy, but being able to also instantiate and pass the strategies in provides more flexibility. This comes up for loadbalance support in Spring's `RSocketRequester` builder. 