### PR TITLE
fixes UnboundedProcessor to have only single threaded access to SC `queue.poll()`

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -103,7 +103,7 @@ class RSocketRequester implements RSocket {
   private final StreamIdSupplier streamIdSupplier;
   private final IntObjectMap<Subscription> senders;
   private final IntObjectMap<Processor<Payload, Payload>> receivers;
-  private final UnboundedProcessor<ByteBuf> sendProcessor;
+  private final UnboundedProcessor sendProcessor;
   private final int mtu;
   private final int maxFrameLength;
   private final RequesterLeaseHandler leaseHandler;
@@ -136,7 +136,7 @@ class RSocketRequester implements RSocket {
     this.serialScheduler = serialScheduler;
 
     // DO NOT Change the order here. The Send processor must be subscribed to before receiving
-    this.sendProcessor = new UnboundedProcessor<>();
+    this.sendProcessor = new UnboundedProcessor();
 
     connection.onClose().subscribe(null, this::tryTerminateOnConnectionError, this::tryShutdown);
     connection.send(sendProcessor).subscribe(null, this::handleSendProcessorError);
@@ -264,7 +264,7 @@ class RSocketRequester implements RSocket {
       return Mono.error(new IllegalArgumentException(INVALID_PAYLOAD_ERROR_MESSAGE));
     }
 
-    final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
+    final UnboundedProcessor sendProcessor = this.sendProcessor;
     final UnicastProcessor<Payload> receiver = UnicastProcessor.create(Queues.<Payload>one().get());
     return Mono.fromDirect(
             new RequestOperator(
@@ -332,7 +332,7 @@ class RSocketRequester implements RSocket {
       return Flux.error(new IllegalArgumentException(INVALID_PAYLOAD_ERROR_MESSAGE));
     }
 
-    final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
+    final UnboundedProcessor sendProcessor = this.sendProcessor;
     final UnicastProcessor<Payload> receiver = UnicastProcessor.create(Queues.<Payload>one().get());
 
     return Flux.from(
@@ -425,7 +425,7 @@ class RSocketRequester implements RSocket {
   }
 
   private Flux<? extends Payload> handleChannel(Payload initialPayload, Flux<Payload> inboundFlux) {
-    final UnboundedProcessor<ByteBuf> sendProcessor = this.sendProcessor;
+    final UnboundedProcessor sendProcessor = this.sendProcessor;
 
     final UnicastProcessor<Payload> receiver = UnicastProcessor.create(Queues.<Payload>one().get());
 

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -98,7 +98,7 @@ class RSocketResponder implements RSocket {
   private final IntObjectMap<Subscription> sendingSubscriptions;
   private final IntObjectMap<Processor<Payload, Payload>> channelProcessors;
 
-  private final UnboundedProcessor<ByteBuf> sendProcessor;
+  private final UnboundedProcessor sendProcessor;
   private final ByteBufAllocator allocator;
 
   RSocketResponder(
@@ -126,7 +126,7 @@ class RSocketResponder implements RSocket {
 
     // DO NOT Change the order here. The Send processor must be subscribed to before receiving
     // connections
-    this.sendProcessor = new UnboundedProcessor<>();
+    this.sendProcessor = new UnboundedProcessor();
 
     connection.send(sendProcessor).subscribe(null, this::handleSendProcessorError);
 

--- a/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java
@@ -16,7 +16,7 @@
 
 package io.rsocket.internal;
 
-import io.netty.util.ReferenceCounted;
+import io.netty.buffer.ByteBuf;
 import io.rsocket.internal.jctools.queues.MpscUnboundedArrayQueue;
 import java.util.Objects;
 import java.util.Queue;
@@ -37,45 +37,38 @@ import reactor.util.context.Context;
  * A Processor implementation that takes a custom queue and allows only a single subscriber.
  *
  * <p>The implementation keeps the order of signals.
- *
- * @param <T> the input and output type
  */
-public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
-    implements Fuseable.QueueSubscription<T>, Fuseable {
+public final class UnboundedProcessor extends FluxProcessor<ByteBuf, ByteBuf>
+    implements Fuseable.QueueSubscription<ByteBuf>, Fuseable {
 
-  final Queue<T> queue;
-  final Queue<T> priorityQueue;
+  final Queue<ByteBuf> queue;
+  final Queue<ByteBuf> priorityQueue;
 
-  volatile boolean done;
+  boolean done;
   Throwable error;
-  // important to not loose the downstream too early and miss discard hook, while
-  // having relevant hasDownstreams()
-  boolean hasDownstream;
-  volatile CoreSubscriber<? super T> actual;
+  CoreSubscriber<? super ByteBuf> actual;
 
-  volatile boolean cancelled;
+  static final long STATE_TERMINATED =
+      0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  static final long FLAG_CANCELLED =
+      0b0100_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  static final long FLAG_SUBSCRIBED_ONCE =
+      0b0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  static final long MAX_VALUE =
+      0b0001_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L;
 
-  volatile int once;
+  volatile long state;
 
-  @SuppressWarnings("rawtypes")
-  static final AtomicIntegerFieldUpdater<UnboundedProcessor> ONCE =
-      AtomicIntegerFieldUpdater.newUpdater(UnboundedProcessor.class, "once");
-
-  volatile int wip;
-
-  @SuppressWarnings("rawtypes")
-  static final AtomicIntegerFieldUpdater<UnboundedProcessor> WIP =
-      AtomicIntegerFieldUpdater.newUpdater(UnboundedProcessor.class, "wip");
+  static final AtomicLongFieldUpdater<UnboundedProcessor> STATE =
+      AtomicLongFieldUpdater.newUpdater(UnboundedProcessor.class, "state");
 
   volatile int discardGuard;
 
-  @SuppressWarnings("rawtypes")
   static final AtomicIntegerFieldUpdater<UnboundedProcessor> DISCARD_GUARD =
       AtomicIntegerFieldUpdater.newUpdater(UnboundedProcessor.class, "discardGuard");
 
   volatile long requested;
 
-  @SuppressWarnings("rawtypes")
   static final AtomicLongFieldUpdater<UnboundedProcessor> REQUESTED =
       AtomicLongFieldUpdater.newUpdater(UnboundedProcessor.class, "requested");
 
@@ -98,11 +91,123 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
     return super.scanUnsafe(key);
   }
 
-  void drainRegular(Subscriber<? super T> a) {
-    int missed = 1;
+  public void onNextPrioritized(ByteBuf t) {
+    if (done) {
+      release(t);
+      return;
+    }
 
-    final Queue<T> q = queue;
-    final Queue<T> pq = priorityQueue;
+    if (!priorityQueue.offer(t)) {
+      Throwable ex =
+          Operators.onOperatorError(null, Exceptions.failWithOverflow(), t, currentContext());
+      onError(Operators.onOperatorError(null, ex, t, currentContext()));
+      release(t);
+      return;
+    }
+
+    drain();
+  }
+
+  @Override
+  public void onNext(ByteBuf t) {
+    if (done) {
+      release(t);
+      return;
+    }
+
+    if (!queue.offer(t)) {
+      Throwable ex =
+          Operators.onOperatorError(null, Exceptions.failWithOverflow(), t, currentContext());
+      onError(Operators.onOperatorError(null, ex, t, currentContext()));
+      release(t);
+      return;
+    }
+
+    drain();
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    if (done) {
+      Operators.onErrorDropped(t, currentContext());
+      return;
+    }
+
+    error = t;
+    done = true;
+
+    drain();
+  }
+
+  @Override
+  public void onComplete() {
+    if (done) {
+      return;
+    }
+
+    done = true;
+
+    drain();
+  }
+
+  @Override
+  public void subscribe(CoreSubscriber<? super ByteBuf> actual) {
+    Objects.requireNonNull(actual, "subscribe");
+    if (markSubscribedOnce(this)) {
+      this.actual = actual;
+      actual.onSubscribe(this);
+      drain();
+    } else {
+      Operators.error(
+          actual,
+          new IllegalStateException("UnboundedProcessor " + "allows only a single Subscriber"));
+    }
+  }
+
+  void drain() {
+    long previousState = wipIncrement(this);
+    if (isTerminated(previousState)) {
+      this.clearSafely();
+      return;
+    }
+
+    if (isWorkInProgress(previousState)) {
+      return;
+    }
+
+    final boolean outputFused = this.outputFused;
+    if (isCancelled(previousState) && !outputFused) {
+      clearAndTerminate(this);
+      return;
+    }
+
+    long expectedState = previousState + 1;
+    for (; ; ) {
+      final Subscriber<? super ByteBuf> a = actual;
+      if (a != null) {
+        if (outputFused) {
+          drainFused(expectedState, a);
+        } else {
+          drainRegular(expectedState, a);
+        }
+        return;
+      }
+
+      expectedState = wipRemoveMissing(this, expectedState);
+      if (isCancelled(expectedState)) {
+        clearAndTerminate(this);
+        return;
+      }
+
+      if (!isWorkInProgress(expectedState)) {
+        return;
+      }
+    }
+  }
+
+  void drainRegular(long expectedState, Subscriber<? super ByteBuf> a) {
+    final Queue<ByteBuf> q = queue;
+    final Queue<ByteBuf> pq = priorityQueue;
 
     for (; ; ) {
 
@@ -110,9 +215,8 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
       long e = 0L;
 
       while (r != e) {
-        boolean d = done;
-
-        T t;
+        ByteBuf t;
+        boolean done = this.done;
         boolean empty;
 
         if (!pq.isEmpty()) {
@@ -123,7 +227,10 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
           empty = t == null;
         }
 
-        if (checkTerminated(d, empty, a)) {
+        if (checkTerminated(done, empty, a)) {
+          if (!empty) {
+            release(t);
+          }
           return;
         }
 
@@ -137,7 +244,7 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
       }
 
       if (r == e) {
-        if (checkTerminated(done, q.isEmpty() && pq.isEmpty(), a)) {
+        if (checkTerminated(this.done, q.isEmpty() && pq.isEmpty(), a)) {
           return;
         }
       }
@@ -146,32 +253,26 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
         REQUESTED.addAndGet(this, -e);
       }
 
-      missed = WIP.addAndGet(this, -missed);
-      if (missed == 0) {
+      expectedState = wipRemoveMissing(this, expectedState);
+      if (isCancelled(expectedState)) {
+        clearAndTerminate(this);
+        return;
+      }
+
+      if (!isWorkInProgress(expectedState)) {
         break;
       }
     }
   }
 
-  void drainFused(Subscriber<? super T> a) {
-    int missed = 1;
-
+  void drainFused(long expectedState, Subscriber<? super ByteBuf> a) {
     for (; ; ) {
-
-      if (cancelled) {
-        this.clear();
-        hasDownstream = false;
-        return;
-      }
-
-      boolean d = done;
+      boolean d = this.done;
 
       a.onNext(null);
 
       if (d) {
-        hasDownstream = false;
-
-        Throwable ex = error;
+        Throwable ex = this.error;
         if (ex != null) {
           a.onError(ex);
         } else {
@@ -180,56 +281,32 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
         return;
       }
 
-      missed = WIP.addAndGet(this, -missed);
-      if (missed == 0) {
-        break;
-      }
-    }
-  }
-
-  public void drain() {
-    if (WIP.getAndIncrement(this) != 0) {
-      if (cancelled) {
-        this.clear();
-      }
-      return;
-    }
-
-    int missed = 1;
-
-    for (; ; ) {
-      Subscriber<? super T> a = actual;
-      if (a != null) {
-
-        if (outputFused) {
-          drainFused(a);
-        } else {
-          drainRegular(a);
-        }
+      expectedState = wipRemoveMissing(this, expectedState);
+      if (isCancelled(expectedState)) {
         return;
       }
 
-      missed = WIP.addAndGet(this, -missed);
-      if (missed == 0) {
+      if (!isWorkInProgress(expectedState)) {
         break;
       }
     }
   }
 
-  boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a) {
-    if (cancelled) {
-      this.clear();
-      hasDownstream = false;
+  boolean checkTerminated(boolean done, boolean empty, Subscriber<? super ByteBuf> a) {
+    final long state = this.state;
+    if (isCancelled(state)) {
+      clearAndTerminate(this);
       return true;
     }
-    if (d && empty) {
-      Throwable e = error;
-      hasDownstream = false;
+
+    if (done && empty) {
+      Throwable e = this.error;
       if (e != null) {
         a.onError(e);
       } else {
         a.onComplete();
       }
+      clearAndTerminate(this);
       return true;
     }
 
@@ -238,7 +315,8 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
 
   @Override
   public void onSubscribe(Subscription s) {
-    if (done || cancelled) {
+    final long state = this.state;
+    if (this.done || isTerminated(state) || isCancelled(state)) {
       s.cancel();
     } else {
       s.request(Long.MAX_VALUE);
@@ -252,86 +330,13 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
 
   @Override
   public Context currentContext() {
-    CoreSubscriber<? super T> actual = this.actual;
-    return actual != null ? actual.currentContext() : Context.empty();
-  }
-
-  public void onNextPrioritized(T t) {
-    if (done || cancelled) {
-      Operators.onNextDropped(t, currentContext());
-      release(t);
-      return;
+    final long state = this.state;
+    if (isSubscribedOnce(state) || isTerminated(state)) {
+      CoreSubscriber<? super ByteBuf> actual = this.actual;
+      return actual != null ? actual.currentContext() : Context.empty();
     }
 
-    if (!priorityQueue.offer(t)) {
-      Throwable ex =
-          Operators.onOperatorError(null, Exceptions.failWithOverflow(), t, currentContext());
-      onError(Operators.onOperatorError(null, ex, t, currentContext()));
-      release(t);
-      return;
-    }
-    drain();
-  }
-
-  @Override
-  public void onNext(T t) {
-    if (done || cancelled) {
-      Operators.onNextDropped(t, currentContext());
-      release(t);
-      return;
-    }
-
-    if (!queue.offer(t)) {
-      Throwable ex =
-          Operators.onOperatorError(null, Exceptions.failWithOverflow(), t, currentContext());
-      onError(Operators.onOperatorError(null, ex, t, currentContext()));
-      release(t);
-      return;
-    }
-    drain();
-  }
-
-  @Override
-  public void onError(Throwable t) {
-    if (done || cancelled) {
-      Operators.onErrorDropped(t, currentContext());
-      return;
-    }
-
-    error = t;
-    done = true;
-
-    drain();
-  }
-
-  @Override
-  public void onComplete() {
-    if (done || cancelled) {
-      return;
-    }
-
-    done = true;
-
-    drain();
-  }
-
-  @Override
-  public void subscribe(CoreSubscriber<? super T> actual) {
-    Objects.requireNonNull(actual, "subscribe");
-    if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
-
-      actual.onSubscribe(this);
-      this.actual = actual;
-      if (cancelled) {
-        this.hasDownstream = false;
-      } else {
-        drain();
-      }
-    } else {
-      Operators.error(
-          actual,
-          new IllegalStateException("UnboundedProcessor " + "allows only a single Subscriber"));
-    }
+    return Context.empty();
   }
 
   @Override
@@ -344,21 +349,26 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
 
   @Override
   public void cancel() {
-    if (cancelled) {
+    if (!markCancelled(this)) {
       return;
     }
-    cancelled = true;
 
-    if (WIP.getAndIncrement(this) == 0) {
-      this.clear();
-      hasDownstream = false;
+    if (this.outputFused) {
+      return;
     }
+
+    final long state = wipIncrement(this);
+    if (isWorkInProgress(state)) {
+      return;
+    }
+
+    clearAndTerminate(this);
   }
 
   @Override
   @Nullable
-  public T poll() {
-    Queue<T> pq = this.priorityQueue;
+  public ByteBuf poll() {
+    Queue<ByteBuf> pq = this.priorityQueue;
     if (!pq.isEmpty()) {
       return pq.poll();
     }
@@ -366,36 +376,18 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
   }
 
   @Override
-  public int size() {
-    return priorityQueue.size() + queue.size();
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return priorityQueue.isEmpty() && queue.isEmpty();
-  }
-
-  @Override
   public void clear() {
+    clearAndTerminate(this);
+  }
+
+  void clearSafely() {
     if (DISCARD_GUARD.getAndIncrement(this) != 0) {
       return;
     }
 
     int missed = 1;
-
     for (; ; ) {
-      while (!queue.isEmpty()) {
-        T t = queue.poll();
-        if (t != null) {
-          release(t);
-        }
-      }
-      while (!priorityQueue.isEmpty()) {
-        T t = priorityQueue.poll();
-        if (t != null) {
-          release(t);
-        }
-      }
+      clearUnsafely();
 
       missed = DISCARD_GUARD.addAndGet(this, -missed);
       if (missed == 0) {
@@ -404,10 +396,34 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
     }
   }
 
+  void clearUnsafely() {
+    final Queue<ByteBuf> queue = this.queue;
+    final Queue<ByteBuf> priorityQueue = this.priorityQueue;
+
+    ByteBuf byteBuf;
+    while ((byteBuf = queue.poll()) != null) {
+      release(byteBuf);
+    }
+
+    while ((byteBuf = priorityQueue.poll()) != null) {
+      release(byteBuf);
+    }
+  }
+
+  @Override
+  public int size() {
+    return this.priorityQueue.size() + this.queue.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return this.priorityQueue.isEmpty() && this.queue.isEmpty();
+  }
+
   @Override
   public int requestFusion(int requestedMode) {
     if ((requestedMode & Fuseable.ASYNC) != 0) {
-      outputFused = true;
+      this.outputFused = true;
       return Fuseable.ASYNC;
     }
     return Fuseable.NONE;
@@ -420,18 +436,25 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
 
   @Override
   public boolean isDisposed() {
-    return cancelled || done;
+    final long state = this.state;
+    return isTerminated(state) || isCancelled(state) || done;
   }
 
   @Override
   public boolean isTerminated() {
-    return done;
+    final long state = this.state;
+    return isTerminated(state) || done;
   }
 
   @Override
   @Nullable
   public Throwable getError() {
-    return error;
+    final long state = this.state;
+    if (isTerminated(state) || done) {
+      return this.error;
+    } else {
+      return null;
+    }
   }
 
   @Override
@@ -441,19 +464,130 @@ public final class UnboundedProcessor<T> extends FluxProcessor<T, T>
 
   @Override
   public boolean hasDownstreams() {
-    return hasDownstream;
+    return (this.state & FLAG_SUBSCRIBED_ONCE) == FLAG_SUBSCRIBED_ONCE && this.actual != null;
   }
 
-  void release(T t) {
-    if (t instanceof ReferenceCounted) {
-      ReferenceCounted refCounted = (ReferenceCounted) t;
-      if (refCounted.refCnt() > 0) {
-        try {
-          refCounted.release();
-        } catch (Throwable ex) {
-          // no ops
-        }
+  static void release(ByteBuf byteBuf) {
+    if (byteBuf.refCnt() > 0) {
+      try {
+        byteBuf.release();
+      } catch (Throwable ex) {
+        // no ops
       }
     }
+  }
+
+  static boolean markSubscribedOnce(UnboundedProcessor instance) {
+    for (; ; ) {
+      long state = instance.state;
+
+      if (state == STATE_TERMINATED) {
+        return false;
+      }
+
+      if ((state & FLAG_SUBSCRIBED_ONCE) == FLAG_SUBSCRIBED_ONCE
+          || (state & FLAG_CANCELLED) == FLAG_CANCELLED) {
+        return false;
+      }
+
+      if (STATE.compareAndSet(instance, state, state | FLAG_SUBSCRIBED_ONCE)) {
+        return true;
+      }
+    }
+  }
+
+  static boolean markCancelled(UnboundedProcessor instance) {
+    for (; ; ) {
+      long state = instance.state;
+
+      if (state == STATE_TERMINATED) {
+        return false;
+      }
+
+      if ((state & FLAG_CANCELLED) == FLAG_CANCELLED) {
+        return false;
+      }
+
+      if (STATE.compareAndSet(instance, state, state | FLAG_CANCELLED)) {
+        return true;
+      }
+    }
+  }
+
+  static long wipIncrement(UnboundedProcessor instance) {
+    for (; ; ) {
+      long state = instance.state;
+
+      if (state == STATE_TERMINATED) {
+        return STATE_TERMINATED;
+      }
+
+      final long nextState = state + 1;
+      if ((nextState & MAX_VALUE) == 0) {
+        return state;
+      }
+
+      if (STATE.compareAndSet(instance, state, nextState)) {
+        return state;
+      }
+    }
+  }
+
+  static long wipRemoveMissing(UnboundedProcessor instance, long previousState) {
+    long missed = previousState & MAX_VALUE;
+    boolean outputFused = instance.outputFused;
+    for (; ; ) {
+      long state = instance.state;
+
+      if (state == STATE_TERMINATED) {
+        return STATE_TERMINATED;
+      }
+
+      if (!outputFused && (state & FLAG_CANCELLED) == FLAG_CANCELLED) {
+        return state;
+      }
+
+      final long nextState = state - missed;
+      if (STATE.compareAndSet(instance, state, nextState)) {
+        return nextState;
+      }
+    }
+  }
+
+  static void clearAndTerminate(UnboundedProcessor instance) {
+    final boolean outputFused = instance.outputFused;
+    for (; ; ) {
+      long state = instance.state;
+
+      if (outputFused) {
+        instance.clearSafely();
+      } else {
+        instance.clearUnsafely();
+      }
+
+      if (state == STATE_TERMINATED) {
+        return;
+      }
+
+      if (STATE.compareAndSet(instance, state, STATE_TERMINATED)) {
+        break;
+      }
+    }
+  }
+
+  static boolean isCancelled(long state) {
+    return (state & FLAG_CANCELLED) == FLAG_CANCELLED;
+  }
+
+  static boolean isWorkInProgress(long state) {
+    return (state & MAX_VALUE) != 0;
+  }
+
+  static boolean isTerminated(long state) {
+    return state == STATE_TERMINATED;
+  }
+
+  static boolean isSubscribedOnce(long state) {
+    return (state & FLAG_SUBSCRIBED_ONCE) == FLAG_SUBSCRIBED_ONCE;
   }
 }

--- a/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java
@@ -92,12 +92,12 @@ public final class UnboundedProcessor extends FluxProcessor<ByteBuf, ByteBuf>
   }
 
   public void onNextPrioritized(ByteBuf t) {
-    if (done) {
+    if (this.done) {
       release(t);
       return;
     }
 
-    if (!priorityQueue.offer(t)) {
+    if (!this.priorityQueue.offer(t)) {
       Throwable ex =
           Operators.onOperatorError(null, Exceptions.failWithOverflow(), t, currentContext());
       onError(Operators.onOperatorError(null, ex, t, currentContext()));
@@ -110,12 +110,12 @@ public final class UnboundedProcessor extends FluxProcessor<ByteBuf, ByteBuf>
 
   @Override
   public void onNext(ByteBuf t) {
-    if (done) {
+    if (this.done) {
       release(t);
       return;
     }
 
-    if (!queue.offer(t)) {
+    if (!this.queue.offer(t)) {
       Throwable ex =
           Operators.onOperatorError(null, Exceptions.failWithOverflow(), t, currentContext());
       onError(Operators.onOperatorError(null, ex, t, currentContext()));
@@ -128,24 +128,24 @@ public final class UnboundedProcessor extends FluxProcessor<ByteBuf, ByteBuf>
 
   @Override
   public void onError(Throwable t) {
-    if (done) {
+    if (this.done) {
       Operators.onErrorDropped(t, currentContext());
       return;
     }
 
-    error = t;
-    done = true;
+    this.error = t;
+    this.done = true;
 
     drain();
   }
 
   @Override
   public void onComplete() {
-    if (done) {
+    if (this.done) {
       return;
     }
 
-    done = true;
+    this.done = true;
 
     drain();
   }
@@ -183,7 +183,7 @@ public final class UnboundedProcessor extends FluxProcessor<ByteBuf, ByteBuf>
 
     long expectedState = previousState + 1;
     for (; ; ) {
-      final Subscriber<? super ByteBuf> a = actual;
+      final Subscriber<? super ByteBuf> a = this.actual;
       if (a != null) {
         if (outputFused) {
           drainFused(expectedState, a);
@@ -206,12 +206,12 @@ public final class UnboundedProcessor extends FluxProcessor<ByteBuf, ByteBuf>
   }
 
   void drainRegular(long expectedState, Subscriber<? super ByteBuf> a) {
-    final Queue<ByteBuf> q = queue;
-    final Queue<ByteBuf> pq = priorityQueue;
+    final Queue<ByteBuf> q = this.queue;
+    final Queue<ByteBuf> pq = this.priorityQueue;
 
     for (; ; ) {
 
-      long r = requested;
+      long r = this.requested;
       long e = 0L;
 
       while (r != e) {
@@ -372,7 +372,7 @@ public final class UnboundedProcessor extends FluxProcessor<ByteBuf, ByteBuf>
     if (!pq.isEmpty()) {
       return pq.poll();
     }
-    return queue.poll();
+    return this.queue.poll();
   }
 
   @Override
@@ -437,20 +437,20 @@ public final class UnboundedProcessor extends FluxProcessor<ByteBuf, ByteBuf>
   @Override
   public boolean isDisposed() {
     final long state = this.state;
-    return isTerminated(state) || isCancelled(state) || done;
+    return isTerminated(state) || isCancelled(state) || this.done;
   }
 
   @Override
   public boolean isTerminated() {
     final long state = this.state;
-    return isTerminated(state) || done;
+    return isTerminated(state) || this.done;
   }
 
   @Override
   @Nullable
   public Throwable getError() {
     final long state = this.state;
-    if (isTerminated(state) || done) {
+    if (isTerminated(state) || this.done) {
       return this.error;
     } else {
       return null;

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
@@ -109,7 +109,7 @@ public class UnboundedProcessorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true})
+  @ValueSource(booleans = {true, false})
   public void ensureUnboundedProcessorDisposesQueueProperly(boolean withFusionEnabled) {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
@@ -113,7 +113,7 @@ public class UnboundedProcessorTest {
   public void ensureUnboundedProcessorDisposesQueueProperly(boolean withFusionEnabled) {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < 100000; i++) {
       final UnboundedProcessor unboundedProcessor = new UnboundedProcessor();
 
       final ByteBuf buffer1 = allocator.buffer(1);

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
@@ -109,7 +109,7 @@ public class UnboundedProcessorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
+  @ValueSource(booleans = {true})
   public void ensureUnboundedProcessorDisposesQueueProperly(boolean withFusionEnabled) {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
@@ -134,12 +134,15 @@ public class UnboundedProcessorTest {
                             unboundedProcessor.onNext(buffer1);
                             unboundedProcessor.onNext(buffer2);
                           },
-                          unboundedProcessor::dispose, Schedulers.elastic()),
-                  assertSubscriber::cancel, Schedulers.elastic()),
+                          unboundedProcessor::dispose,
+                          Schedulers.elastic()),
+                  assertSubscriber::cancel,
+                  Schedulers.elastic()),
           () -> {
             assertSubscriber.request(1);
             assertSubscriber.request(1);
-          }, Schedulers.elastic());
+          },
+          Schedulers.elastic());
 
       assertSubscriber.values().forEach(ReferenceCountUtil::safeRelease);
 

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
@@ -131,8 +131,8 @@ public class UnboundedProcessorTest {
     for (int i = 0; i < 100000; i++) {
       final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
 
-      final ByteBuf buffer1 = allocator.buffer();
-      final ByteBuf buffer2 = allocator.buffer();
+      final ByteBuf buffer1 = allocator.buffer(1);
+      final ByteBuf buffer2 = allocator.buffer(2);
 
       final AssertSubscriber<Object> assertSubscriber =
           new AssertSubscriber<>(0)

--- a/rsocket-core/src/test/java/io/rsocket/internal/subscriber/AssertSubscriber.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/subscriber/AssertSubscriber.java
@@ -882,6 +882,10 @@ public class AssertSubscriber<T> implements CoreSubscriber<T>, Subscription {
   public void onNext(T t) {
     if (establishedFusionMode == Fuseable.ASYNC) {
       for (; ; ) {
+        if (isCancelled()) {
+          qs.clear();
+          break;
+        }
         t = qs.poll();
         if (t == null) {
           break;

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
@@ -16,7 +16,6 @@
 
 package io.rsocket.transport.local;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.rsocket.DuplexConnection;
 import io.rsocket.internal.UnboundedProcessor;
@@ -78,8 +77,8 @@ public final class LocalClientTransport implements ClientTransport {
             return Mono.error(new IllegalArgumentException("Could not find server: " + name));
           }
 
-          UnboundedProcessor<ByteBuf> in = new UnboundedProcessor<>();
-          UnboundedProcessor<ByteBuf> out = new UnboundedProcessor<>();
+          UnboundedProcessor in = new UnboundedProcessor();
+          UnboundedProcessor out = new UnboundedProcessor();
           MonoProcessor<Void> closeNotifier = MonoProcessor.create();
 
           server.apply(new LocalDuplexConnection(allocator, out, in, closeNotifier)).subscribe();


### PR DESCRIPTION
closes #947 