### PR TITLE
fixes memory leak and adds test that reproduces live lock on `queue.poll()`

### DIFF
--- a/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
@@ -119,7 +119,7 @@ public class UnboundedProcessorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
+  @ValueSource(booleans = {true})
   public void ensureUnboundedProcessorDisposesQueueProperly(boolean withFusionEnabled) {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
@@ -144,12 +144,15 @@ public class UnboundedProcessorTest {
                             unboundedProcessor.onNext(buffer1);
                             unboundedProcessor.onNext(buffer2);
                           },
-                          unboundedProcessor::dispose, Schedulers.elastic()),
-                  assertSubscriber::cancel, Schedulers.elastic()),
+                          unboundedProcessor::dispose,
+                          Schedulers.elastic()),
+                  assertSubscriber::cancel,
+                  Schedulers.elastic()),
           () -> {
             assertSubscriber.request(1);
             assertSubscriber.request(1);
-          }, Schedulers.elastic());
+          },
+          Schedulers.elastic());
 
       assertSubscriber.values().forEach(ReferenceCountUtil::safeRelease);
 

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
@@ -126,8 +126,8 @@ public class UnboundedProcessorTest {
     for (int i = 0; i < 100000; i++) {
       final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
 
-      final ByteBuf buffer1 = allocator.buffer();
-      final ByteBuf buffer2 = allocator.buffer();
+      final ByteBuf buffer1 = allocator.buffer(1);
+      final ByteBuf buffer2 = allocator.buffer(2);
 
       final AssertSubscriber<Object> assertSubscriber =
           new AssertSubscriber<>(0)

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
@@ -21,7 +21,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import java.util.concurrent.CountDownLatch;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.Fuseable;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.util.RaceTestUtils;
 
 public class UnboundedProcessorTest {
   @Test
@@ -111,6 +116,45 @@ public class UnboundedProcessorTest {
     ByteBuf byteBuf = processor.poll();
 
     Assert.assertEquals(byteBuf.toString(CharsetUtil.UTF_8), "test");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void ensureUnboundedProcessorDisposesQueueProperly(boolean withFusionEnabled) {
+    final LeaksTrackingByteBufAllocator allocator =
+        LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
+    for (int i = 0; i < 100000; i++) {
+      final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
+
+      final ByteBuf buffer1 = allocator.buffer();
+      final ByteBuf buffer2 = allocator.buffer();
+
+      final AssertSubscriber<Object> assertSubscriber =
+          new AssertSubscriber<>(0)
+              .requestedFusionMode(withFusionEnabled ? Fuseable.ANY : Fuseable.NONE);
+
+      unboundedProcessor.subscribe(assertSubscriber);
+
+      RaceTestUtils.race(
+          () ->
+              RaceTestUtils.race(
+                  () ->
+                      RaceTestUtils.race(
+                          () -> {
+                            unboundedProcessor.onNext(buffer1);
+                            unboundedProcessor.onNext(buffer2);
+                          },
+                          unboundedProcessor::dispose, Schedulers.elastic()),
+                  assertSubscriber::cancel, Schedulers.elastic()),
+          () -> {
+            assertSubscriber.request(1);
+            assertSubscriber.request(1);
+          }, Schedulers.elastic());
+
+      assertSubscriber.values().forEach(ReferenceCountUtil::safeRelease);
+
+      allocator.assertHasNoLeaks();
+    }
   }
 
   public void testOnNextAfterSubscribeN(int n) throws Exception {

--- a/rsocket-core/src/test/java/io/rsocket/internal/subscriber/AssertSubscriber.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/subscriber/AssertSubscriber.java
@@ -882,6 +882,10 @@ public class AssertSubscriber<T> implements CoreSubscriber<T>, Subscription {
   public void onNext(T t) {
     if (establishedFusionMode == Fuseable.ASYNC) {
       for (; ; ) {
+        if (isCancelled()) {
+          qs.clear();
+          break;
+        }
         t = qs.poll();
         if (t == null) {
           break;


### PR DESCRIPTION
This PR fixes a spot that may cause a memory leak in UnboundenProcessor, adds some formating convenience to it, and improves testing to ensure no leaks happen on the UnboundenProcessor level

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>