### PR TITLE
fixes netty-tcnative-boringssl-static dependency resolution

### DIFF
--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 def os_suffix = ""
-if (osdetector.classifier in ["linux-x86_64"] || ["osx-x86_64"] || ["windows-x86_64"]) {
+if (osdetector.classifier in ["linux-x86_64", "osx-x86_64", "windows-x86_64"]) {
     os_suffix = "::" + osdetector.classifier
 }
 


### PR DESCRIPTION
Fix resolution of `netty-tcnative-boringssl-static` artifact classifier.

### Motivation:
On apple m1 mac, that is resolved as `osdetector.classifier="osx-aarch_64"` in gradle IntelliJ fails to import the project with diagnostics:
```
Could not find netty-tcnative-boringssl-static-2.0.36.Final-osx-aarch_64.jar (io.netty:netty-tcnative-boringssl-static:2.0.36.Final).
```

### Modifications:

Root cause is wrong resolution of `os_suffix` variable. Fixed.

### Result:

Verified on architectures: `osx-aarch_64`, `linux-x86_64`, `osx-x86_64`.

Apple M1 machines now can import the project and execute tests via gradle CLI.