### PR TITLE
Add capnp & flatbuffers serialization support

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/metadata/WellKnownMimeType.java
+++ b/rsocket-core/src/main/java/io/rsocket/metadata/WellKnownMimeType.java
@@ -70,6 +70,8 @@ public enum WellKnownMimeType {
   APPLICATION_HESSIAN("application/x-hessian", (byte) 0x26),
   APPLICATION_JAVA_OBJECT("application/x-java-object", (byte) 0x27),
   APPLICATION_CLOUDEVENTS_JSON("application/cloudevents+json", (byte) 0x28),
+  APPLICATION_CAPNP("application/x-capnp", (byte) 0x29),
+  APPLICATION_FLATBUFFER("application/x-flatbuffers", (byte) 0x2A),
 
   // ... reserved for future use ...
   MESSAGE_RSOCKET_MIMETYPE("message/x.rsocket.mime-type.v0", (byte) 0x7A),


### PR DESCRIPTION
Cap’n Proto and FlatBuffers  are high performance serialization library, and they should be included in WellKnownType, and especially useful to per stream DataMimeType, and text MimeType is too long for them because of performance.