### PR TITLE
fixes OverflowException if UnicstProcessr request and onNext race

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RequestOperator.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RequestOperator.java
@@ -93,7 +93,6 @@ abstract class RequestOperator
 
   @Override
   public void request(long n) {
-    this.s.request(n);
     if (!firstRequest) {
       try {
         this.hookOnRemainingRequests(n);
@@ -115,6 +114,7 @@ abstract class RequestOperator
       if (firstLoop) {
         firstLoop = false;
         try {
+          this.s.request(Long.MAX_VALUE);
           this.hookOnFirstRequest(n);
         } catch (Throwable throwable) {
           onError(throwable);

--- a/rsocket-core/src/main/java/io/rsocket/core/RequestOperator.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RequestOperator.java
@@ -114,6 +114,14 @@ abstract class RequestOperator
       if (firstLoop) {
         firstLoop = false;
         try {
+          // since in all the scenarios where RequestOperator is used, the
+          // CorePublisher is either UnicastProcessor or UnicastProcessor.next()
+          // we are free to propagate unbounded demand to that publisher right after
+          // the first request happens. UnicastProcessor is only there to allow sending signals from
+          // the
+          // connection to a real subscriber and does not have to check the real demand
+          // For more info see
+          // https://github.com/rsocket/rsocket/blob/master/Protocol.md#handling-the-unexpected
           this.s.request(Long.MAX_VALUE);
           this.hookOnFirstRequest(n);
         } catch (Throwable throwable) {

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -1168,8 +1168,7 @@ public class RSocketRequesterTest {
             assertSubscriber.request(1);
           });
 
-      Assertions.assertThat(rule.connection.getSent())
-          .allMatch(ByteBuf::release);
+      Assertions.assertThat(rule.connection.getSent()).allMatch(ByteBuf::release);
 
       Assertions.assertThat(rule.socket.isDisposed()).isFalse();
 

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -1142,6 +1142,45 @@ public class RSocketRequesterTest {
     rule.assertHasNoLeaks();
   }
 
+  @Test
+  // see https://github.com/rsocket/rsocket-java/issues/959
+  public void testWorkaround959() {
+    for (int i = 1; i < 100000; i += 2) {
+      ByteBuf buffer = rule.alloc().buffer();
+      buffer.writeCharSequence("test", CharsetUtil.UTF_8);
+
+      final AssertSubscriber<Payload> assertSubscriber = new AssertSubscriber<>(3);
+      rule.socket.requestStream(ByteBufPayload.create(buffer)).subscribe(assertSubscriber);
+
+      final ByteBuf payloadFrame =
+          PayloadFrameCodec.encode(
+              rule.alloc(), i, false, false, true, Unpooled.EMPTY_BUFFER, Unpooled.EMPTY_BUFFER);
+
+      RaceTestUtils.race(
+          () -> {
+            rule.connection.addToReceivedBuffer(payloadFrame.copy());
+            rule.connection.addToReceivedBuffer(payloadFrame.copy());
+            rule.connection.addToReceivedBuffer(payloadFrame);
+          },
+          () -> {
+            assertSubscriber.request(1);
+            assertSubscriber.request(1);
+            assertSubscriber.request(1);
+          });
+
+      Assertions.assertThat(rule.connection.getSent())
+          .allMatch(ByteBuf::release);
+
+      Assertions.assertThat(rule.socket.isDisposed()).isFalse();
+
+      assertSubscriber.values().forEach(ReferenceCountUtil::safeRelease);
+      assertSubscriber.assertNoError();
+
+      rule.connection.clearSendReceiveBuffers();
+      rule.assertHasNoLeaks();
+    }
+  }
+
   public static class ClientSocketRule extends AbstractSocketRule<RSocketRequester> {
     @Override
     protected RSocketRequester newRSocket() {


### PR DESCRIPTION
closes #959 

Some fix details:

Due to the RSocket Specification, section ["Handling the unexpected"](https://github.com/rsocket/rsocket/blob/master/Protocol.md#handling-the-unexpected)

> Lack of REQUEST_N frames that stops a stream is an application concern and SHALL NOT be handled by the protocol.

the `RequestOperator` does unbounded request to the `UnicastProcessor` once in order to avoid any concurrency on the internal WIP field.

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>