### PR TITLE
Codecs for Per-Stream MimeType Extension

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/metadata/MimeMetadataCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/metadata/MimeMetadataCodec.java
@@ -24,127 +24,122 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * A flyweight class that can be used to encode/decode stream data mime types.
  *
- * A flyweight class that can be used to encode/decode  stream data mime types.
  * <p>For more on the above metadata formats, see the corresponding <a
- *  href="https://github.com/rsocket/rsocket/blob/master/Extensions/PerStreamDataMimeTypesDefinition.md">Per stream
- *    data mime types definition</a>
- *
- **/
+ * href="https://github.com/rsocket/rsocket/blob/master/Extensions/PerStreamDataMimeTypesDefinition.md">Per
+ * stream data mime types definition</a>
+ */
 public class MimeMetadataCodec {
-    static final int STREAM_METADATA_KNOWN_MASK = 0x80; // 1000 0000
-    static final byte STREAM_METADATA_LENGTH_MASK = 0x7F; // 0111 1111
+  static final int STREAM_METADATA_KNOWN_MASK = 0x80; // 1000 0000
+  static final byte STREAM_METADATA_LENGTH_MASK = 0x7F; // 0111 1111
 
-    private MimeMetadataCodec() {}
+  private MimeMetadataCodec() {}
 
-    /**
-     * made up of a single byte: this represents an encoded mime id, which can be further
-     *       decoded using {@link #decode(ByteBuf)}
-     **/
-    public static ByteBuf encodeWellKnowMime(
-            ByteBufAllocator allocator, WellKnownMimeType mimeType) {
-        return allocator.buffer(1, 1)
-                .writeByte(mimeType.getIdentifier() | STREAM_METADATA_KNOWN_MASK);
+  /**
+   * made up of a single byte: this represents an encoded mime id, which can be further decoded
+   * using {@link #decode(ByteBuf)}
+   */
+  public static ByteBuf encodeWellKnowMime(ByteBufAllocator allocator, WellKnownMimeType mimeType) {
+    return allocator.buffer(1, 1).writeByte(mimeType.getIdentifier() | STREAM_METADATA_KNOWN_MASK);
+  }
+
+  /**
+   * Encode {@link WellKnownMimeType} or custom mime type into a newly allocated {@link ByteBuf}
+   *
+   * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
+   * @param mimeType mime type
+   * @return the encoded mime
+   */
+  public static ByteBuf encode(ByteBufAllocator allocator, String mimeType) {
+    if (mimeType == null || mimeType.length() == 0) {
+      throw new IllegalArgumentException("Mime type null or length is zero");
     }
-
-    /**
-     * Encode {@link WellKnownMimeType} or custom mime type  into a newly allocated {@link ByteBuf}
-     * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
-     * @param mimeType  mime type
-     * @return the encoded mime
-     **/
-    public static ByteBuf  encode(
-            ByteBufAllocator allocator,
-            String mimeType) {
-        if (mimeType == null || mimeType.length() == 0) {
-            throw new IllegalArgumentException("Mime type null or length is zero");
-        }
-        WellKnownMimeType wkn = WellKnownMimeType.fromString(mimeType);
-        if (wkn == WellKnownMimeType.UNPARSEABLE_MIME_TYPE) {
-           return encodeCustomMime(allocator,mimeType);
-        }else {
-            return encodeWellKnowMime(allocator,wkn);
-        }
+    WellKnownMimeType wkn = WellKnownMimeType.fromString(mimeType);
+    if (wkn == WellKnownMimeType.UNPARSEABLE_MIME_TYPE) {
+      return encodeCustomMime(allocator, mimeType);
+    } else {
+      return encodeWellKnowMime(allocator, wkn);
     }
+  }
 
-    /**
-     * Encode multiple {@link WellKnownMimeType} or custom mime type  into a newly allocated {@link ByteBuf}
-     * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
-     * @param mimeTypes  mime types
-     * @return the encoded mimes
-     **/
-    public static ByteBuf encode(
-            ByteBufAllocator allocator,
-            List<String> mimeTypes) {
-        if (mimeTypes == null || mimeTypes.size() == 0) {
-            throw new IllegalArgumentException("Mime types empty");
-        }
-        CompositeByteBuf compositeMimeByteBuf = allocator.compositeBuffer();
-        for (String mimeType : mimeTypes) {
-            compositeMimeByteBuf.addComponents(true, encode(allocator, mimeType));
-        }
-        return compositeMimeByteBuf;
+  /**
+   * Encode multiple {@link WellKnownMimeType} or custom mime type into a newly allocated {@link
+   * ByteBuf}
+   *
+   * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
+   * @param mimeTypes mime types
+   * @return the encoded mimes
+   */
+  public static ByteBuf encode(ByteBufAllocator allocator, List<String> mimeTypes) {
+    if (mimeTypes == null || mimeTypes.size() == 0) {
+      throw new IllegalArgumentException("Mime types empty");
     }
-
-    /**
-     * Encode a custom mime type into a newly allocated {@link ByteBuf}.
-     *
-     * <p>This larger representation encodes the mime type representation's length on a single byte,
-     * then the representation itself
-     * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
-     * @param customMime a custom mime type to encode.
-     * @return the encoded mime
-     */
-   public static ByteBuf encodeCustomMime(
-            ByteBufAllocator allocator, String customMime) {
-        ByteBuf mime = allocator.buffer(1 + customMime.length());
-        // reserve 1 byte for the customMime length
-        // /!\ careful not to read that first byte, which is random at this point
-        int writerIndexInitial = mime.writerIndex();
-        mime.writerIndex(writerIndexInitial + 1);
-
-        // write the custom mime in UTF8 but validate it is all ASCII-compatible
-        // (which produces the right result since ASCII chars are still encoded on 1 byte in UTF8)
-        int customMimeLength = ByteBufUtil.writeUtf8(mime, customMime);
-        if (!ByteBufUtil.isText(
-                mime, mime.readerIndex() + 1, customMimeLength, CharsetUtil.US_ASCII)) {
-            mime.release();
-            throw new IllegalArgumentException("custom mime type must be US_ASCII characters only");
-        }
-        if (customMimeLength < 1 || customMimeLength > 128) {
-            mime.release();
-            throw new IllegalArgumentException(
-                    "custom mime type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128");
-        }
-        mime.markWriterIndex();
-        // go back to beginning and write the length
-        // encoded length is one less than actual length, since 0 is never a valid length, which gives
-        // wider representation range
-        mime.writerIndex(writerIndexInitial);
-        mime.writeByte(customMimeLength - 1);
-
-        // go back to post-mime type
-        mime.resetWriterIndex();
-        return mime;
+    CompositeByteBuf compositeMimeByteBuf = allocator.compositeBuffer();
+    for (String mimeType : mimeTypes) {
+      compositeMimeByteBuf.addComponents(true, encode(allocator, mimeType));
     }
+    return compositeMimeByteBuf;
+  }
 
-    /**
-     * Decode mimes from a {@link ByteBuf} that contains at least enough bytes for one mime.
-     * @return decoded mime types
-     **/
-    public static List<String> decode(ByteBuf buf) {
-        List<String> mimes = new ArrayList<>();
-        while(buf.isReadable()){
-            byte mimeIdOrLength = buf.readByte();
-            if ((mimeIdOrLength & STREAM_METADATA_KNOWN_MASK) == STREAM_METADATA_KNOWN_MASK) {
-                byte mimeIdentifier = (byte)( mimeIdOrLength & STREAM_METADATA_LENGTH_MASK);
-                mimes.add(WellKnownMimeType.fromIdentifier(mimeIdentifier).toString());
-            }
-            else{
-                int mimeLen = Byte.toUnsignedInt(mimeIdOrLength) + 1;
-                mimes.add(buf.readCharSequence(mimeLen, CharsetUtil.US_ASCII).toString());
-            }
-        }
-        return mimes;
+  /**
+   * Encode a custom mime type into a newly allocated {@link ByteBuf}.
+   *
+   * <p>This larger representation encodes the mime type representation's length on a single byte,
+   * then the representation itself
+   *
+   * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
+   * @param customMime a custom mime type to encode.
+   * @return the encoded mime
+   */
+  public static ByteBuf encodeCustomMime(ByteBufAllocator allocator, String customMime) {
+    ByteBuf mime = allocator.buffer(1 + customMime.length());
+    // reserve 1 byte for the customMime length
+    // /!\ careful not to read that first byte, which is random at this point
+    int writerIndexInitial = mime.writerIndex();
+    mime.writerIndex(writerIndexInitial + 1);
+
+    // write the custom mime in UTF8 but validate it is all ASCII-compatible
+    // (which produces the right result since ASCII chars are still encoded on 1 byte in UTF8)
+    int customMimeLength = ByteBufUtil.writeUtf8(mime, customMime);
+    if (!ByteBufUtil.isText(mime, mime.readerIndex() + 1, customMimeLength, CharsetUtil.US_ASCII)) {
+      mime.release();
+      throw new IllegalArgumentException("custom mime type must be US_ASCII characters only");
     }
+    if (customMimeLength < 1 || customMimeLength > 128) {
+      mime.release();
+      throw new IllegalArgumentException(
+          "custom mime type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128");
+    }
+    mime.markWriterIndex();
+    // go back to beginning and write the length
+    // encoded length is one less than actual length, since 0 is never a valid length, which gives
+    // wider representation range
+    mime.writerIndex(writerIndexInitial);
+    mime.writeByte(customMimeLength - 1);
+
+    // go back to post-mime type
+    mime.resetWriterIndex();
+    return mime;
+  }
+
+  /**
+   * Decode mimes from a {@link ByteBuf} that contains at least enough bytes for one mime.
+   *
+   * @return decoded mime types
+   */
+  public static List<String> decode(ByteBuf buf) {
+    List<String> mimes = new ArrayList<>();
+    while (buf.isReadable()) {
+      byte mimeIdOrLength = buf.readByte();
+      if ((mimeIdOrLength & STREAM_METADATA_KNOWN_MASK) == STREAM_METADATA_KNOWN_MASK) {
+        byte mimeIdentifier = (byte) (mimeIdOrLength & STREAM_METADATA_LENGTH_MASK);
+        mimes.add(WellKnownMimeType.fromIdentifier(mimeIdentifier).toString());
+      } else {
+        int mimeLen = Byte.toUnsignedInt(mimeIdOrLength) + 1;
+        mimes.add(buf.readCharSequence(mimeLen, CharsetUtil.US_ASCII).toString());
+      }
+    }
+    return mimes;
+  }
 }

--- a/rsocket-core/src/main/java/io/rsocket/metadata/MimeMetadataCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/metadata/MimeMetadataCodec.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rsocket.metadata;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.util.CharsetUtil;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * A flyweight class that can be used to encode/decode  stream data mime types.
+ * <p>For more on the above metadata formats, see the corresponding <a
+ *  href="https://github.com/rsocket/rsocket/blob/master/Extensions/PerStreamDataMimeTypesDefinition.md">Per stream
+ *    data mime types definition</a>
+ *
+ **/
+public class MimeMetadataCodec {
+    static final int STREAM_METADATA_KNOWN_MASK = 0x80; // 1000 0000
+    static final byte STREAM_METADATA_LENGTH_MASK = 0x7F; // 0111 1111
+
+    private MimeMetadataCodec() {}
+
+    /**
+     * made up of a single byte: this represents an encoded mime id, which can be further
+     *       decoded using {@link #decode(ByteBuf)}
+     **/
+    public static ByteBuf encodeWellKnowMime(
+            ByteBufAllocator allocator, WellKnownMimeType mimeType) {
+        return allocator.buffer(1, 1)
+                .writeByte(mimeType.getIdentifier() | STREAM_METADATA_KNOWN_MASK);
+    }
+
+    /**
+     * Encode {@link WellKnownMimeType} or custom mime type  into a newly allocated {@link ByteBuf}
+     * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
+     * @param mimeType  mime type
+     * @return the encoded mime
+     **/
+    public static ByteBuf  encode(
+            ByteBufAllocator allocator,
+            String mimeType) {
+        if (mimeType == null || mimeType.length() == 0) {
+            throw new IllegalArgumentException("Mime type null or length is zero");
+        }
+        WellKnownMimeType wkn = WellKnownMimeType.fromString(mimeType);
+        if (wkn == WellKnownMimeType.UNPARSEABLE_MIME_TYPE) {
+           return encodeCustomMime(allocator,mimeType);
+        }else {
+            return encodeWellKnowMime(allocator,wkn);
+        }
+    }
+
+    /**
+     * Encode multiple {@link WellKnownMimeType} or custom mime type  into a newly allocated {@link ByteBuf}
+     * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
+     * @param mimeTypes  mime types
+     * @return the encoded mimes
+     **/
+    public static ByteBuf encode(
+            ByteBufAllocator allocator,
+            List<String> mimeTypes) {
+        if (mimeTypes == null || mimeTypes.size() == 0) {
+            throw new IllegalArgumentException("Mime types empty");
+        }
+        CompositeByteBuf compositeMimeByteBuf = allocator.compositeBuffer();
+        for (String mimeType : mimeTypes) {
+            compositeMimeByteBuf.addComponents(true, encode(allocator, mimeType));
+        }
+        return compositeMimeByteBuf;
+    }
+
+    /**
+     * Encode a custom mime type into a newly allocated {@link ByteBuf}.
+     *
+     * <p>This larger representation encodes the mime type representation's length on a single byte,
+     * then the representation itself
+     * @param allocator the {@link ByteBufAllocator} to use to create the buffer.
+     * @param customMime a custom mime type to encode.
+     * @return the encoded mime
+     */
+   public static ByteBuf encodeCustomMime(
+            ByteBufAllocator allocator, String customMime) {
+        ByteBuf mime = allocator.buffer(1 + customMime.length());
+        // reserve 1 byte for the customMime length
+        // /!\ careful not to read that first byte, which is random at this point
+        int writerIndexInitial = mime.writerIndex();
+        mime.writerIndex(writerIndexInitial + 1);
+
+        // write the custom mime in UTF8 but validate it is all ASCII-compatible
+        // (which produces the right result since ASCII chars are still encoded on 1 byte in UTF8)
+        int customMimeLength = ByteBufUtil.writeUtf8(mime, customMime);
+        if (!ByteBufUtil.isText(
+                mime, mime.readerIndex() + 1, customMimeLength, CharsetUtil.US_ASCII)) {
+            mime.release();
+            throw new IllegalArgumentException("custom mime type must be US_ASCII characters only");
+        }
+        if (customMimeLength < 1 || customMimeLength > 128) {
+            mime.release();
+            throw new IllegalArgumentException(
+                    "custom mime type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128");
+        }
+        mime.markWriterIndex();
+        // go back to beginning and write the length
+        // encoded length is one less than actual length, since 0 is never a valid length, which gives
+        // wider representation range
+        mime.writerIndex(writerIndexInitial);
+        mime.writeByte(customMimeLength - 1);
+
+        // go back to post-mime type
+        mime.resetWriterIndex();
+        return mime;
+    }
+
+    /**
+     * Decode mimes from a {@link ByteBuf} that contains at least enough bytes for one mime.
+     * @return decoded mime types
+     **/
+    public static List<String> decode(ByteBuf buf) {
+        List<String> mimes = new ArrayList<>();
+        while(buf.isReadable()){
+            byte mimeIdOrLength = buf.readByte();
+            if ((mimeIdOrLength & STREAM_METADATA_KNOWN_MASK) == STREAM_METADATA_KNOWN_MASK) {
+                byte mimeIdentifier = (byte)( mimeIdOrLength & STREAM_METADATA_LENGTH_MASK);
+                mimes.add(WellKnownMimeType.fromIdentifier(mimeIdentifier).toString());
+            }
+            else{
+                int mimeLen = Byte.toUnsignedInt(mimeIdOrLength) + 1;
+                mimes.add(buf.readCharSequence(mimeLen, CharsetUtil.US_ASCII).toString());
+            }
+        }
+        return mimes;
+    }
+}

--- a/rsocket-core/src/main/java/io/rsocket/metadata/MimeTypeMetadataCodec.java
+++ b/rsocket-core/src/main/java/io/rsocket/metadata/MimeTypeMetadataCodec.java
@@ -60,7 +60,7 @@ public class MimeTypeMetadataCodec {
     }
     WellKnownMimeType wkn = WellKnownMimeType.fromString(mimeType);
     if (wkn == WellKnownMimeType.UNPARSEABLE_MIME_TYPE) {
-      return encodeCustomMime(allocator, mimeType);
+      return encodeCustomMimeType(allocator, mimeType);
     } else {
       return encode(allocator, wkn);
     }
@@ -92,18 +92,18 @@ public class MimeTypeMetadataCodec {
    * then the representation itself.
    *
    * @param allocator the {@link ByteBufAllocator} to use to create the buffer
-   * @param customMime a custom mime type to encode
-   * @return the encoded mime
+   * @param customMimeType a custom mime type to encode
+   * @return the encoded mime type
    */
-  private static ByteBuf encodeCustomMime(ByteBufAllocator allocator, String customMime) {
-    ByteBuf mime = allocator.buffer(1 + customMime.length());
+  private static ByteBuf encodeCustomMimeType(ByteBufAllocator allocator, String customMimeType) {
+    ByteBuf mime = allocator.buffer(1 + customMimeType.length());
     // reserve 1 byte for the customMime length
     // /!\ careful not to read that first byte, which is random at this point
     mime.writerIndex(1);
 
     // write the custom mime in UTF8 but validate it is all ASCII-compatible
     // (which produces the right result since ASCII chars are still encoded on 1 byte in UTF8)
-    int customMimeLength = ByteBufUtil.writeUtf8(mime, customMime);
+    int customMimeLength = ByteBufUtil.writeUtf8(mime, customMimeType);
     if (!ByteBufUtil.isText(mime, mime.readerIndex() + 1, customMimeLength, CharsetUtil.US_ASCII)) {
       mime.release();
       throw new IllegalArgumentException("custom mime type must be US_ASCII characters only");

--- a/rsocket-core/src/test/java/io/rsocket/metadata/MimeMetadataCodecTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/metadata/MimeMetadataCodecTest.java
@@ -18,39 +18,36 @@ package io.rsocket.metadata;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class MimeMetadataCodecTest {
 
   @Test
-  public void customMime() {
-    String customMime = "aaa/bb";
-    ByteBuf byteBuf = MimeMetadataCodec.encodeCustomMime(ByteBufAllocator.DEFAULT, customMime);
-    List<String> mimes = MimeMetadataCodec.decode(byteBuf);
-    Assert.assertTrue(mimes.size() == 1);
-    Assert.assertEquals(customMime, mimes.get(0));
+  public void customMimeType() {
+    String customMimeType = "aaa/bb";
+    ByteBuf byteBuf = MimeTypeMetadataCodec.encode(ByteBufAllocator.DEFAULT, customMimeType);
+    List<String> mimeTypes = MimeTypeMetadataCodec.decode(byteBuf);
+    Assertions.assertThat(mimeTypes.size()).isEqualTo(1);
+    Assertions.assertThat(customMimeType).isEqualTo(mimeTypes.get(0));
   }
 
   @Test
-  public void wellKnowMime() {
+  public void wellKnowMimeType() {
     WellKnownMimeType wellKnownMimeType = WellKnownMimeType.APPLICATION_HESSIAN;
-    ByteBuf byteBuf =
-        MimeMetadataCodec.encodeWellKnowMime(ByteBufAllocator.DEFAULT, wellKnownMimeType);
-    List<String> mimes = MimeMetadataCodec.decode(byteBuf);
-    Assert.assertTrue(mimes.size() == 1);
-    Assert.assertEquals(wellKnownMimeType, WellKnownMimeType.fromString(mimes.get(0)));
+    ByteBuf byteBuf = MimeTypeMetadataCodec.encode(ByteBufAllocator.DEFAULT, wellKnownMimeType);
+    List<String> mimes = MimeTypeMetadataCodec.decode(byteBuf);
+    Assertions.assertThat(mimes.size()).isEqualTo(1);
+    Assertions.assertThat(wellKnownMimeType).isEqualTo(WellKnownMimeType.fromString(mimes.get(0)));
   }
 
   @Test
-  public void multipleAndMixTypeMime() {
-    List<String> mimes =
+  public void multipleAndMixMimeType() {
+    List<String> mimeTypes =
         Lists.newArrayList("aaa/bbb", WellKnownMimeType.APPLICATION_HESSIAN.getString());
-    ByteBuf byteBuf = MimeMetadataCodec.encode(ByteBufAllocator.DEFAULT, mimes);
-    List<String> decodedMimes = MimeMetadataCodec.decode(byteBuf);
-    Assert.assertTrue(mimes.size() == 2);
-    Assert.assertTrue(mimes.containsAll(decodedMimes));
-    Assert.assertTrue(decodedMimes.containsAll(mimes));
+    ByteBuf byteBuf = MimeTypeMetadataCodec.encode(ByteBufAllocator.DEFAULT, mimeTypes);
+    List<String> decodedMimeTypes = MimeTypeMetadataCodec.decode(byteBuf);
+    Assertions.assertThat(decodedMimeTypes).isEqualTo(mimeTypes);
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/metadata/MimeMetadataCodecTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/metadata/MimeMetadataCodecTest.java
@@ -17,39 +17,40 @@ package io.rsocket.metadata;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import java.util.List;
 import org.assertj.core.util.Lists;
 import org.junit.Assert;
 import org.junit.Test;
-import java.util.List;
 
 public class MimeMetadataCodecTest {
 
-    @Test
-    public void customMime() {
-        String customMime = "aaa/bb";
-        ByteBuf byteBuf = MimeMetadataCodec.encodeCustomMime(ByteBufAllocator.DEFAULT, customMime);
-        List<String> mimes = MimeMetadataCodec.decode(byteBuf);
-        Assert.assertTrue(mimes.size() == 1);
-        Assert.assertEquals(customMime, mimes.get(0));
-    }
+  @Test
+  public void customMime() {
+    String customMime = "aaa/bb";
+    ByteBuf byteBuf = MimeMetadataCodec.encodeCustomMime(ByteBufAllocator.DEFAULT, customMime);
+    List<String> mimes = MimeMetadataCodec.decode(byteBuf);
+    Assert.assertTrue(mimes.size() == 1);
+    Assert.assertEquals(customMime, mimes.get(0));
+  }
 
-    @Test
-    public void wellKnowMime() {
-        WellKnownMimeType wellKnownMimeType = WellKnownMimeType.APPLICATION_HESSIAN;
-        ByteBuf byteBuf = MimeMetadataCodec.encodeWellKnowMime(ByteBufAllocator.DEFAULT, wellKnownMimeType);
-        List<String> mimes = MimeMetadataCodec.decode(byteBuf);
-        Assert.assertTrue(mimes.size() == 1);
-        Assert.assertEquals(wellKnownMimeType, WellKnownMimeType.fromString(mimes.get(0)));
-    }
+  @Test
+  public void wellKnowMime() {
+    WellKnownMimeType wellKnownMimeType = WellKnownMimeType.APPLICATION_HESSIAN;
+    ByteBuf byteBuf =
+        MimeMetadataCodec.encodeWellKnowMime(ByteBufAllocator.DEFAULT, wellKnownMimeType);
+    List<String> mimes = MimeMetadataCodec.decode(byteBuf);
+    Assert.assertTrue(mimes.size() == 1);
+    Assert.assertEquals(wellKnownMimeType, WellKnownMimeType.fromString(mimes.get(0)));
+  }
 
-    @Test
-    public void multipleAndMixTypeMime() {
-        List<String> mimes = Lists.newArrayList("aaa/bbb", WellKnownMimeType.APPLICATION_HESSIAN.getString());
-        ByteBuf byteBuf = MimeMetadataCodec.encode(ByteBufAllocator.DEFAULT, mimes);
-        List<String> decodedMimes = MimeMetadataCodec.decode(byteBuf);
-        Assert.assertTrue(mimes.size() == 2);
-        Assert.assertTrue(mimes.containsAll(decodedMimes));
-        Assert.assertTrue(decodedMimes.containsAll(mimes));
-    }
-
+  @Test
+  public void multipleAndMixTypeMime() {
+    List<String> mimes =
+        Lists.newArrayList("aaa/bbb", WellKnownMimeType.APPLICATION_HESSIAN.getString());
+    ByteBuf byteBuf = MimeMetadataCodec.encode(ByteBufAllocator.DEFAULT, mimes);
+    List<String> decodedMimes = MimeMetadataCodec.decode(byteBuf);
+    Assert.assertTrue(mimes.size() == 2);
+    Assert.assertTrue(mimes.containsAll(decodedMimes));
+    Assert.assertTrue(decodedMimes.containsAll(mimes));
+  }
 }

--- a/rsocket-core/src/test/java/io/rsocket/metadata/MimeMetadataCodecTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/metadata/MimeMetadataCodecTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rsocket.metadata;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import org.assertj.core.util.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.List;
+
+public class MimeMetadataCodecTest {
+
+    @Test
+    public void customMime() {
+        String customMime = "aaa/bb";
+        ByteBuf byteBuf = MimeMetadataCodec.encodeCustomMime(ByteBufAllocator.DEFAULT, customMime);
+        List<String> mimes = MimeMetadataCodec.decode(byteBuf);
+        Assert.assertTrue(mimes.size() == 1);
+        Assert.assertEquals(customMime, mimes.get(0));
+    }
+
+    @Test
+    public void wellKnowMime() {
+        WellKnownMimeType wellKnownMimeType = WellKnownMimeType.APPLICATION_HESSIAN;
+        ByteBuf byteBuf = MimeMetadataCodec.encodeWellKnowMime(ByteBufAllocator.DEFAULT, wellKnownMimeType);
+        List<String> mimes = MimeMetadataCodec.decode(byteBuf);
+        Assert.assertTrue(mimes.size() == 1);
+        Assert.assertEquals(wellKnownMimeType, WellKnownMimeType.fromString(mimes.get(0)));
+    }
+
+    @Test
+    public void multipleAndMixTypeMime() {
+        List<String> mimes = Lists.newArrayList("aaa/bbb", WellKnownMimeType.APPLICATION_HESSIAN.getString());
+        ByteBuf byteBuf = MimeMetadataCodec.encode(ByteBufAllocator.DEFAULT, mimes);
+        List<String> decodedMimes = MimeMetadataCodec.decode(byteBuf);
+        Assert.assertTrue(mimes.size() == 2);
+        Assert.assertTrue(mimes.containsAll(decodedMimes));
+        Assert.assertTrue(decodedMimes.containsAll(mimes));
+    }
+
+}


### PR DESCRIPTION
A codec for stream data MIME types metadata and Spring-projects/spring-framework#26379 depend on this implementation
Fix issue #996
### Motivation:

There is currently no encoding and decoding support for the [ PerStreamDataMimeTypesDefinition](https://github.com/rsocket/rsocket/blob/master/Extensions/PerStreamDataMimeTypesDefinition.md)  extension




