### PR TITLE
 Add rsocket object get address

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/DuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/DuplexConnection.java
@@ -76,6 +76,17 @@ public interface DuplexConnection extends Availability, Closeable {
   ByteBufAllocator alloc();
 
   /**
+   * Return the local address that this connection is connected to. The returned {@link
+   * SocketAddress} varies by transport type and should be downcast to obtain more detailed
+   * information. For TCP and WebSocket, the address type is {@link java.net.InetSocketAddress}. For
+   * local transport, it is {@link io.rsocket.transport.local.LocalSocketAddress}.
+   *
+   * @return the address
+   * @since 1.1
+   */
+  SocketAddress localAddress();
+
+  /**
    * Return the remote address that this connection is connected to. The returned {@link
    * SocketAddress} varies by transport type and should be downcast to obtain more detailed
    * information. For TCP and WebSocket, the address type is {@link java.net.InetSocketAddress}. For

--- a/rsocket-core/src/main/java/io/rsocket/RSocket.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocket.java
@@ -19,6 +19,7 @@ package io.rsocket;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import java.net.SocketAddress;
 
 /**
  * A contract providing different interaction models for <a
@@ -77,6 +78,36 @@ public interface RSocket extends Availability, Closeable {
    */
   default Mono<Void> metadataPush(Payload payload) {
     return RSocketAdapter.metadataPush(payload);
+  }
+
+  /**
+   * Returns the local address where this channel is bound to.  The returned
+   * {@link SocketAddress} is supposed to be down-cast into more concrete
+   * type such as {@link java.net.InetSocketAddress} to retrieve the detailed
+   * information.
+   *
+   * @return the local address of this channel.
+   *         {@code null} if this channel is not bound.
+   */
+  default SocketAddress localAddress() {
+    return null;
+  }
+
+  /**
+   * Returns the remote address where this channel is connected to.  The
+   * returned {@link SocketAddress} is supposed to be down-cast into more
+   * concrete type such as {@link java.net.InetSocketAddress} to retrieve the detailed
+   * information.
+   *
+   * @return the remote address of this channel.
+   *         {@code null} if this channel is not connected.
+   *         If this channel is not connected but it can receive messages
+   *         from arbitrary remote addresses to determine
+   *         the origination of the received message as this method will
+   *         return {@code null}.
+   */
+  default SocketAddress remoteAddress() {
+    return null;
   }
 
   @Override

--- a/rsocket-core/src/main/java/io/rsocket/core/ClientServerInputMultiplexer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ClientServerInputMultiplexer.java
@@ -277,6 +277,11 @@ class ClientServerInputMultiplexer implements CoreSubscriber<ByteBuf>, Closeable
     }
 
     @Override
+    public SocketAddress localAddress() {
+      return source.localAddress();
+    }
+
+    @Override
     public SocketAddress remoteAddress() {
       return source.remoteAddress();
     }

--- a/rsocket-core/src/main/java/io/rsocket/core/LoggingDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/LoggingDuplexConnection.java
@@ -58,6 +58,11 @@ class LoggingDuplexConnection implements DuplexConnection {
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return source.localAddress();
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return source.remoteAddress();
   }

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -34,6 +34,8 @@ import io.rsocket.keepalive.KeepAliveFramesAcceptor;
 import io.rsocket.keepalive.KeepAliveHandler;
 import io.rsocket.keepalive.KeepAliveSupport;
 import io.rsocket.plugins.RequestInterceptor;
+
+import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
@@ -172,6 +174,16 @@ class RSocketRequester extends RequesterResponderSupport implements RSocket {
     }
 
     return nextStreamId;
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return getDuplexConnection().localAddress();
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return getDuplexConnection().remoteAddress();
   }
 
   @Override

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -34,7 +34,6 @@ import io.rsocket.keepalive.KeepAliveFramesAcceptor;
 import io.rsocket.keepalive.KeepAliveHandler;
 import io.rsocket.keepalive.KeepAliveSupport;
 import io.rsocket.plugins.RequestInterceptor;
-
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -32,7 +32,6 @@ import io.rsocket.frame.RequestResponseFrameCodec;
 import io.rsocket.frame.RequestStreamFrameCodec;
 import io.rsocket.frame.decoder.PayloadDecoder;
 import io.rsocket.plugins.RequestInterceptor;
-
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CancellationException;

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -32,6 +32,8 @@ import io.rsocket.frame.RequestResponseFrameCodec;
 import io.rsocket.frame.RequestStreamFrameCodec;
 import io.rsocket.frame.decoder.PayloadDecoder;
 import io.rsocket.plugins.RequestInterceptor;
+
+import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -149,6 +151,16 @@ class RSocketResponder extends RequesterResponderSupport implements RSocket {
     } catch (Throwable t) {
       return Mono.error(t);
     }
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return getDuplexConnection().localAddress();
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return getDuplexConnection().remoteAddress();
   }
 
   @Override

