### PR TITLE
Rename RequestInterceptor registration methods

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/loadbalance/WeightedLoadbalanceStrategy.java
+++ b/rsocket-core/src/main/java/io/rsocket/loadbalance/WeightedLoadbalanceStrategy.java
@@ -214,7 +214,7 @@ public class WeightedLoadbalanceStrategy implements ClientLoadbalanceStrategy {
     void init(RSocketConnector connector) {
       connector.interceptors(
           registry ->
-              registry.forRequester(
+              registry.forRequestsInRequester(
                   (Function<RSocket, ? extends RequestInterceptor>)
                       rSocket -> {
                         final WeightedStatsRequestInterceptor interceptor =

--- a/rsocket-core/src/main/java/io/rsocket/plugins/InitializingInterceptorRegistry.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/InitializingInterceptorRegistry.java
@@ -28,12 +28,14 @@ public class InitializingInterceptorRegistry extends InterceptorRegistry {
 
   @Nullable
   public RequestInterceptor initRequesterRequestInterceptor(RSocket rSocketRequester) {
-    return CompositeRequestInterceptor.create(rSocketRequester, getRequesterRequestInterceptors());
+    return CompositeRequestInterceptor.create(
+        rSocketRequester, getRequestInterceptorsForRequester());
   }
 
   @Nullable
   public RequestInterceptor initResponderRequestInterceptor(RSocket rSocketResponder) {
-    return CompositeRequestInterceptor.create(rSocketResponder, getResponderRequestInterceptors());
+    return CompositeRequestInterceptor.create(
+        rSocketResponder, getRequestInterceptorsForResponder());
   }
 
   public DuplexConnection initConnection(

--- a/rsocket-core/src/main/java/io/rsocket/plugins/InterceptorRegistry.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/InterceptorRegistry.java
@@ -48,7 +48,7 @@ public class InterceptorRegistry {
    *     RequestInterceptor}
    * @since 1.1
    */
-  public InterceptorRegistry forRequester(
+  public InterceptorRegistry forRequestsInRequester(
       Function<RSocket, ? extends RequestInterceptor> interceptor) {
     requesterRequestInterceptors.add(interceptor);
     return this;
@@ -61,7 +61,7 @@ public class InterceptorRegistry {
    *     RequestInterceptor}
    * @since 1.1
    */
-  public InterceptorRegistry forResponder(
+  public InterceptorRegistry forRequestsInResponder(
       Function<RSocket, ? extends RequestInterceptor> interceptor) {
     responderRequestInterceptors.add(interceptor);
     return this;
@@ -134,11 +134,11 @@ public class InterceptorRegistry {
     return this;
   }
 
-  List<Function<RSocket, ? extends RequestInterceptor>> getRequesterRequestInterceptors() {
+  List<Function<RSocket, ? extends RequestInterceptor>> getRequestInterceptorsForRequester() {
     return requesterRequestInterceptors;
   }
 
-  List<Function<RSocket, ? extends RequestInterceptor>> getResponderRequestInterceptors() {
+  List<Function<RSocket, ? extends RequestInterceptor>> getRequestInterceptorsForResponder() {
     return responderRequestInterceptors;
   }
 

--- a/rsocket-core/src/test/java/io/rsocket/plugins/RequestInterceptorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/plugins/RequestInterceptorTest.java
@@ -66,7 +66,7 @@ public class RequestInterceptorTest {
         RSocketConnector.create()
             .interceptors(
                 ir ->
-                    ir.forRequester(
+                    ir.forRequestsInRequester(
                         (Function<RSocket, ? extends RequestInterceptor>)
                             (__) -> testRequestInterceptor))
             .connect(LocalClientTransport.create("test"))
@@ -206,7 +206,7 @@ public class RequestInterceptorTest {
                     }))
             .interceptors(
                 ir ->
-                    ir.forResponder(
+                    ir.forRequestsInResponder(
                         (Function<RSocket, ? extends RequestInterceptor>)
                             (__) -> testRequestInterceptor))
             .connect(LocalClientTransport.create("test"))
@@ -292,7 +292,7 @@ public class RequestInterceptorTest {
                     }))
             .interceptors(
                 ir ->
-                    ir.forResponder(
+                    ir.forRequestsInResponder(
                         (Function<RSocket, ? extends RequestInterceptor>)
                             (__) -> testRequestInterceptor))
             .bindNow(LocalServerTransport.create("test"));
@@ -400,7 +400,7 @@ public class RequestInterceptorTest {
                             }))
             .interceptors(
                 ir ->
-                    ir.forRequester(
+                    ir.forRequestsInRequester(
                         (Function<RSocket, ? extends RequestInterceptor>)
                             (__) -> testRequestInterceptor))
             .bindNow(LocalServerTransport.create("test"));
@@ -543,7 +543,7 @@ public class RequestInterceptorTest {
         RSocketConnector.create()
             .interceptors(
                 ir ->
-                    ir.forRequester(
+                    ir.forRequestsInRequester(
                         (Function<RSocket, ? extends RequestInterceptor>)
                             (__) -> testRequestInterceptor))
             .connect(LocalClientTransport.create("test"))
@@ -646,13 +646,13 @@ public class RequestInterceptorTest {
         RSocketConnector.create()
             .interceptors(
                 ir ->
-                    ir.forRequester(
+                    ir.forRequestsInRequester(
                             (Function<RSocket, ? extends RequestInterceptor>)
                                 (__) -> testRequestInterceptor)
-                        .forRequester(
+                        .forRequestsInRequester(
                             (Function<RSocket, ? extends RequestInterceptor>)
                                 (__) -> testRequestInterceptor1)
-                        .forRequester(
+                        .forRequestsInRequester(
                             (Function<RSocket, ? extends RequestInterceptor>)
                                 (__) -> testRequestInterceptor2))
             .connect(LocalClientTransport.create("test"))


### PR DESCRIPTION
Avoiding the overload with `RSocketInterceptor` registrations helps to avoid ambiguity when using lambdas.