### PR TITLE
adds jcstress for requester and responder operators

### DIFF
--- a/rsocket-core/build.gradle
+++ b/rsocket-core/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest-library'
 
+    jcstressImplementation(project(":rsocket-test"))
     jcstressImplementation "ch.qos.logback:logback-classic"
 }
 

--- a/rsocket-core/src/jcstress/java/io/rsocket/core/FireAndForgetRequesterMonoStressTest.java
+++ b/rsocket-core/src/jcstress/java/io/rsocket/core/FireAndForgetRequesterMonoStressTest.java
@@ -1,0 +1,115 @@
+package io.rsocket.core;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+import io.netty.buffer.ByteBuf;
+import io.rsocket.test.TestDuplexConnection;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLL_Result;
+
+public abstract class FireAndForgetRequesterMonoStressTest {
+
+  abstract static class BaseStressTest {
+
+    final StressSubscriber<ByteBuf> outboundSubscriber = new StressSubscriber<>();
+
+    final StressSubscriber<Void> stressSubscriber = new StressSubscriber<>();
+
+    final TestDuplexConnection testDuplexConnection =
+        new TestDuplexConnection(this.outboundSubscriber, false);
+
+    final TestRequesterResponderSupport requesterResponderSupport =
+        new TestRequesterResponderSupport(testDuplexConnection, StreamIdSupplier.clientSupplier());
+
+    final FireAndForgetRequesterMono source = source();
+
+    abstract FireAndForgetRequesterMono source();
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 3, 1, 0"},
+      expect = ACCEPTABLE)
+  @State
+  public static class TwoSubscribesRaceStressTest extends BaseStressTest {
+
+    final StressSubscriber<Void> stressSubscriber1 = new StressSubscriber<>();
+
+    @Override
+    FireAndForgetRequesterMono source() {
+      return new FireAndForgetRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Actor
+    public void subscribe1() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void subscribe2() {
+      this.source.subscribe(this.stressSubscriber1);
+    }
+
+    @Arbiter
+    public void arbiter(LLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber1.onCompleteCalls
+              + this.stressSubscriber1.onErrorCalls * 2;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.source.payload.refCnt();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 1, 1, 0"},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first")
+  @State
+  public static class SubscribeAndCancelRaceStressTest extends BaseStressTest {
+
+    @Override
+    FireAndForgetRequesterMono source() {
+      return new FireAndForgetRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Actor
+    public void subscribe() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Arbiter
+    public void arbiter(LLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 = this.stressSubscriber.onCompleteCalls + this.stressSubscriber.onErrorCalls * 2;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.source.payload.refCnt();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+}

--- a/rsocket-core/src/jcstress/java/io/rsocket/core/RequestResponseRequesterMonoStressTest.java
+++ b/rsocket-core/src/jcstress/java/io/rsocket/core/RequestResponseRequesterMonoStressTest.java
@@ -1,0 +1,650 @@
+package io.rsocket.core;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.rsocket.Payload;
+import io.rsocket.frame.FrameHeaderCodec;
+import io.rsocket.frame.LeaseFrameCodec;
+import io.rsocket.frame.PayloadFrameCodec;
+import io.rsocket.test.TestDuplexConnection;
+import java.util.stream.IntStream;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLLLL_Result;
+import org.openjdk.jcstress.infra.results.LLLLL_Result;
+import org.openjdk.jcstress.infra.results.LLLL_Result;
+
+public abstract class RequestResponseRequesterMonoStressTest {
+
+  abstract static class BaseStressTest {
+
+    final StressSubscriber<ByteBuf> outboundSubscriber = new StressSubscriber<>();
+
+    final StressSubscriber<Payload> stressSubscriber = new StressSubscriber<>(initialRequest());
+
+    final TestDuplexConnection testDuplexConnection =
+        new TestDuplexConnection(this.outboundSubscriber, false);
+
+    final RequesterLeaseTracker requesterLeaseTracker;
+
+    final TestRequesterResponderSupport requesterResponderSupport;
+
+    final RequestResponseRequesterMono source;
+
+    BaseStressTest(RequesterLeaseTracker requesterLeaseTracker) {
+      this.requesterLeaseTracker = requesterLeaseTracker;
+      this.requesterResponderSupport =
+          new TestRequesterResponderSupport(
+              testDuplexConnection, StreamIdSupplier.clientSupplier(), requesterLeaseTracker);
+      this.source = source();
+    }
+
+    abstract RequestResponseRequesterMono source();
+
+    abstract long initialRequest();
+  }
+
+  abstract static class BaseStressTestWithLease extends BaseStressTest {
+
+    BaseStressTestWithLease(int maximumAllowedAwaitingPermitHandlersNumber) {
+      super(new RequesterLeaseTracker("test", maximumAllowedAwaitingPermitHandlersNumber));
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 3, 1, 0, 0"},
+      expect = ACCEPTABLE)
+  @State
+  public static class TwoSubscribesRaceStressTest extends BaseStressTestWithLease {
+
+    final StressSubscriber<Payload> stressSubscriber1 = new StressSubscriber<>();
+
+    public TwoSubscribesRaceStressTest() {
+      super(0);
+    }
+
+    @Override
+    RequestResponseRequesterMono source() {
+      return new RequestResponseRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    long initialRequest() {
+      return Long.MAX_VALUE;
+    }
+
+    // init
+    {
+      final ByteBuf leaseFrame =
+          LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+    }
+
+    @Actor
+    public void subscribe1() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void subscribe2() {
+      this.source.subscribe(this.stressSubscriber1);
+    }
+
+    @Arbiter
+    public void arbiter(LLLLL_Result r) {
+      final ByteBuf nextFrame =
+          PayloadFrameCodec.encode(
+              this.testDuplexConnection.alloc(),
+              1,
+              false,
+              true,
+              true,
+              null,
+              ByteBufUtil.writeUtf8(this.testDuplexConnection.alloc(), "response-data"));
+      this.source.handleNext(nextFrame, false, true);
+      nextFrame.release();
+
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber1.onCompleteCalls
+              + this.stressSubscriber1.onErrorCalls * 2;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.requesterLeaseTracker.availableRequests;
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+      this.stressSubscriber.values.forEach(Payload::release);
+      this.stressSubscriber1.values.forEach(Payload::release);
+
+      r.r5 = this.source.payload.refCnt() + nextFrame.refCnt();
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 0, 2, 0, 0, " + (0x04 + 2 * 0x09)},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first")
+  @State
+  public static class SubscribeAndRequestAndCancelRaceStressTest extends BaseStressTestWithLease {
+
+    public SubscribeAndRequestAndCancelRaceStressTest() {
+      super(0);
+    }
+
+    @Override
+    RequestResponseRequesterMono source() {
+      return new RequestResponseRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    long initialRequest() {
+      return 0;
+    }
+
+    // init
+    {
+      final ByteBuf leaseFrame =
+          LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+    }
+
+    @Actor
+    public void subscribe() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Actor
+    public void request() {
+      this.stressSubscriber.request(1);
+      this.stressSubscriber.request(Long.MAX_VALUE);
+      this.stressSubscriber.request(1);
+    }
+
+    @Arbiter
+    public void arbiter(LLLLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 = this.stressSubscriber.onCompleteCalls + this.stressSubscriber.onErrorCalls * 2;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.requesterLeaseTracker.availableRequests;
+      r.r5 = this.source.payload.refCnt();
+
+      r.r6 =
+          IntStream.range(0, this.outboundSubscriber.values.size())
+              .map(
+                  i ->
+                      FrameHeaderCodec.frameType(this.outboundSubscriber.values.get(i))
+                              .getEncodedType()
+                          * (i + 1))
+              .sum();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 0, 2, 0, 0, " + (0x04 + 2 * 0x09)},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first")
+  @State
+  public static class SubscribeAndRequestAndCancelWithDeferredLeaseRaceStressTest
+      extends BaseStressTestWithLease {
+
+    final ByteBuf leaseFrame =
+        LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+
+    public SubscribeAndRequestAndCancelWithDeferredLeaseRaceStressTest() {
+      super(1);
+    }
+
+    @Override
+    RequestResponseRequesterMono source() {
+      return new RequestResponseRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    long initialRequest() {
+      return 0;
+    }
+
+    @Actor
+    public void issueLease() {
+      final ByteBuf leaseFrame = this.leaseFrame;
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+    }
+
+    @Actor
+    public void subscribe() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Actor
+    public void request() {
+      this.stressSubscriber.request(1);
+      this.stressSubscriber.request(Long.MAX_VALUE);
+      this.stressSubscriber.request(1);
+    }
+
+    @Arbiter
+    public void arbiter(LLLLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 = this.stressSubscriber.onCompleteCalls + this.stressSubscriber.onErrorCalls * 2;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.requesterLeaseTracker.availableRequests;
+      r.r5 = this.source.payload.refCnt();
+      r.r6 =
+          IntStream.range(0, this.outboundSubscriber.values.size())
+              .map(
+                  i ->
+                      FrameHeaderCodec.frameType(this.outboundSubscriber.values.get(i))
+                              .getEncodedType()
+                          * (i + 1))
+              .sum();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 0, 2, 0, 0, " + (0x04 + 2 * 0x09)},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 2, 0, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "NoLeaseError delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first or in between")
+  @Outcome(
+      id = {"-9223372036854775808, 3, 0, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc =
+          "cancellation happened after lease permit requested but before it was actually decided and in the case when no lease are available. Error is dropped")
+  @State
+  public static class SubscribeAndRequestAndCancelWithDeferredLease2RaceStressTest
+      extends BaseStressTestWithLease {
+
+    final ByteBuf leaseFrame =
+        LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+
+    SubscribeAndRequestAndCancelWithDeferredLease2RaceStressTest() {
+      super(0);
+    }
+
+    @Override
+    RequestResponseRequesterMono source() {
+      return new RequestResponseRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    long initialRequest() {
+      return 0;
+    }
+
+    @Actor
+    public void issueLease() {
+      final ByteBuf leaseFrame = this.leaseFrame;
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+    }
+
+    @Actor
+    public void subscribe() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Actor
+    public void request() {
+      this.stressSubscriber.request(1);
+      this.stressSubscriber.request(Long.MAX_VALUE);
+      this.stressSubscriber.request(1);
+    }
+
+    @Arbiter
+    public void arbiter(LLLLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber.droppedErrors.size() * 3;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.requesterLeaseTracker.availableRequests;
+      r.r5 = this.source.payload.refCnt();
+      r.r6 =
+          IntStream.range(0, this.outboundSubscriber.values.size())
+              .map(
+                  i ->
+                      FrameHeaderCodec.frameType(this.outboundSubscriber.values.get(i))
+                              .getEncodedType()
+                          * (i + 1))
+              .sum();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 0, 2, 0, " + (0x04 + 2 * 0x09)},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first")
+  @State
+  public static class SubscribeAndRequestAndCancel extends BaseStressTest {
+
+    SubscribeAndRequestAndCancel() {
+      super(null);
+    }
+
+    @Override
+    RequestResponseRequesterMono source() {
+      return new RequestResponseRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    long initialRequest() {
+      return 0;
+    }
+
+    @Actor
+    public void subscribe() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Actor
+    public void request() {
+      this.stressSubscriber.request(1);
+      this.stressSubscriber.request(Long.MAX_VALUE);
+      this.stressSubscriber.request(1);
+    }
+
+    @Arbiter
+    public void arbiter(LLLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber.droppedErrors.size() * 3;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.source.payload.refCnt();
+      r.r5 =
+          IntStream.range(0, this.outboundSubscriber.values.size())
+              .map(
+                  i ->
+                      FrameHeaderCodec.frameType(this.outboundSubscriber.values.get(i))
+                              .getEncodedType()
+                          * (i + 1))
+              .sum();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 1, 1, 0"},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first or in between")
+  @State
+  public static class CancelWithInboundNextRaceStressTest extends BaseStressTestWithLease {
+
+    final ByteBuf nextFrame =
+        PayloadFrameCodec.encode(
+            this.testDuplexConnection.alloc(),
+            1,
+            false,
+            true,
+            true,
+            null,
+            ByteBufUtil.writeUtf8(this.testDuplexConnection.alloc(), "response-data"));
+
+    CancelWithInboundNextRaceStressTest() {
+      super(0);
+    }
+
+    @Override
+    RequestResponseRequesterMono source() {
+      return new RequestResponseRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    // init
+    {
+      final ByteBuf leaseFrame =
+          LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Override
+    long initialRequest() {
+      return 1;
+    }
+
+    @Actor
+    public void inboundNext() {
+      this.source.handleNext(this.nextFrame, false, true);
+      this.nextFrame.release();
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Arbiter
+    public void arbiter(LLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber.droppedErrors.size() * 3;
+      r.r3 = this.stressSubscriber.onNextCalls;
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+      this.stressSubscriber.values.forEach(Payload::release);
+
+      r.r4 = this.source.payload.refCnt() + this.nextFrame.refCnt();
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first or in between")
+  @State
+  public static class CancelWithInboundCompleteRaceStressTest extends BaseStressTestWithLease {
+
+    CancelWithInboundCompleteRaceStressTest() {
+      super(0);
+    }
+
+    @Override
+    RequestResponseRequesterMono source() {
+      return new RequestResponseRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    // init
+    {
+      final ByteBuf leaseFrame =
+          LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Override
+    long initialRequest() {
+      return 1;
+    }
+
+    @Actor
+    public void inboundComplete() {
+      this.source.handleComplete();
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Arbiter
+    public void arbiter(LLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber.droppedErrors.size() * 3;
+      r.r3 = this.stressSubscriber.onNextCalls;
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+      this.stressSubscriber.values.forEach(Payload::release);
+
+      r.r4 = this.source.payload.refCnt();
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 2, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 3, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first. inbound error dropped")
+  @State
+  public static class CancelWithInboundErrorRaceStressTest extends BaseStressTestWithLease {
+
+    static final RuntimeException ERROR = new RuntimeException("Test");
+
+    CancelWithInboundErrorRaceStressTest() {
+      super(0);
+    }
+
+    @Override
+    RequestResponseRequesterMono source() {
+      return new RequestResponseRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    // init
+    {
+      final ByteBuf leaseFrame =
+          LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Override
+    long initialRequest() {
+      return 1;
+    }
+
+    @Actor
+    public void inboundError() {
+      this.source.handleError(ERROR);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Arbiter
+    public void arbiter(LLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber.droppedErrors.size() * 3;
+      r.r3 = this.stressSubscriber.onNextCalls;
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+      this.stressSubscriber.values.forEach(Payload::release);
+
+      r.r4 = this.source.payload.refCnt();
+    }
+  }
+}

--- a/rsocket-core/src/jcstress/java/io/rsocket/core/SlowFireAndForgetRequesterMonoStressTest.java
+++ b/rsocket-core/src/jcstress/java/io/rsocket/core/SlowFireAndForgetRequesterMonoStressTest.java
@@ -1,0 +1,288 @@
+package io.rsocket.core;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+import io.netty.buffer.ByteBuf;
+import io.rsocket.frame.LeaseFrameCodec;
+import io.rsocket.test.TestDuplexConnection;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LLLLL_Result;
+
+public abstract class SlowFireAndForgetRequesterMonoStressTest {
+
+  abstract static class BaseStressTest {
+
+    final StressSubscriber<ByteBuf> outboundSubscriber = new StressSubscriber<>();
+
+    final StressSubscriber<Void> stressSubscriber = new StressSubscriber<>();
+
+    final TestDuplexConnection testDuplexConnection =
+        new TestDuplexConnection(this.outboundSubscriber, false);
+
+    final RequesterLeaseTracker requesterLeaseTracker =
+        new RequesterLeaseTracker("test", maximumAllowedAwaitingPermitHandlersNumber());
+
+    final TestRequesterResponderSupport requesterResponderSupport =
+        new TestRequesterResponderSupport(
+            testDuplexConnection, StreamIdSupplier.clientSupplier(), requesterLeaseTracker);
+
+    final SlowFireAndForgetRequesterMono source = source();
+
+    abstract SlowFireAndForgetRequesterMono source();
+
+    abstract int maximumAllowedAwaitingPermitHandlersNumber();
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 3, 1, 0, 0"},
+      expect = ACCEPTABLE)
+  @State
+  public static class TwoSubscribesRaceStressTest extends BaseStressTest {
+
+    final StressSubscriber<Void> stressSubscriber1 = new StressSubscriber<>();
+
+    @Override
+    SlowFireAndForgetRequesterMono source() {
+      return new SlowFireAndForgetRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    int maximumAllowedAwaitingPermitHandlersNumber() {
+      return 0;
+    }
+
+    // init
+    {
+      final ByteBuf leaseFrame =
+          LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+    }
+
+    @Actor
+    public void subscribe1() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void subscribe2() {
+      this.source.subscribe(this.stressSubscriber1);
+    }
+
+    @Arbiter
+    public void arbiter(LLLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber1.onCompleteCalls
+              + this.stressSubscriber1.onErrorCalls * 2;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.requesterLeaseTracker.availableRequests;
+      r.r5 = this.source.payload.refCnt();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 1, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 1, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened in between")
+  @State
+  public static class SubscribeAndCancelRaceStressTest extends BaseStressTest {
+
+    @Override
+    SlowFireAndForgetRequesterMono source() {
+      return new SlowFireAndForgetRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    int maximumAllowedAwaitingPermitHandlersNumber() {
+      return 0;
+    }
+
+    // init
+    {
+      final ByteBuf leaseFrame =
+          LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+    }
+
+    @Actor
+    public void subscribe() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Arbiter
+    public void arbiter(LLLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 = this.stressSubscriber.onCompleteCalls + this.stressSubscriber.onErrorCalls * 2;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.requesterLeaseTracker.availableRequests;
+      r.r5 = this.source.payload.refCnt();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 1, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened in between")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 1, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first")
+  @State
+  public static class SubscribeAndCancelWithDeferredLeaseRaceStressTest extends BaseStressTest {
+
+    final ByteBuf leaseFrame =
+        LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+
+    @Override
+    SlowFireAndForgetRequesterMono source() {
+      return new SlowFireAndForgetRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    int maximumAllowedAwaitingPermitHandlersNumber() {
+      return 1;
+    }
+
+    @Actor
+    public void issueLease() {
+      final ByteBuf leaseFrame = this.leaseFrame;
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+    }
+
+    @Actor
+    public void subscribe() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Arbiter
+    public void arbiter(LLLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 = this.stressSubscriber.onCompleteCalls + this.stressSubscriber.onErrorCalls * 2;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.requesterLeaseTracker.availableRequests;
+      r.r5 = this.source.payload.refCnt();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"-9223372036854775808, 1, 1, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "frame delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 2, 0, 1, 0"},
+      expect = ACCEPTABLE,
+      desc = "no lease error delivered before cancellation")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 1, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened first")
+  @Outcome(
+      id = {"-9223372036854775808, 0, 0, 0, 0"},
+      expect = ACCEPTABLE,
+      desc = "cancellation happened in between")
+  @Outcome(
+      id = {"-9223372036854775808, 3, 0, 1, 0"},
+      expect = ACCEPTABLE,
+      desc =
+          "cancellation happened after lease permit requested but before it was actually decided and in the case when no lease are available. Error is dropped")
+  @State
+  public static class SubscribeAndCancelWithDeferredLease2RaceStressTest extends BaseStressTest {
+
+    final ByteBuf leaseFrame =
+        LeaseFrameCodec.encode(this.testDuplexConnection.alloc(), 1000, 1, null);
+
+    @Override
+    SlowFireAndForgetRequesterMono source() {
+      return new SlowFireAndForgetRequesterMono(
+          UnpooledByteBufPayload.create(
+              "test-data", "test-metadata", this.requesterResponderSupport.getAllocator()),
+          this.requesterResponderSupport);
+    }
+
+    @Override
+    int maximumAllowedAwaitingPermitHandlersNumber() {
+      return 0;
+    }
+
+    @Actor
+    public void issueLease() {
+      final ByteBuf leaseFrame = this.leaseFrame;
+      this.requesterLeaseTracker.handleLeaseFrame(leaseFrame);
+      leaseFrame.release();
+    }
+
+    @Actor
+    public void subscribe() {
+      this.source.subscribe(this.stressSubscriber);
+    }
+
+    @Actor
+    public void cancel() {
+      this.stressSubscriber.cancel();
+    }
+
+    @Arbiter
+    public void arbiter(LLLLL_Result r) {
+      r.r1 = this.source.state;
+      r.r2 =
+          this.stressSubscriber.onCompleteCalls
+              + this.stressSubscriber.onErrorCalls * 2
+              + this.stressSubscriber.droppedErrors.size() * 3;
+      r.r3 = this.outboundSubscriber.onNextCalls;
+      r.r4 = this.requesterLeaseTracker.availableRequests;
+      r.r5 = this.source.payload.refCnt();
+
+      this.outboundSubscriber.values.forEach(ByteBuf::release);
+    }
+  }
+}

--- a/rsocket-core/src/jcstress/java/io/rsocket/core/StressSubscription.java
+++ b/rsocket-core/src/jcstress/java/io/rsocket/core/StressSubscription.java
@@ -39,7 +39,7 @@ public class StressSubscription<T> implements Subscription {
 
   public volatile int requestsCount;
 
-  @SuppressWarnings("rawtypes")
+  @SuppressWarnings("rawtype  s")
   static final AtomicIntegerFieldUpdater<StressSubscription> REQUESTS_COUNT =
       AtomicIntegerFieldUpdater.newUpdater(StressSubscription.class, "requestsCount");
 

--- a/rsocket-core/src/jcstress/java/io/rsocket/core/TestRequesterResponderSupport.java
+++ b/rsocket-core/src/jcstress/java/io/rsocket/core/TestRequesterResponderSupport.java
@@ -1,0 +1,39 @@
+package io.rsocket.core;
+
+import static io.rsocket.frame.FrameLengthCodec.FRAME_LENGTH_MASK;
+
+import io.rsocket.DuplexConnection;
+import io.rsocket.RSocket;
+import io.rsocket.frame.decoder.PayloadDecoder;
+import reactor.util.annotation.Nullable;
+
+public class TestRequesterResponderSupport extends RequesterResponderSupport implements RSocket {
+
+  @Nullable private final RequesterLeaseTracker requesterLeaseTracker;
+
+  public TestRequesterResponderSupport(
+      DuplexConnection connection, StreamIdSupplier streamIdSupplier) {
+    this(connection, streamIdSupplier, null);
+  }
+
+  public TestRequesterResponderSupport(
+      DuplexConnection connection,
+      StreamIdSupplier streamIdSupplier,
+      @Nullable RequesterLeaseTracker requesterLeaseTracker) {
+    super(
+        0,
+        FRAME_LENGTH_MASK,
+        Integer.MAX_VALUE,
+        PayloadDecoder.ZERO_COPY,
+        connection,
+        streamIdSupplier,
+        __ -> null);
+    this.requesterLeaseTracker = requesterLeaseTracker;
+  }
+
+  @Override
+  @Nullable
+  public RequesterLeaseTracker getRequesterLeaseTracker() {
+    return this.requesterLeaseTracker;
+  }
+}

--- a/rsocket-core/src/jcstress/java/io/rsocket/core/UnpooledByteBufPayload.java
+++ b/rsocket-core/src/jcstress/java/io/rsocket/core/UnpooledByteBufPayload.java
@@ -1,0 +1,155 @@
+package io.rsocket.core;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.IllegalReferenceCountException;
+import io.rsocket.Payload;
+import reactor.util.annotation.Nullable;
+
+public class UnpooledByteBufPayload extends AbstractReferenceCounted implements Payload {
+
+  private final ByteBuf data;
+  private final ByteBuf metadata;
+
+  /**
+   * Static factory method for a text payload. Mainly looks better than "new ByteBufPayload(data)"
+   *
+   * @param data the data of the payload.
+   * @return a payload.
+   */
+  public static Payload create(String data) {
+    return create(data, ByteBufAllocator.DEFAULT);
+  }
+
+  /**
+   * Static factory method for a text payload. Mainly looks better than "new ByteBufPayload(data)"
+   *
+   * @param data the data of the payload.
+   * @return a payload.
+   */
+  public static Payload create(String data, ByteBufAllocator allocator) {
+    return new UnpooledByteBufPayload(ByteBufUtil.writeUtf8(allocator, data), null);
+  }
+
+  /**
+   * Static factory method for a text payload. Mainly looks better than "new ByteBufPayload(data,
+   * metadata)"
+   *
+   * @param data the data of the payload.
+   * @param metadata the metadata for the payload.
+   * @return a payload.
+   */
+  public static Payload create(String data, @Nullable String metadata) {
+    return create(data, metadata, ByteBufAllocator.DEFAULT);
+  }
+
+  /**
+   * Static factory method for a text payload. Mainly looks better than "new ByteBufPayload(data,
+   * metadata)"
+   *
+   * @param data the data of the payload.
+   * @param metadata the metadata for the payload.
+   * @return a payload.
+   */
+  public static Payload create(String data, @Nullable String metadata, ByteBufAllocator allocator) {
+    return new UnpooledByteBufPayload(
+        ByteBufUtil.writeUtf8(allocator, data),
+        metadata == null ? null : ByteBufUtil.writeUtf8(allocator, metadata));
+  }
+
+  public UnpooledByteBufPayload(ByteBuf data, @Nullable ByteBuf metadata) {
+    this.data = data;
+    this.metadata = metadata;
+  }
+
+  @Override
+  public boolean hasMetadata() {
+    ensureAccessible();
+    return metadata != null;
+  }
+
+  @Override
+  public ByteBuf sliceMetadata() {
+    ensureAccessible();
+    return metadata == null ? Unpooled.EMPTY_BUFFER : metadata.slice();
+  }
+
+  @Override
+  public ByteBuf data() {
+    ensureAccessible();
+    return data;
+  }
+
+  @Override
+  public ByteBuf metadata() {
+    ensureAccessible();
+    return metadata == null ? Unpooled.EMPTY_BUFFER : metadata;
+  }
+
+  @Override
+  public ByteBuf sliceData() {
+    ensureAccessible();
+    return data.slice();
+  }
+
+  @Override
+  public UnpooledByteBufPayload retain() {
+    super.retain();
+    return this;
+  }
+
+  @Override
+  public UnpooledByteBufPayload retain(int increment) {
+    super.retain(increment);
+    return this;
+  }
+
+  @Override
+  public UnpooledByteBufPayload touch() {
+    ensureAccessible();
+    data.touch();
+    if (metadata != null) {
+      metadata.touch();
+    }
+    return this;
+  }
+
+  @Override
+  public UnpooledByteBufPayload touch(Object hint) {
+    ensureAccessible();
+    data.touch(hint);
+    if (metadata != null) {
+      metadata.touch(hint);
+    }
+    return this;
+  }
+
+  @Override
+  protected void deallocate() {
+    data.release();
+    if (metadata != null) {
+      metadata.release();
+    }
+  }
+
+  /**
+   * Should be called by every method that tries to access the buffers content to check if the
+   * buffer was released before.
+   */
+  void ensureAccessible() {
+    if (!isAccessible()) {
+      throw new IllegalReferenceCountException(0);
+    }
+  }
+
+  /**
+   * Used internally by {@link UnpooledByteBufPayload#ensureAccessible()} to try to guard against
+   * using the buffer after it was released (best-effort).
+   */
+  boolean isAccessible() {
+    return refCnt() != 0;
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/core/RequesterLeaseTracker.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RequesterLeaseTracker.java
@@ -55,8 +55,9 @@ final class RequesterLeaseTracker implements Availability {
     final boolean isExpired = leaseReceived && isExpired(l);
 
     if (leaseReceived && availableRequests > 0 && !isExpired) {
-      leasePermitHandler.handlePermit();
-      this.availableRequests = availableRequests - 1;
+      if (leasePermitHandler.handlePermit()) {
+        this.availableRequests = availableRequests - 1;
+      }
     } else {
       final Queue<LeasePermitHandler> queue = this.awaitingPermitHandlersQueue;
       if (this.maximumAllowedAwaitingPermitHandlersNumber > queue.size()) {

--- a/rsocket-test/src/main/java/io/rsocket/test/LeaksTrackingByteBufAllocator.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/LeaksTrackingByteBufAllocator.java
@@ -18,7 +18,7 @@ import org.assertj.core.api.Assertions;
  * Additional Utils which allows to decorate a ByteBufAllocator and track/assertOnLeaks all created
  * ByteBuffs
  */
-class LeaksTrackingByteBufAllocator implements ByteBufAllocator {
+public class LeaksTrackingByteBufAllocator implements ByteBufAllocator {
 
   /**
    * Allows to instrument any given the instance of ByteBufAllocator

--- a/rsocket-test/src/main/java/io/rsocket/test/TestDuplexConnection.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TestDuplexConnection.java
@@ -1,0 +1,166 @@
+package io.rsocket.test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.rsocket.DuplexConnection;
+import io.rsocket.RSocketErrorException;
+import io.rsocket.frame.PayloadFrameCodec;
+import java.net.SocketAddress;
+import java.util.function.BiFunction;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.Sinks;
+import reactor.util.annotation.Nullable;
+
+public class TestDuplexConnection implements DuplexConnection {
+
+  final ByteBufAllocator allocator;
+  final Sinks.Many<ByteBuf> inbound = Sinks.unsafe().many().unicast().onBackpressureError();
+  final Sinks.Many<ByteBuf> outbound = Sinks.unsafe().many().unicast().onBackpressureError();
+  final Sinks.One<Void> close = Sinks.one();
+
+  public TestDuplexConnection(
+      CoreSubscriber<? super ByteBuf> outboundSubscriber, boolean trackLeaks) {
+    this.outbound.asFlux().subscribe(outboundSubscriber);
+    this.allocator =
+        trackLeaks
+            ? LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT)
+            : ByteBufAllocator.DEFAULT;
+  }
+
+  @Override
+  public void dispose() {
+    this.inbound.tryEmitComplete();
+    this.outbound.tryEmitComplete();
+    this.close.tryEmitEmpty();
+  }
+
+  @Override
+  public Mono<Void> onClose() {
+    return this.close.asMono();
+  }
+
+  @Override
+  public void sendErrorAndClose(RSocketErrorException errorException) {}
+
+  @Override
+  public Flux<ByteBuf> receive() {
+    return this.inbound
+        .asFlux()
+        .transform(
+            Operators.lift(
+                (BiFunction<
+                        Scannable,
+                        CoreSubscriber<? super ByteBuf>,
+                        CoreSubscriber<? super ByteBuf>>)
+                    ByteBufReleaserOperator::create));
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return this.allocator;
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return new SocketAddress() {
+      @Override
+      public String toString() {
+        return "Test";
+      }
+    };
+  }
+
+  @Override
+  public void sendFrame(int streamId, ByteBuf frame) {
+    this.outbound.tryEmitNext(frame);
+  }
+
+  public void sendPayloadFrame(
+      int streamId, ByteBuf data, @Nullable ByteBuf metadata, boolean complete) {
+    sendFrame(
+        streamId,
+        PayloadFrameCodec.encode(this.allocator, streamId, false, complete, true, metadata, data));
+  }
+
+  static class ByteBufReleaserOperator
+      implements CoreSubscriber<ByteBuf>, Subscription, Fuseable.QueueSubscription<ByteBuf> {
+
+    static CoreSubscriber<? super ByteBuf> create(
+        Scannable scannable, CoreSubscriber<? super ByteBuf> actual) {
+      return new ByteBufReleaserOperator(actual);
+    }
+
+    final CoreSubscriber<? super ByteBuf> actual;
+
+    Subscription s;
+
+    public ByteBufReleaserOperator(CoreSubscriber<? super ByteBuf> actual) {
+      this.actual = actual;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+      if (Operators.validate(this.s, s)) {
+        this.s = s;
+        this.actual.onSubscribe(this);
+      }
+    }
+
+    @Override
+    public void onNext(ByteBuf buf) {
+      this.actual.onNext(buf);
+      buf.release();
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      actual.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+      actual.onComplete();
+    }
+
+    @Override
+    public void request(long n) {
+      s.request(n);
+    }
+
+    @Override
+    public void cancel() {
+      s.cancel();
+    }
+
+    @Override
+    public int requestFusion(int requestedMode) {
+      return Fuseable.NONE;
+    }
+
+    @Override
+    public ByteBuf poll() {
+      throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int size() {
+      throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean isEmpty() {
+      throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public void clear() {
+      throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+    }
+  }
+}


### PR DESCRIPTION
# Adds JCStressTests Support

### Motivation:

JCStress is a proven tool for making sure correctness of concurrency model used in various places

### Modifications:

Adds list of JCStress tests

### Result:

Better verification of concurrency related issues


Signed-off-by: Oleh Dokuka <oleh.dokuka@icloud.com>