--- a/rsocket-core/src/main/java/io/rsocket/core/SetupHandlingDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/SetupHandlingDuplexConnection.java
@@ -64,6 +64,11 @@ class SetupHandlingDuplexConnection extends Flux<ByteBuf>
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return source.localAddress();
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return source.remoteAddress();
   }

--- a/rsocket-core/src/main/java/io/rsocket/resume/ResumableDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ResumableDuplexConnection.java
@@ -47,6 +47,7 @@ public class ResumableDuplexConnection extends Flux<ByteBuf>
   final UnboundedProcessor savableFramesSender;
   final Disposable framesSaverDisposable;
   final Sinks.Empty<Void> onClose;
+  final SocketAddress localAddress;
   final SocketAddress remoteAddress;
   final Sinks.Many<Integer> onConnectionClosedSink;
 
@@ -73,6 +74,7 @@ public class ResumableDuplexConnection extends Flux<ByteBuf>
     this.savableFramesSender = new UnboundedProcessor();
     this.framesSaverDisposable = resumableFramesStore.saveFrames(savableFramesSender).subscribe();
     this.onClose = Sinks.empty();
+    this.localAddress = initialConnection.localAddress();
     this.remoteAddress = initialConnection.remoteAddress();
 
     ACTIVE_CONNECTION.lazySet(this, initialConnection);
@@ -220,6 +222,11 @@ public class ResumableDuplexConnection extends Flux<ByteBuf>
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return localAddress;
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return remoteAddress;
   }
@@ -276,6 +283,11 @@ public class ResumableDuplexConnection extends Flux<ByteBuf>
     @Override
     public ByteBufAllocator alloc() {
       return ByteBufAllocator.DEFAULT;
+    }
+
+    @Override
+    public SocketAddress localAddress() {
+      return null;
     }
 
     @Override

--- a/rsocket-core/src/main/java/io/rsocket/util/RSocketProxy.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/RSocketProxy.java
@@ -21,7 +21,6 @@ import io.rsocket.RSocket;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import java.net.SocketAddress;
 
 /** Wrapper/Proxy for a RSocket. This is useful when we want to override a specific method. */

--- a/rsocket-core/src/main/java/io/rsocket/util/RSocketProxy.java
+++ b/rsocket-core/src/main/java/io/rsocket/util/RSocketProxy.java
@@ -22,6 +22,8 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.net.SocketAddress;
+
 /** Wrapper/Proxy for a RSocket. This is useful when we want to override a specific method. */
 public class RSocketProxy implements RSocket {
   protected final RSocket source;
@@ -53,6 +55,16 @@ public class RSocketProxy implements RSocket {
   @Override
   public Mono<Void> metadataPush(Payload payload) {
     return source.metadataPush(payload);
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return source.localAddress();
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return source.remoteAddress();
   }
 
   @Override

--- a/rsocket-core/src/test/java/io/rsocket/test/util/LocalDuplexConnection.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/LocalDuplexConnection.java
@@ -102,6 +102,11 @@ public class LocalDuplexConnection implements DuplexConnection {
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return new TestLocalSocketAddress(name);
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return new TestLocalSocketAddress(name);
   }

--- a/rsocket-core/src/test/java/io/rsocket/test/util/MockRSocket.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/MockRSocket.java
@@ -21,6 +21,8 @@ import static org.hamcrest.Matchers.is;
 
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+
+import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -69,6 +71,16 @@ public class MockRSocket implements RSocket {
   @Override
   public final Mono<Void> metadataPush(Payload payload) {
     return delegate.metadataPush(payload).doOnSubscribe(s -> pushCount.incrementAndGet());
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return delegate.localAddress();
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return delegate.remoteAddress();
   }
 
   @Override

--- a/rsocket-core/src/test/java/io/rsocket/test/util/MockRSocket.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/MockRSocket.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.is;
 
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
-
 import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.Publisher;

--- a/rsocket-core/src/test/java/io/rsocket/test/util/TestDuplexConnection.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/TestDuplexConnection.java
@@ -125,6 +125,11 @@ public class TestDuplexConnection implements DuplexConnection {
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return new TestLocalSocketAddress("TestDuplexConnection");
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return new TestLocalSocketAddress("TestDuplexConnection");
   }

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
@@ -23,6 +23,8 @@ import io.rsocket.stat.FrugalQuantile;
 import io.rsocket.stat.Median;
 import io.rsocket.stat.Quantile;
 import io.rsocket.util.Clock;
+
+import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -516,6 +518,16 @@ public abstract class LoadBalancedRSocketMono extends Mono<RSocket>
     @Override
     public Mono<Void> metadataPush(Payload payload) {
       return errorVoid;
+    }
+
+    @Override
+    public SocketAddress localAddress() {
+      throw new RuntimeException(NoAvailableRSocketException.INSTANCE);
+    }
+
+    @Override
+    public SocketAddress remoteAddress() {
+      throw new RuntimeException(NoAvailableRSocketException.INSTANCE);
     }
 
     @Override

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/LoadBalancedRSocketMono.java
@@ -23,7 +23,6 @@ import io.rsocket.stat.FrugalQuantile;
 import io.rsocket.stat.Median;
 import io.rsocket.stat.Quantile;
 import io.rsocket.util.Clock;
-
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/BackupRequestSocket.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/BackupRequestSocket.java
@@ -21,7 +21,6 @@ import io.rsocket.RSocket;
 import io.rsocket.stat.FrugalQuantile;
 import io.rsocket.stat.Quantile;
 import io.rsocket.util.Clock;
-
 import java.net.SocketAddress;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/BackupRequestSocket.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/BackupRequestSocket.java
@@ -21,6 +21,8 @@ import io.rsocket.RSocket;
 import io.rsocket.stat.FrugalQuantile;
 import io.rsocket.stat.Quantile;
 import io.rsocket.util.Clock;
+
+import java.net.SocketAddress;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -82,6 +84,16 @@ public class BackupRequestSocket implements RSocket {
   @Override
   public Mono<Void> metadataPush(Payload payload) {
     return child.metadataPush(payload);
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return child.localAddress();
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return child.remoteAddress();
   }
 
   @Override

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/RSocketSupplier.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/RSocketSupplier.java
@@ -23,7 +23,6 @@ import io.rsocket.RSocket;
 import io.rsocket.stat.Ewma;
 import io.rsocket.util.Clock;
 import io.rsocket.util.RSocketProxy;
-
 import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;

--- a/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/RSocketSupplier.java
+++ b/rsocket-load-balancer/src/main/java/io/rsocket/client/filter/RSocketSupplier.java
@@ -23,6 +23,8 @@ import io.rsocket.RSocket;
 import io.rsocket.stat.Ewma;
 import io.rsocket.util.Clock;
 import io.rsocket.util.RSocketProxy;
+
+import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
@@ -147,6 +149,16 @@ public class RSocketSupplier implements Availability, Supplier<Mono<RSocket>>, C
           .metadataPush(payload)
           .doOnError(t -> errorPercentage.insert(0.0))
           .doOnSuccess(v -> updateErrorPercentage(1.0));
+    }
+
+    @Override
+    public SocketAddress localAddress() {
+      return source.localAddress();
+    }
+
+    @Override
+    public SocketAddress remoteAddress() {
+      return source.remoteAddress();
     }
 
     @Override

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerDuplexConnection.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerDuplexConnection.java
@@ -90,6 +90,11 @@ final class MicrometerDuplexConnection implements DuplexConnection {
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return delegate.localAddress();
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return delegate.remoteAddress();
   }

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerRSocket.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerRSocket.java
@@ -29,7 +29,6 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Sample;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
-
 import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.function.BiConsumer;

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerRSocket.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/MicrometerRSocket.java
@@ -29,6 +29,8 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Sample;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+
+import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -93,6 +95,16 @@ final class MicrometerRSocket implements RSocket {
   @Override
   public Mono<Void> metadataPush(Payload payload) {
     return delegate.metadataPush(payload).doFinally(metadataPush);
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return delegate.localAddress();
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return delegate.remoteAddress();
   }
 
   @Override

--- a/rsocket-test/src/main/java/io/rsocket/test/TransportTest.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TransportTest.java
@@ -680,6 +680,11 @@ public interface TransportTest {
       }
 
       @Override
+      public SocketAddress localAddress() {
+        return duplexConnection.localAddress();
+      }
+
+      @Override
       public SocketAddress remoteAddress() {
         return duplexConnection.remoteAddress();
       }
@@ -752,6 +757,11 @@ public interface TransportTest {
       @Override
       public ByteBufAllocator alloc() {
         return source.alloc();
+      }
+
+      @Override
+      public SocketAddress localAddress() {
+        return source.localAddress();
       }
 
       @Override

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
@@ -111,6 +111,11 @@ final class LocalDuplexConnection implements DuplexConnection {
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return address;
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return address;
   }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
@@ -58,6 +58,11 @@ public final class TcpDuplexConnection extends BaseDuplexConnection {
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return connection.channel().localAddress();
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return connection.channel().remoteAddress();
   }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
@@ -63,6 +63,11 @@ public final class WebsocketDuplexConnection extends BaseDuplexConnection {
   }
 
   @Override
+  public SocketAddress localAddress() {
+    return connection.channel().localAddress();
+  }
+
+  @Override
   public SocketAddress remoteAddress() {
     return connection.channel().remoteAddress();
   }


### PR DESCRIPTION
Add Rsocket Object supports get local address and remote address

### Motivation:

It is convenient for business system to obtain local address and remote address from rsocket object

### Modifications:

Modify the rsocket interface and duplexconnection interface, as well as their implementation classes

### Result:

Adding localAddress and remoteAddress methods to rsocket object
Signed-off-by: atshow <phsxf@hotmail.com>