### PR TITLE
reworks InMemoryResumableFramesStore and improves its tests coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,8 +153,9 @@ subprojects {
         test {
             useJUnitPlatform()
             testLogging {
-                events "FAILED"
+                events "PASSED", "FAILED"
                 showExceptions true
+                showCauses true
                 exceptionFormat "FULL"
                 stackTraceFilters "ENTRY_POINT"
                 maxGranularity 3
@@ -168,6 +169,8 @@ subprojects {
                     println last
                 }
             }
+
+            forkEvery = 1
 
             if (isCiServer) {
                 def stdout = new LinkedList<TestOutputEvent>()

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketConnector.java
@@ -612,6 +612,7 @@ public class RSocketConnector {
                                     final ResumableDuplexConnection resumableDuplexConnection =
                                         new ResumableDuplexConnection(
                                             CLIENT_TAG,
+                                            resumeToken,
                                             clientServerConnection,
                                             resumableFramesStore);
                                     final ResumableClientSetup resumableClientSetup =

--- a/rsocket-core/src/main/java/io/rsocket/core/Resume.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/Resume.java
@@ -160,7 +160,7 @@ public class Resume {
   Function<? super ByteBuf, ? extends ResumableFramesStore> getStoreFactory(String tag) {
     return storeFactory != null
         ? storeFactory
-        : token -> new InMemoryResumableFramesStore(tag, 100_000);
+        : token -> new InMemoryResumableFramesStore(tag, token, 100_000);
   }
 
   Duration getStreamTimeout() {

--- a/rsocket-core/src/main/java/io/rsocket/core/ServerSetup.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ServerSetup.java
@@ -109,7 +109,8 @@ abstract class ServerSetup {
 
         final ResumableFramesStore resumableFramesStore = resumeStoreFactory.apply(resumeToken);
         final ResumableDuplexConnection resumableDuplexConnection =
-            new ResumableDuplexConnection("server", duplexConnection, resumableFramesStore);
+            new ResumableDuplexConnection(
+                "server", resumeToken, duplexConnection, resumableFramesStore);
         final ServerRSocketSession serverRSocketSession =
             new ServerRSocketSession(
                 resumeToken,

--- a/rsocket-core/src/main/java/io/rsocket/resume/InMemoryResumableFramesStore.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/InMemoryResumableFramesStore.java
@@ -19,118 +19,286 @@ package io.rsocket.resume;
 import static io.rsocket.resume.ResumableDuplexConnection.isResumableFrame;
 
 import io.netty.buffer.ByteBuf;
-import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import io.netty.util.CharsetUtil;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
 import reactor.core.publisher.Sinks;
+import reactor.util.annotation.Nullable;
 
 /**
  * writes - n (where n is frequent, primary operation) reads - m (where m == KeepAliveFrequency)
  * skip - k -> 0 (where k is the rare operation which happens after disconnection
  */
 public class InMemoryResumableFramesStore extends Flux<ByteBuf>
-    implements CoreSubscriber<ByteBuf>, ResumableFramesStore, Subscription {
+    implements ResumableFramesStore, Subscription {
 
+  private FramesSubscriber framesSubscriber;
   private static final Logger logger = LoggerFactory.getLogger(InMemoryResumableFramesStore.class);
 
   final Sinks.Empty<Void> disposed = Sinks.empty();
-  final ArrayList<ByteBuf> cachedFrames;
-  final String tag;
+  final Queue<ByteBuf> cachedFrames;
+  final String side;
+  final String session;
   final int cacheLimit;
 
   volatile long impliedPosition;
   static final AtomicLongFieldUpdater<InMemoryResumableFramesStore> IMPLIED_POSITION =
       AtomicLongFieldUpdater.newUpdater(InMemoryResumableFramesStore.class, "impliedPosition");
 
-  volatile long position;
-  static final AtomicLongFieldUpdater<InMemoryResumableFramesStore> POSITION =
-      AtomicLongFieldUpdater.newUpdater(InMemoryResumableFramesStore.class, "position");
+  volatile long firstAvailableFramePosition;
+  static final AtomicLongFieldUpdater<InMemoryResumableFramesStore> FIRST_AVAILABLE_FRAME_POSITION =
+      AtomicLongFieldUpdater.newUpdater(
+          InMemoryResumableFramesStore.class, "firstAvailableFramePosition");
 
-  volatile int cacheSize;
-  static final AtomicIntegerFieldUpdater<InMemoryResumableFramesStore> CACHE_SIZE =
-      AtomicIntegerFieldUpdater.newUpdater(InMemoryResumableFramesStore.class, "cacheSize");
+  long remoteImpliedPosition;
 
-  CoreSubscriber<? super Void> saveFramesSubscriber;
+  int cacheSize;
+
+  Throwable terminal;
 
   CoreSubscriber<? super ByteBuf> actual;
+  CoreSubscriber<? super ByteBuf> pendingActual;
+
+  volatile long state;
+  static final AtomicLongFieldUpdater<InMemoryResumableFramesStore> STATE =
+      AtomicLongFieldUpdater.newUpdater(InMemoryResumableFramesStore.class, "state");
 
   /**
-   * Indicates whether there is an active connection or not.
-   *
-   * <ul>
-   *   <li>0 - no active connection
-   *   <li>1 - active connection
-   *   <li>2 - disposed
-   * </ul>
-   *
-   * <pre>
-   * 0 <-----> 1
-   * |         |
-   * +--> 2 <--+
-   * </pre>
+   * Flag which indicates that {@link InMemoryResumableFramesStore} is finalized and all related
+   * stores are cleaned
    */
-  volatile int state;
+  static final long FINALIZED_FLAG =
+      0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  /**
+   * Flag which indicates that {@link InMemoryResumableFramesStore} is terminated via the {@link
+   * InMemoryResumableFramesStore#dispose()} method
+   */
+  static final long DISPOSED_FLAG =
+      0b0100_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  /**
+   * Flag which indicates that {@link InMemoryResumableFramesStore} is terminated via the {@link
+   * FramesSubscriber#onComplete()} or {@link FramesSubscriber#onError(Throwable)} ()} methods
+   */
+  static final long TERMINATED_FLAG =
+      0b0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  /** Flag which indicates that {@link InMemoryResumableFramesStore} has active frames consumer */
+  static final long CONNECTED_FLAG =
+      0b0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  /**
+   * Flag which indicates that {@link InMemoryResumableFramesStore} has no active frames consumer
+   * but there is a one pending
+   */
+  static final long PENDING_CONNECTION_FLAG =
+      0b0000_1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  /**
+   * Flag which indicates that there are some received implied position changes from the remote
+   * party
+   */
+  static final long REMOTE_IMPLIED_POSITION_CHANGED_FLAG =
+      0b0000_0100_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  /**
+   * Flag which indicates that there are some frames stored in the {@link
+   * io.rsocket.internal.UnboundedProcessor} which has to be cached and sent to the remote party
+   */
+  static final long HAS_FRAME_FLAG =
+      0b0000_0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L;
+  /**
+   * Flag which indicates that {@link InMemoryResumableFramesStore#drain(long)} has an actor which
+   * is currently progressing on the work. This flag should work as a guard to enter|exist into|from
+   * the {@link InMemoryResumableFramesStore#drain(long)} method.
+   */
+  static final long MAX_WORK_IN_PROGRESS =
+      0b0000_0000_0000_0000_0000_0000_0000_0000_1111_1111_1111_1111_1111_1111_1111_1111L;
 
-  static final AtomicIntegerFieldUpdater<InMemoryResumableFramesStore> STATE =
-      AtomicIntegerFieldUpdater.newUpdater(InMemoryResumableFramesStore.class, "state");
-
-  public InMemoryResumableFramesStore(String tag, int cacheSizeBytes) {
-    this.tag = tag;
+  public InMemoryResumableFramesStore(String side, ByteBuf session, int cacheSizeBytes) {
+    this.side = side;
+    this.session = session.toString(CharsetUtil.UTF_8);
     this.cacheLimit = cacheSizeBytes;
-    this.cachedFrames = new ArrayList<>();
+    this.cachedFrames = new ArrayDeque<>();
   }
 
   public Mono<Void> saveFrames(Flux<ByteBuf> frames) {
     return frames
         .transform(
-            Operators.lift(
-                (__, actual) -> {
-                  this.saveFramesSubscriber = actual;
-                  return this;
-                }))
+            Operators.<ByteBuf, Void>lift(
+                (__, actual) -> this.framesSubscriber = new FramesSubscriber(actual, this)))
         .then();
   }
 
   @Override
   public void releaseFrames(long remoteImpliedPos) {
-    long pos = position;
-    logger.debug(
-        "{} Removing frames for local: {}, remote implied: {}", tag, pos, remoteImpliedPos);
-    long toRemoveBytes = Math.max(0, remoteImpliedPos - pos);
-    int removedBytes = 0;
-    final ArrayList<ByteBuf> frames = cachedFrames;
-    synchronized (this) {
-      while (toRemoveBytes > removedBytes && frames.size() > 0) {
-        ByteBuf cachedFrame = frames.remove(0);
-        int frameSize = cachedFrame.readableBytes();
-        cachedFrame.release();
-        removedBytes += frameSize;
+    long lastReceivedRemoteImpliedPosition = this.remoteImpliedPosition;
+    if (lastReceivedRemoteImpliedPosition > remoteImpliedPos) {
+      throw new IllegalStateException(
+          "Given Remote Implied Position is behind the last received Remote Implied Position");
+    }
+
+    this.remoteImpliedPosition = remoteImpliedPos;
+
+    final long previousState = markRemoteImpliedPositionChanged(this);
+    if (isFinalized(previousState) || isWorkInProgress(previousState)) {
+      return;
+    }
+
+    drain((previousState + 1) | REMOTE_IMPLIED_POSITION_CHANGED_FLAG);
+  }
+
+  void drain(long expectedState) {
+    final Fuseable.QueueSubscription<ByteBuf> qs = this.framesSubscriber.qs;
+    final Queue<ByteBuf> cachedFrames = this.cachedFrames;
+
+    for (; ; ) {
+      if (hasRemoteImpliedPositionChanged(expectedState)) {
+        expectedState = handlePendingRemoteImpliedPositionChanges(expectedState, cachedFrames);
+      }
+
+      if (hasPendingConnection(expectedState)) {
+        expectedState = handlePendingConnection(expectedState, cachedFrames);
+      }
+
+      if (isConnected(expectedState)) {
+        if (isTerminated(expectedState)) {
+          handleTerminal(this.terminal);
+        } else if (isDisposed()) {
+          handleTerminal(new CancellationException("Disposed"));
+        } else if (hasFrames(expectedState)) {
+          handlePendingFrames(qs);
+        }
+      }
+
+      if (isDisposed(expectedState) || isTerminated(expectedState)) {
+        clearAndFinalize(this);
+        return;
+      }
+
+      expectedState = markWorkDone(this, expectedState);
+      if (isFinalized(expectedState)) {
+        return;
+      }
+
+      if (!isWorkInProgress(expectedState)) {
+        return;
+      }
+    }
+  }
+
+  long handlePendingRemoteImpliedPositionChanges(long expectedState, Queue<ByteBuf> cachedFrames) {
+    final long remoteImpliedPosition = this.remoteImpliedPosition;
+    final long firstAvailableFramePosition = this.firstAvailableFramePosition;
+    final long toDropFromCache = Math.max(0, remoteImpliedPosition - firstAvailableFramePosition);
+
+    if (toDropFromCache > 0) {
+      final int droppedFromCache = dropFramesFromCache(toDropFromCache, cachedFrames);
+
+      if (toDropFromCache > droppedFromCache) {
+        this.terminal =
+            new IllegalStateException(
+                String.format(
+                    "Local and remote state disagreement: "
+                        + "need to remove additional %d bytes, but cache is empty",
+                    toDropFromCache));
+        expectedState = markTerminated(this) | TERMINATED_FLAG;
+      }
+
+      if (toDropFromCache < droppedFromCache) {
+        this.terminal =
+            new IllegalStateException(
+                "Local and remote state disagreement: local and remote frame sizes are not equal");
+        expectedState = markTerminated(this) | TERMINATED_FLAG;
+      }
+
+      FIRST_AVAILABLE_FRAME_POSITION.lazySet(this, firstAvailableFramePosition + droppedFromCache);
+      if (this.cacheLimit != Integer.MAX_VALUE) {
+        this.cacheSize -= droppedFromCache;
+
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              "Side[{}]|Session[{}]. Removed frames from cache to position[{}]. CacheSize[{}]",
+              this.side,
+              this.session,
+              this.remoteImpliedPosition,
+              this.cacheSize);
+        }
       }
     }
 
-    if (toRemoveBytes > removedBytes) {
-      throw new IllegalStateException(
-          String.format(
-              "Local and remote state disagreement: "
-                  + "need to remove additional %d bytes, but cache is empty",
-              toRemoveBytes));
-    } else if (toRemoveBytes < removedBytes) {
-      throw new IllegalStateException(
-          "Local and remote state disagreement: local and remote frame sizes are not equal");
-    } else {
-      POSITION.addAndGet(this, removedBytes);
-      if (cacheLimit != Integer.MAX_VALUE) {
-        CACHE_SIZE.addAndGet(this, -removedBytes);
-        logger.debug("{} Removed frames. Current cache size: {}", tag, cacheSize);
+    return expectedState;
+  }
+
+  void handlePendingFrames(Fuseable.QueueSubscription<ByteBuf> qs) {
+    for (; ; ) {
+      final ByteBuf frame = qs.poll();
+      final boolean empty = frame == null;
+
+      if (empty) {
+        break;
+      }
+
+      handleFrame(frame);
+
+      if (!isConnected(this.state)) {
+        break;
       }
     }
+  }
+
+  long handlePendingConnection(long expectedState, Queue<ByteBuf> cachedFrames) {
+    CoreSubscriber<? super ByteBuf> lastActual = null;
+    for (; ; ) {
+      final CoreSubscriber<? super ByteBuf> nextActual = this.pendingActual;
+
+      if (nextActual != lastActual) {
+        for (final ByteBuf frame : cachedFrames) {
+          nextActual.onNext(frame.retainedSlice());
+        }
+      }
+
+      expectedState = markConnected(this, expectedState);
+      if (isConnected(expectedState)) {
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              "Side[{}]|Session[{}]. Connected at Position[{}] and ImpliedPosition[{}]",
+              side,
+              session,
+              firstAvailableFramePosition,
+              impliedPosition);
+        }
+
+        this.actual = nextActual;
+        break;
+      }
+
+      if (!hasPendingConnection(expectedState)) {
+        break;
+      }
+
+      lastActual = nextActual;
+    }
+    return expectedState;
+  }
+
+  static int dropFramesFromCache(long toRemoveBytes, Queue<ByteBuf> cache) {
+    int removedBytes = 0;
+    while (toRemoveBytes > removedBytes && cache.size() > 0) {
+      final ByteBuf cachedFrame = cache.poll();
+      final int frameSize = cachedFrame.readableBytes();
+
+      cachedFrame.release();
+
+      removedBytes += frameSize;
+    }
+
+    return removedBytes;
   }
 
   @Override
@@ -140,12 +308,12 @@ public class InMemoryResumableFramesStore extends Flux<ByteBuf>
 
   @Override
   public long framePosition() {
-    return position;
+    return this.firstAvailableFramePosition;
   }
 
   @Override
   public long frameImpliedPosition() {
-    return impliedPosition & Long.MAX_VALUE;
+    return this.impliedPosition & Long.MAX_VALUE;
   }
 
   @Override
@@ -169,7 +337,8 @@ public class InMemoryResumableFramesStore extends Flux<ByteBuf>
       final long impliedPosition = this.impliedPosition;
 
       if (IMPLIED_POSITION.compareAndSet(this, impliedPosition, impliedPosition | Long.MIN_VALUE)) {
-        logger.debug("Tag {}. Paused at position[{}]", tag, impliedPosition);
+        logger.debug(
+            "Side[{}]|Session[{}]. Paused at position[{}]", side, session, impliedPosition);
         return;
       }
     }
@@ -181,7 +350,11 @@ public class InMemoryResumableFramesStore extends Flux<ByteBuf>
 
       final long restoredImpliedPosition = impliedPosition & Long.MAX_VALUE;
       if (IMPLIED_POSITION.compareAndSet(this, impliedPosition, restoredImpliedPosition)) {
-        logger.debug("Tag {}. Resumed at position[{}]", tag, restoredImpliedPosition);
+        logger.debug(
+            "Side[{}]|Session[{}]. Resumed at position[{}]",
+            side,
+            session,
+            restoredImpliedPosition);
         return;
       }
     }
@@ -194,102 +367,94 @@ public class InMemoryResumableFramesStore extends Flux<ByteBuf>
 
   @Override
   public void dispose() {
-    if (STATE.getAndSet(this, 2) != 2) {
-      cacheSize = 0;
-      synchronized (this) {
-        logger.debug("Tag {}.Disposing InMemoryFrameStore", tag);
-        for (ByteBuf frame : cachedFrames) {
-          if (frame != null) {
-            frame.release();
-          }
-        }
-        cachedFrames.clear();
-      }
-      disposed.tryEmitEmpty();
+    final long previousState = markDisposed(this);
+    if (isFinalized(previousState)
+        || isDisposed(previousState)
+        || isWorkInProgress(previousState)) {
+      return;
+    }
+
+    drain(previousState | DISPOSED_FLAG);
+  }
+
+  void clearCache() {
+    final Queue<ByteBuf> frames = this.cachedFrames;
+    this.cacheSize = 0;
+
+    ByteBuf frame;
+    while ((frame = frames.poll()) != null) {
+      frame.release();
     }
   }
 
   @Override
   public boolean isDisposed() {
-    return state == 2;
+    return isDisposed(this.state);
   }
 
-  @Override
-  public void onSubscribe(Subscription s) {
-    saveFramesSubscriber.onSubscribe(Operators.emptySubscription());
-    s.request(Long.MAX_VALUE);
-  }
-
-  @Override
-  public void onError(Throwable t) {
-    saveFramesSubscriber.onError(t);
-  }
-
-  @Override
-  public void onComplete() {
-    saveFramesSubscriber.onComplete();
-  }
-
-  @Override
-  public void onNext(ByteBuf frame) {
-    final int state;
+  void handleFrame(ByteBuf frame) {
     final boolean isResumable = isResumableFrame(frame);
-    boolean canBeStore = isResumable;
     if (isResumable) {
-      final ArrayList<ByteBuf> frames = cachedFrames;
-      final int incomingFrameSize = frame.readableBytes();
-      final int cacheLimit = this.cacheLimit;
+      handleResumableFrame(frame);
+      return;
+    }
 
-      if (cacheLimit != Integer.MAX_VALUE) {
-        long availableSize = cacheLimit - cacheSize;
-        if (availableSize < incomingFrameSize) {
-          int removedBytes = 0;
-          synchronized (this) {
-            while (availableSize < incomingFrameSize) {
-              if (frames.size() == 0) {
-                break;
-              }
-              ByteBuf cachedFrame;
-              cachedFrame = frames.remove(0);
-              final int frameSize = cachedFrame.readableBytes();
-              availableSize += frameSize;
-              removedBytes += frameSize;
-              cachedFrame.release();
-            }
-          }
-          CACHE_SIZE.addAndGet(this, -removedBytes);
+    handleConnectionFrame(frame);
+  }
 
-          canBeStore = availableSize >= incomingFrameSize;
-          POSITION.addAndGet(this, removedBytes + (canBeStore ? 0 : incomingFrameSize));
+  void handleTerminal(@Nullable Throwable t) {
+    if (t != null) {
+      this.actual.onError(t);
+    } else {
+      this.actual.onComplete();
+    }
+  }
+
+  void handleConnectionFrame(ByteBuf frame) {
+    this.actual.onNext(frame);
+  }
+
+  void handleResumableFrame(ByteBuf frame) {
+    final Queue<ByteBuf> frames = this.cachedFrames;
+    final int incomingFrameSize = frame.readableBytes();
+    final int cacheLimit = this.cacheLimit;
+
+    final boolean canBeStore;
+    int cacheSize = this.cacheSize;
+    if (cacheLimit != Integer.MAX_VALUE) {
+      final long availableSize = cacheLimit - cacheSize;
+
+      if (availableSize < incomingFrameSize) {
+        final long firstAvailableFramePosition = this.firstAvailableFramePosition;
+        final long toRemoveBytes = incomingFrameSize - availableSize;
+        final int removedBytes = dropFramesFromCache(toRemoveBytes, frames);
+
+        cacheSize = cacheSize - removedBytes;
+        canBeStore = removedBytes >= toRemoveBytes;
+
+        if (canBeStore) {
+          FIRST_AVAILABLE_FRAME_POSITION.lazySet(this, firstAvailableFramePosition + removedBytes);
         } else {
-          canBeStore = true;
+          this.cacheSize = cacheSize;
+          FIRST_AVAILABLE_FRAME_POSITION.lazySet(
+              this, firstAvailableFramePosition + removedBytes + incomingFrameSize);
         }
       } else {
         canBeStore = true;
       }
-
-      state = this.state;
-      if (canBeStore) {
-        synchronized (this) {
-          if (state != 2) {
-            frames.add(frame);
-          }
-        }
-
-        if (cacheLimit != Integer.MAX_VALUE) {
-          CACHE_SIZE.addAndGet(this, incomingFrameSize);
-        }
-      }
     } else {
-      state = this.state;
+      canBeStore = true;
     }
 
-    final CoreSubscriber<? super ByteBuf> actual = this.actual;
-    if (state == 1) {
-      actual.onNext(isResumable && canBeStore ? frame.retainedSlice() : frame);
-    } else if (!isResumable || !canBeStore || state == 2) {
-      frame.release();
+    if (canBeStore) {
+      frames.offer(frame);
+
+      if (cacheLimit != Integer.MAX_VALUE) {
+        this.cacheSize = cacheSize + incomingFrameSize;
+      }
     }
+
+    this.actual.onNext(canBeStore ? frame.retainedSlice() : frame);
   }
 
   @Override
@@ -298,30 +463,377 @@ public class InMemoryResumableFramesStore extends Flux<ByteBuf>
   @Override
   public void cancel() {
     pauseImplied();
-    state = 0;
+    markDisconnected(this);
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "Side[{}]|Session[{}]. Disconnected at Position[{}] and ImpliedPosition[{}]",
+          side,
+          session,
+          firstAvailableFramePosition,
+          frameImpliedPosition());
+    }
   }
 
   @Override
   public void subscribe(CoreSubscriber<? super ByteBuf> actual) {
-    final int state = this.state;
-    if (state != 2) {
-      resumeImplied();
-      logger.debug(
-          "Tag: {}. Subscribed at Position[{}] and ImpliedPosition[{}]",
-          tag,
-          position,
-          impliedPosition);
-      actual.onSubscribe(this);
-      synchronized (this) {
-        for (final ByteBuf frame : cachedFrames) {
-          actual.onNext(frame.retainedSlice());
+    resumeImplied();
+    actual.onSubscribe(this);
+    this.pendingActual = actual;
+
+    final long previousState = markPendingConnection(this);
+    if (isDisposed(previousState)) {
+      actual.onError(new CancellationException("Disposed"));
+      return;
+    }
+
+    if (isTerminated(previousState)) {
+      actual.onError(new CancellationException("Disposed"));
+      return;
+    }
+
+    if (isWorkInProgress(previousState)) {
+      return;
+    }
+
+    drain((previousState + 1) | PENDING_CONNECTION_FLAG);
+  }
+
+  static class FramesSubscriber
+      implements CoreSubscriber<ByteBuf>, Fuseable.QueueSubscription<Void> {
+
+    final CoreSubscriber<? super Void> actual;
+    final InMemoryResumableFramesStore parent;
+
+    Fuseable.QueueSubscription<ByteBuf> qs;
+
+    boolean done;
+
+    FramesSubscriber(CoreSubscriber<? super Void> actual, InMemoryResumableFramesStore parent) {
+      this.actual = actual;
+      this.parent = parent;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void onSubscribe(Subscription s) {
+      if (Operators.validate(this.qs, s)) {
+        final Fuseable.QueueSubscription<ByteBuf> qs = (Fuseable.QueueSubscription<ByteBuf>) s;
+        this.qs = qs;
+
+        final int m = qs.requestFusion(Fuseable.ANY);
+
+        if (m != Fuseable.ASYNC) {
+          s.cancel();
+          this.actual.onSubscribe(this);
+          this.actual.onError(new IllegalStateException("Source has to be ASYNC fuseable"));
+          return;
         }
+
+        this.actual.onSubscribe(this);
+      }
+    }
+
+    @Override
+    public void onNext(ByteBuf byteBuf) {
+      final InMemoryResumableFramesStore parent = this.parent;
+      long previousState = InMemoryResumableFramesStore.markFrameAdded(parent);
+
+      if (isFinalized(previousState)) {
+        this.qs.clear();
+        return;
       }
 
-      this.actual = actual;
-      STATE.compareAndSet(this, 0, 1);
-    } else {
-      Operators.complete(actual);
+      if (isWorkInProgress(previousState)
+          || (!isConnected(previousState) && !hasPendingConnection(previousState))) {
+        return;
+      }
+
+      parent.drain(previousState + 1);
     }
+
+    @Override
+    public void onError(Throwable t) {
+      if (this.done) {
+        Operators.onErrorDropped(t, this.actual.currentContext());
+        return;
+      }
+
+      final InMemoryResumableFramesStore parent = this.parent;
+
+      parent.terminal = t;
+      this.done = true;
+
+      final long previousState = InMemoryResumableFramesStore.markTerminated(parent);
+      if (isFinalized(previousState)) {
+        Operators.onErrorDropped(t, this.actual.currentContext());
+        return;
+      }
+
+      if (isWorkInProgress(previousState)) {
+        return;
+      }
+
+      parent.drain(previousState | TERMINATED_FLAG);
+    }
+
+    @Override
+    public void onComplete() {
+      if (this.done) {
+        return;
+      }
+
+      final InMemoryResumableFramesStore parent = this.parent;
+
+      this.done = true;
+
+      final long previousState = InMemoryResumableFramesStore.markTerminated(parent);
+      if (isFinalized(previousState)) {
+        return;
+      }
+
+      if (isWorkInProgress(previousState)) {
+        return;
+      }
+
+      parent.drain(previousState | TERMINATED_FLAG);
+    }
+
+    @Override
+    public void cancel() {
+      if (this.done) {
+        return;
+      }
+
+      this.done = true;
+
+      final long previousState = InMemoryResumableFramesStore.markTerminated(parent);
+      if (isFinalized(previousState)) {
+        return;
+      }
+
+      if (isWorkInProgress(previousState)) {
+        return;
+      }
+
+      parent.drain(previousState | TERMINATED_FLAG);
+    }
+
+    @Override
+    public void request(long n) {}
+
+    @Override
+    public int requestFusion(int requestedMode) {
+      return Fuseable.NONE;
+    }
+
+    @Override
+    public Void poll() {
+      return null;
+    }
+
+    @Override
+    public int size() {
+      return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public void clear() {}
+  }
+
+  static long markFrameAdded(InMemoryResumableFramesStore store) {
+    for (; ; ) {
+      final long state = store.state;
+
+      if (isFinalized(state)) {
+        return state;
+      }
+
+      long nextState = state;
+      if (isConnected(state) || hasPendingConnection(state) || isWorkInProgress(state)) {
+        nextState =
+            (state & MAX_WORK_IN_PROGRESS) == MAX_WORK_IN_PROGRESS ? nextState : nextState + 1;
+      }
+
+      if (STATE.compareAndSet(store, state, nextState | HAS_FRAME_FLAG)) {
+        return state;
+      }
+    }
+  }
+
+  static long markPendingConnection(InMemoryResumableFramesStore store) {
+    for (; ; ) {
+      final long state = store.state;
+
+      if (isFinalized(state) || isDisposed(state) || isTerminated(state)) {
+        return state;
+      }
+
+      if (isConnected(state)) {
+        return state;
+      }
+
+      final long nextState =
+          (state & MAX_WORK_IN_PROGRESS) == MAX_WORK_IN_PROGRESS ? state : state + 1;
+      if (STATE.compareAndSet(store, state, nextState | PENDING_CONNECTION_FLAG)) {
+        return state;
+      }
+    }
+  }
+
+  static long markRemoteImpliedPositionChanged(InMemoryResumableFramesStore store) {
+    for (; ; ) {
+      final long state = store.state;
+
+      if (isFinalized(state)) {
+        return state;
+      }
+
+      final long nextState =
+          (state & MAX_WORK_IN_PROGRESS) == MAX_WORK_IN_PROGRESS ? state : (state + 1);
+      if (STATE.compareAndSet(store, state, nextState | REMOTE_IMPLIED_POSITION_CHANGED_FLAG)) {
+        return state;
+      }
+    }
+  }
+
+  static long markDisconnected(InMemoryResumableFramesStore store) {
+    for (; ; ) {
+      final long state = store.state;
+
+      if (isFinalized(state)) {
+        return state;
+      }
+
+      if (STATE.compareAndSet(store, state, state & ~CONNECTED_FLAG & ~PENDING_CONNECTION_FLAG)) {
+        return state;
+      }
+    }
+  }
+
+  static long markWorkDone(InMemoryResumableFramesStore store, long expectedState) {
+    for (; ; ) {
+      final long state = store.state;
+
+      if (expectedState != state) {
+        return state;
+      }
+
+      if (isFinalized(state)) {
+        return state;
+      }
+
+      final long nextState = state & ~MAX_WORK_IN_PROGRESS & ~REMOTE_IMPLIED_POSITION_CHANGED_FLAG;
+      if (STATE.compareAndSet(store, state, nextState)) {
+        return nextState;
+      }
+    }
+  }
+
+  static long markConnected(InMemoryResumableFramesStore store, long expectedState) {
+    for (; ; ) {
+      final long state = store.state;
+
+      if (state != expectedState) {
+        return state;
+      }
+
+      if (isFinalized(state)) {
+        return state;
+      }
+
+      final long nextState = state ^ PENDING_CONNECTION_FLAG | CONNECTED_FLAG;
+      if (STATE.compareAndSet(store, state, nextState)) {
+        return nextState;
+      }
+    }
+  }
+
+  static long markTerminated(InMemoryResumableFramesStore store) {
+    for (; ; ) {
+      final long state = store.state;
+
+      if (isFinalized(state)) {
+        return state;
+      }
+
+      final long nextState =
+          (state & MAX_WORK_IN_PROGRESS) == MAX_WORK_IN_PROGRESS ? state : (state + 1);
+      if (STATE.compareAndSet(store, state, nextState | TERMINATED_FLAG)) {
+        return state;
+      }
+    }
+  }
+
+  static long markDisposed(InMemoryResumableFramesStore store) {
+    for (; ; ) {
+      final long state = store.state;
+
+      if (isFinalized(state)) {
+        return state;
+      }
+
+      final long nextState =
+          (state & MAX_WORK_IN_PROGRESS) == MAX_WORK_IN_PROGRESS ? state : (state + 1);
+      if (STATE.compareAndSet(store, state, nextState | DISPOSED_FLAG)) {
+        return state;
+      }
+    }
+  }
+
+  static void clearAndFinalize(InMemoryResumableFramesStore store) {
+    final Fuseable.QueueSubscription<ByteBuf> qs = store.framesSubscriber.qs;
+    for (; ; ) {
+      final long state = store.state;
+
+      qs.clear();
+      store.clearCache();
+
+      if (isFinalized(state)) {
+        return;
+      }
+
+      if (STATE.compareAndSet(store, state, state | FINALIZED_FLAG & ~MAX_WORK_IN_PROGRESS)) {
+        store.disposed.tryEmitEmpty();
+        store.framesSubscriber.onComplete();
+        return;
+      }
+    }
+  }
+
+  static boolean isConnected(long state) {
+    return (state & CONNECTED_FLAG) == CONNECTED_FLAG;
+  }
+
+  static boolean hasRemoteImpliedPositionChanged(long state) {
+    return (state & REMOTE_IMPLIED_POSITION_CHANGED_FLAG) == REMOTE_IMPLIED_POSITION_CHANGED_FLAG;
+  }
+
+  static boolean hasPendingConnection(long state) {
+    return (state & PENDING_CONNECTION_FLAG) == PENDING_CONNECTION_FLAG;
+  }
+
+  static boolean hasFrames(long state) {
+    return (state & HAS_FRAME_FLAG) == HAS_FRAME_FLAG;
+  }
+
+  static boolean isTerminated(long state) {
+    return (state & TERMINATED_FLAG) == TERMINATED_FLAG;
+  }
+
+  static boolean isDisposed(long state) {
+    return (state & DISPOSED_FLAG) == DISPOSED_FLAG;
+  }
+
+  static boolean isFinalized(long state) {
+    return (state & FINALIZED_FLAG) == FINALIZED_FLAG;
+  }
+
+  static boolean isWorkInProgress(long state) {
+    return (state & MAX_WORK_IN_PROGRESS) > 0;
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/resume/InMemoryResumeStoreTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/resume/InMemoryResumeStoreTest.java
@@ -4,59 +4,123 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCounted;
+import io.rsocket.RaceTestConstants;
+import io.rsocket.internal.UnboundedProcessor;
+import io.rsocket.internal.subscriber.AssertSubscriber;
 import java.util.Arrays;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Flux;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.Disposable;
+import reactor.core.publisher.Hooks;
+import reactor.test.util.RaceTestUtils;
 
 public class InMemoryResumeStoreTest {
 
   @Test
   void saveNonResumableFrame() {
-    InMemoryResumableFramesStore store = inMemoryStore(25);
-    ByteBuf frame1 = fakeConnectionFrame(10);
-    ByteBuf frame2 = fakeConnectionFrame(35);
-    store.saveFrames(Flux.just(frame1, frame2)).block();
+    final InMemoryResumableFramesStore store = inMemoryStore(25);
+    final UnboundedProcessor sender = new UnboundedProcessor();
+
+    store.saveFrames(sender).subscribe();
+
+    final AssertSubscriber<ByteBuf> assertSubscriber =
+        store.resumeStream().subscribeWith(AssertSubscriber.create());
+
+    final ByteBuf frame1 = fakeConnectionFrame(10);
+    final ByteBuf frame2 = fakeConnectionFrame(35);
+
+    sender.onNext(frame1);
+    sender.onNext(frame2);
+
     assertThat(store.cachedFrames.size()).isZero();
     assertThat(store.cacheSize).isZero();
-    assertThat(store.position).isZero();
+    assertThat(store.firstAvailableFramePosition).isZero();
+
+    assertSubscriber.assertValueCount(2).values().forEach(ByteBuf::release);
+
     assertThat(frame1.refCnt()).isZero();
     assertThat(frame2.refCnt()).isZero();
   }
 
   @Test
   void saveWithoutTailRemoval() {
-    InMemoryResumableFramesStore store = inMemoryStore(25);
-    ByteBuf frame = fakeResumableFrame(10);
-    store.saveFrames(Flux.just(frame)).block();
+    final InMemoryResumableFramesStore store = inMemoryStore(25);
+    final UnboundedProcessor sender = new UnboundedProcessor();
+
+    store.saveFrames(sender).subscribe();
+
+    final AssertSubscriber<ByteBuf> assertSubscriber =
+        store.resumeStream().subscribeWith(AssertSubscriber.create());
+
+    final ByteBuf frame = fakeResumableFrame(10);
+
+    sender.onNext(frame);
+
     assertThat(store.cachedFrames.size()).isEqualTo(1);
     assertThat(store.cacheSize).isEqualTo(frame.readableBytes());
-    assertThat(store.position).isZero();
+    assertThat(store.firstAvailableFramePosition).isZero();
+
+    assertSubscriber.assertValueCount(1).values().forEach(ByteBuf::release);
+
     assertThat(frame.refCnt()).isOne();
   }
 
   @Test
   void saveRemoveOneFromTail() {
-    InMemoryResumableFramesStore store = inMemoryStore(25);
-    ByteBuf frame1 = fakeResumableFrame(20);
-    ByteBuf frame2 = fakeResumableFrame(10);
-    store.saveFrames(Flux.just(frame1, frame2)).block();
+    final InMemoryResumableFramesStore store = inMemoryStore(25);
+    final UnboundedProcessor sender = new UnboundedProcessor();
+
+    store.saveFrames(sender).subscribe();
+
+    final AssertSubscriber<ByteBuf> assertSubscriber =
+        store.resumeStream().subscribeWith(AssertSubscriber.create());
+    final ByteBuf frame1 = fakeResumableFrame(20);
+    final ByteBuf frame2 = fakeResumableFrame(10);
+
+    sender.onNext(frame1);
+    sender.onNext(frame2);
+
     assertThat(store.cachedFrames.size()).isOne();
     assertThat(store.cacheSize).isEqualTo(frame2.readableBytes());
-    assertThat(store.position).isEqualTo(frame1.readableBytes());
+    assertThat(store.firstAvailableFramePosition).isEqualTo(frame1.readableBytes());
+
+    assertSubscriber.assertValueCount(2).values().forEach(ByteBuf::release);
+
     assertThat(frame1.refCnt()).isZero();
     assertThat(frame2.refCnt()).isOne();
   }
 
   @Test
   void saveRemoveTwoFromTail() {
-    InMemoryResumableFramesStore store = inMemoryStore(25);
-    ByteBuf frame1 = fakeResumableFrame(10);
-    ByteBuf frame2 = fakeResumableFrame(10);
-    ByteBuf frame3 = fakeResumableFrame(20);
-    store.saveFrames(Flux.just(frame1, frame2, frame3)).block();
+    final InMemoryResumableFramesStore store = inMemoryStore(25);
+    final UnboundedProcessor sender = new UnboundedProcessor();
+
+    store.saveFrames(sender).subscribe();
+
+    final AssertSubscriber<ByteBuf> assertSubscriber =
+        store.resumeStream().subscribeWith(AssertSubscriber.create());
+
+    final ByteBuf frame1 = fakeResumableFrame(10);
+    final ByteBuf frame2 = fakeResumableFrame(10);
+    final ByteBuf frame3 = fakeResumableFrame(20);
+
+    sender.onNext(frame1);
+    sender.onNext(frame2);
+    sender.onNext(frame3);
+
     assertThat(store.cachedFrames.size()).isOne();
     assertThat(store.cacheSize).isEqualTo(frame3.readableBytes());
-    assertThat(store.position).isEqualTo(size(frame1, frame2));
+    assertThat(store.firstAvailableFramePosition).isEqualTo(size(frame1, frame2));
+
+    assertSubscriber.assertValueCount(3).values().forEach(ByteBuf::release);
+
     assertThat(frame1.refCnt()).isZero();
     assertThat(frame2.refCnt()).isZero();
     assertThat(frame3.refCnt()).isOne();
@@ -64,14 +128,27 @@ public class InMemoryResumeStoreTest {
 
   @Test
   void saveBiggerThanStore() {
-    InMemoryResumableFramesStore store = inMemoryStore(25);
-    ByteBuf frame1 = fakeResumableFrame(10);
-    ByteBuf frame2 = fakeResumableFrame(10);
-    ByteBuf frame3 = fakeResumableFrame(30);
-    store.saveFrames(Flux.just(frame1, frame2, frame3)).block();
+    final InMemoryResumableFramesStore store = inMemoryStore(25);
+    final UnboundedProcessor sender = new UnboundedProcessor();
+
+    store.saveFrames(sender).subscribe();
+
+    final AssertSubscriber<ByteBuf> assertSubscriber =
+        store.resumeStream().subscribeWith(AssertSubscriber.create());
+    final ByteBuf frame1 = fakeResumableFrame(10);
+    final ByteBuf frame2 = fakeResumableFrame(10);
+    final ByteBuf frame3 = fakeResumableFrame(30);
+
+    sender.onNext(frame1);
+    sender.onNext(frame2);
+    sender.onNext(frame3);
+
     assertThat(store.cachedFrames.size()).isZero();
     assertThat(store.cacheSize).isZero();
-    assertThat(store.position).isEqualTo(size(frame1, frame2, frame3));
+    assertThat(store.firstAvailableFramePosition).isEqualTo(size(frame1, frame2, frame3));
+
+    assertSubscriber.assertValueCount(3).values().forEach(ByteBuf::release);
+
     assertThat(frame1.refCnt()).isZero();
     assertThat(frame2.refCnt()).isZero();
     assertThat(frame3.refCnt()).isZero();
@@ -79,15 +156,30 @@ public class InMemoryResumeStoreTest {
 
   @Test
   void releaseFrames() {
-    InMemoryResumableFramesStore store = inMemoryStore(100);
-    ByteBuf frame1 = fakeResumableFrame(10);
-    ByteBuf frame2 = fakeResumableFrame(10);
-    ByteBuf frame3 = fakeResumableFrame(30);
-    store.saveFrames(Flux.just(frame1, frame2, frame3)).block();
+    final InMemoryResumableFramesStore store = inMemoryStore(100);
+
+    final UnboundedProcessor producer = new UnboundedProcessor();
+    store.saveFrames(producer).subscribe();
+
+    final AssertSubscriber<ByteBuf> assertSubscriber =
+        store.resumeStream().subscribeWith(AssertSubscriber.create());
+
+    final ByteBuf frame1 = fakeResumableFrame(10);
+    final ByteBuf frame2 = fakeResumableFrame(10);
+    final ByteBuf frame3 = fakeResumableFrame(30);
+
+    producer.onNext(frame1);
+    producer.onNext(frame2);
+    producer.onNext(frame3);
+
     store.releaseFrames(20);
+
     assertThat(store.cachedFrames.size()).isOne();
     assertThat(store.cacheSize).isEqualTo(frame3.readableBytes());
-    assertThat(store.position).isEqualTo(size(frame1, frame2));
+    assertThat(store.firstAvailableFramePosition).isEqualTo(size(frame1, frame2));
+
+    assertSubscriber.assertValueCount(3).values().forEach(ByteBuf::release);
+
     assertThat(frame1.refCnt()).isZero();
     assertThat(frame2.refCnt()).isZero();
     assertThat(frame3.refCnt()).isOne();
@@ -95,12 +187,342 @@ public class InMemoryResumeStoreTest {
 
   @Test
   void receiveImpliedPosition() {
-    InMemoryResumableFramesStore store = inMemoryStore(100);
+    final InMemoryResumableFramesStore store = inMemoryStore(100);
+
     ByteBuf frame1 = fakeResumableFrame(10);
     ByteBuf frame2 = fakeResumableFrame(30);
+
     store.resumableFrameReceived(frame1);
     store.resumableFrameReceived(frame2);
+
     assertThat(store.frameImpliedPosition()).isEqualTo(size(frame1, frame2));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void ensuresCleansOnTerminal(boolean hasSubscriber) {
+    final InMemoryResumableFramesStore store = inMemoryStore(100);
+
+    final UnboundedProcessor producer = new UnboundedProcessor();
+    store.saveFrames(producer).subscribe();
+
+    final AssertSubscriber<ByteBuf> assertSubscriber =
+        hasSubscriber ? store.resumeStream().subscribeWith(AssertSubscriber.create()) : null;
+
+    final ByteBuf frame1 = fakeResumableFrame(10);
+    final ByteBuf frame2 = fakeResumableFrame(10);
+    final ByteBuf frame3 = fakeResumableFrame(30);
+
+    producer.onNext(frame1);
+    producer.onNext(frame2);
+    producer.onNext(frame3);
+    producer.onComplete();
+
+    assertThat(store.cachedFrames.size()).isZero();
+    assertThat(store.cacheSize).isZero();
+
+    assertThat(producer.isDisposed()).isTrue();
+
+    if (hasSubscriber) {
+      assertSubscriber.assertValueCount(3).assertTerminated().values().forEach(ByteBuf::release);
+    }
+
+    assertThat(frame1.refCnt()).isZero();
+    assertThat(frame2.refCnt()).isZero();
+    assertThat(frame3.refCnt()).isZero();
+  }
+
+  @Test
+  void ensuresCleansOnTerminalLateSubscriber() {
+    final InMemoryResumableFramesStore store = inMemoryStore(100);
+
+    final UnboundedProcessor producer = new UnboundedProcessor();
+    store.saveFrames(producer).subscribe();
+
+    final ByteBuf frame1 = fakeResumableFrame(10);
+    final ByteBuf frame2 = fakeResumableFrame(10);
+    final ByteBuf frame3 = fakeResumableFrame(30);
+
+    producer.onNext(frame1);
+    producer.onNext(frame2);
+    producer.onNext(frame3);
+    producer.onComplete();
+
+    assertThat(store.cachedFrames.size()).isZero();
+    assertThat(store.cacheSize).isZero();
+
+    assertThat(producer.isDisposed()).isTrue();
+
+    final AssertSubscriber<ByteBuf> assertSubscriber =
+        store.resumeStream().subscribeWith(AssertSubscriber.create());
+    assertSubscriber.assertTerminated();
+
+    assertThat(frame1.refCnt()).isZero();
+    assertThat(frame2.refCnt()).isZero();
+    assertThat(frame3.refCnt()).isZero();
+  }
+
+  @ParameterizedTest(name = "Sending vs Reconnect Race Test. WithLateSubscriber[{0}]")
+  @ValueSource(booleans = {true, false})
+  void sendingVsReconnectRaceTest(boolean withLateSubscriber) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
+      final InMemoryResumableFramesStore store = inMemoryStore(Integer.MAX_VALUE);
+      final UnboundedProcessor frames = new UnboundedProcessor();
+      final BlockingQueue<ByteBuf> receivedFrames = new ArrayBlockingQueue<>(10);
+      final AtomicInteger receivedPosition = new AtomicInteger();
+
+      store.saveFrames(frames).subscribe();
+
+      final Consumer<ByteBuf> consumer =
+          f -> {
+            if (ResumableDuplexConnection.isResumableFrame(f)) {
+              receivedPosition.addAndGet(f.readableBytes());
+              receivedFrames.offer(f);
+              return;
+            }
+            f.release();
+          };
+      final AtomicReference<Disposable> disposableReference =
+          new AtomicReference<>(
+              withLateSubscriber ? null : store.resumeStream().subscribe(consumer));
+
+      final ByteBuf byteBuf1 = fakeResumableFrame(5);
+      final ByteBuf byteBuf11 = fakeConnectionFrame(5);
+      final ByteBuf byteBuf2 = fakeResumableFrame(6);
+      final ByteBuf byteBuf21 = fakeConnectionFrame(5);
+      final ByteBuf byteBuf3 = fakeResumableFrame(7);
+      final ByteBuf byteBuf31 = fakeConnectionFrame(5);
+      final ByteBuf byteBuf4 = fakeResumableFrame(8);
+      final ByteBuf byteBuf41 = fakeConnectionFrame(5);
+      final ByteBuf byteBuf5 = fakeResumableFrame(25);
+      final ByteBuf byteBuf51 = fakeConnectionFrame(35);
+
+      RaceTestUtils.race(
+          () -> {
+            if (withLateSubscriber) {
+              disposableReference.set(store.resumeStream().subscribe(consumer));
+            }
+
+            // disconnect
+            disposableReference.get().dispose();
+
+            while (InMemoryResumableFramesStore.isWorkInProgress(store.state)) {
+              // ignore
+            }
+
+            // mimic RESUME_OK frame received
+            store.releaseFrames(receivedPosition.get());
+            disposableReference.set(store.resumeStream().subscribe(consumer));
+
+            // disconnect
+            disposableReference.get().dispose();
+
+            while (InMemoryResumableFramesStore.isWorkInProgress(store.state)) {
+              // ignore
+            }
+
+            // mimic RESUME_OK frame received
+            store.releaseFrames(receivedPosition.get());
+            disposableReference.set(store.resumeStream().subscribe(consumer));
+          },
+          () -> {
+            frames.onNext(byteBuf1);
+            frames.onNextPrioritized(byteBuf11);
+            frames.onNext(byteBuf2);
+            frames.onNext(byteBuf3);
+            frames.onNextPrioritized(byteBuf31);
+            frames.onNext(byteBuf4);
+            frames.onNext(byteBuf5);
+          },
+          () -> {
+            frames.onNextPrioritized(byteBuf21);
+            frames.onNextPrioritized(byteBuf41);
+            frames.onNextPrioritized(byteBuf51);
+          });
+
+      store.releaseFrames(receivedFrames.stream().mapToInt(ByteBuf::readableBytes).sum());
+
+      assertThat(store.cacheSize).isZero();
+      assertThat(store.cachedFrames).isEmpty();
+
+      assertThat(receivedFrames)
+          .hasSize(5)
+          .containsSequence(byteBuf1, byteBuf2, byteBuf3, byteBuf4, byteBuf5);
+      receivedFrames.forEach(ReferenceCounted::release);
+
+      assertThat(byteBuf1.refCnt()).isZero();
+      assertThat(byteBuf11.refCnt()).isZero();
+      assertThat(byteBuf2.refCnt()).isZero();
+      assertThat(byteBuf21.refCnt()).isZero();
+      assertThat(byteBuf3.refCnt()).isZero();
+      assertThat(byteBuf31.refCnt()).isZero();
+      assertThat(byteBuf4.refCnt()).isZero();
+      assertThat(byteBuf41.refCnt()).isZero();
+      assertThat(byteBuf5.refCnt()).isZero();
+      assertThat(byteBuf51.refCnt()).isZero();
+    }
+  }
+
+  @ParameterizedTest(
+      name = "Sending vs Reconnect with incorrect position Race Test. WithLateSubscriber[{0}]")
+  @ValueSource(booleans = {true, false})
+  void incorrectReleaseFramesWithOnNextRaceTest(boolean withLateSubscriber) {
+    Hooks.onErrorDropped(t -> {});
+    try {
+      for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
+        final InMemoryResumableFramesStore store = inMemoryStore(Integer.MAX_VALUE);
+        final UnboundedProcessor frames = new UnboundedProcessor();
+
+        store.saveFrames(frames).subscribe();
+
+        final AtomicInteger terminationCnt = new AtomicInteger();
+        final Consumer<ByteBuf> consumer = ReferenceCounted::release;
+        final Consumer<Throwable> errorConsumer = __ -> terminationCnt.incrementAndGet();
+        final AtomicReference<Disposable> disposableReference =
+            new AtomicReference<>(
+                withLateSubscriber
+                    ? null
+                    : store.resumeStream().subscribe(consumer, errorConsumer));
+
+        final ByteBuf byteBuf1 = fakeResumableFrame(5);
+        final ByteBuf byteBuf11 = fakeConnectionFrame(5);
+        final ByteBuf byteBuf2 = fakeResumableFrame(6);
+        final ByteBuf byteBuf21 = fakeConnectionFrame(5);
+        final ByteBuf byteBuf3 = fakeResumableFrame(7);
+        final ByteBuf byteBuf31 = fakeConnectionFrame(5);
+        final ByteBuf byteBuf4 = fakeResumableFrame(8);
+        final ByteBuf byteBuf41 = fakeConnectionFrame(5);
+        final ByteBuf byteBuf5 = fakeResumableFrame(25);
+        final ByteBuf byteBuf51 = fakeConnectionFrame(35);
+
+        RaceTestUtils.race(
+            () -> {
+              if (withLateSubscriber) {
+                disposableReference.set(store.resumeStream().subscribe(consumer, errorConsumer));
+              }
+              // disconnect
+              disposableReference.get().dispose();
+
+              // mimic RESUME_OK frame received but with incorrect position
+              store.releaseFrames(25);
+              disposableReference.set(store.resumeStream().subscribe(consumer, errorConsumer));
+            },
+            () -> {
+              frames.onNext(byteBuf1);
+              frames.onNextPrioritized(byteBuf11);
+              frames.onNext(byteBuf2);
+              frames.onNext(byteBuf3);
+              frames.onNextPrioritized(byteBuf31);
+              frames.onNext(byteBuf4);
+              frames.onNext(byteBuf5);
+            },
+            () -> {
+              frames.onNextPrioritized(byteBuf21);
+              frames.onNextPrioritized(byteBuf41);
+              frames.onNextPrioritized(byteBuf51);
+            });
+
+        assertThat(store.cacheSize).isZero();
+        assertThat(store.cachedFrames).isEmpty();
+        assertThat(disposableReference.get().isDisposed()).isTrue();
+        assertThat(terminationCnt).hasValue(1);
+
+        assertThat(byteBuf1.refCnt()).isZero();
+        assertThat(byteBuf11.refCnt()).isZero();
+        assertThat(byteBuf2.refCnt()).isZero();
+        assertThat(byteBuf21.refCnt()).isZero();
+        assertThat(byteBuf3.refCnt()).isZero();
+        assertThat(byteBuf31.refCnt()).isZero();
+        assertThat(byteBuf4.refCnt()).isZero();
+        assertThat(byteBuf41.refCnt()).isZero();
+        assertThat(byteBuf5.refCnt()).isZero();
+        assertThat(byteBuf51.refCnt()).isZero();
+      }
+    } finally {
+      Hooks.resetOnErrorDropped();
+    }
+  }
+
+  @ParameterizedTest(
+      name =
+          "Dispose vs Sending vs Reconnect with incorrect position Race Test. WithLateSubscriber[{0}]")
+  @ValueSource(booleans = {true, false})
+  void incorrectReleaseFramesWithOnNextWithDisposeRaceTest(boolean withLateSubscriber) {
+    Hooks.onErrorDropped(t -> {});
+    try {
+      for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
+        final InMemoryResumableFramesStore store = inMemoryStore(Integer.MAX_VALUE);
+        final UnboundedProcessor frames = new UnboundedProcessor();
+
+        store.saveFrames(frames).subscribe();
+
+        final AtomicInteger terminationCnt = new AtomicInteger();
+        final Consumer<ByteBuf> consumer = ReferenceCounted::release;
+        final Consumer<Throwable> errorConsumer = __ -> terminationCnt.incrementAndGet();
+        final AtomicReference<Disposable> disposableReference =
+            new AtomicReference<>(
+                withLateSubscriber
+                    ? null
+                    : store.resumeStream().subscribe(consumer, errorConsumer));
+
+        final ByteBuf byteBuf1 = fakeResumableFrame(5);
+        final ByteBuf byteBuf11 = fakeConnectionFrame(5);
+        final ByteBuf byteBuf2 = fakeResumableFrame(6);
+        final ByteBuf byteBuf21 = fakeConnectionFrame(5);
+        final ByteBuf byteBuf3 = fakeResumableFrame(7);
+        final ByteBuf byteBuf31 = fakeConnectionFrame(5);
+        final ByteBuf byteBuf4 = fakeResumableFrame(8);
+        final ByteBuf byteBuf41 = fakeConnectionFrame(5);
+        final ByteBuf byteBuf5 = fakeResumableFrame(25);
+        final ByteBuf byteBuf51 = fakeConnectionFrame(35);
+
+        RaceTestUtils.race(
+            () -> {
+              if (withLateSubscriber) {
+                disposableReference.set(store.resumeStream().subscribe(consumer, errorConsumer));
+              }
+              // disconnect
+              disposableReference.get().dispose();
+
+              // mimic RESUME_OK frame received but with incorrect position
+              store.releaseFrames(25);
+              disposableReference.set(store.resumeStream().subscribe(consumer, errorConsumer));
+            },
+            () -> {
+              frames.onNext(byteBuf1);
+              frames.onNextPrioritized(byteBuf11);
+              frames.onNext(byteBuf2);
+              frames.onNext(byteBuf3);
+              frames.onNextPrioritized(byteBuf31);
+              frames.onNext(byteBuf4);
+              frames.onNext(byteBuf5);
+            },
+            () -> {
+              frames.onNextPrioritized(byteBuf21);
+              frames.onNextPrioritized(byteBuf41);
+              frames.onNextPrioritized(byteBuf51);
+            },
+            store::dispose);
+
+        assertThat(store.cacheSize).isZero();
+        assertThat(store.cachedFrames).isEmpty();
+        assertThat(disposableReference.get().isDisposed()).isTrue();
+        assertThat(terminationCnt).hasValueGreaterThanOrEqualTo(1).hasValueLessThanOrEqualTo(2);
+
+        assertThat(byteBuf1.refCnt()).isZero();
+        assertThat(byteBuf11.refCnt()).isZero();
+        assertThat(byteBuf2.refCnt()).isZero();
+        assertThat(byteBuf21.refCnt()).isZero();
+        assertThat(byteBuf3.refCnt()).isZero();
+        assertThat(byteBuf31.refCnt()).isZero();
+        assertThat(byteBuf4.refCnt()).isZero();
+        assertThat(byteBuf41.refCnt()).isZero();
+        assertThat(byteBuf5.refCnt()).isZero();
+        assertThat(byteBuf51.refCnt()).isZero();
+      }
+    } finally {
+      Hooks.resetOnErrorDropped();
+    }
   }
 
   private int size(ByteBuf... byteBufs) {
@@ -108,7 +530,7 @@ public class InMemoryResumeStoreTest {
   }
 
   private static InMemoryResumableFramesStore inMemoryStore(int size) {
-    return new InMemoryResumableFramesStore("test", size);
+    return new InMemoryResumableFramesStore("test", Unpooled.EMPTY_BUFFER, size);
   }
 
   private static ByteBuf fakeResumableFrame(int size) {

--- a/rsocket-examples/src/test/java/io/rsocket/resume/ResumeIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/resume/ResumeIntegrationTest.java
@@ -182,7 +182,7 @@ public class ResumeIntegrationTest {
         .resume(
             new Resume()
                 .sessionDuration(Duration.ofSeconds(sessionDurationSeconds))
-                .storeFactory(t -> new InMemoryResumableFramesStore("client", 500_000))
+                .storeFactory(t -> new InMemoryResumableFramesStore("client", t, 500_000))
                 .cleanupStoreOnKeepAlive()
                 .retry(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofSeconds(1))))
         .keepAlive(Duration.ofSeconds(5), Duration.ofMinutes(5))
@@ -199,7 +199,7 @@ public class ResumeIntegrationTest {
             new Resume()
                 .sessionDuration(Duration.ofSeconds(sessionDurationSeconds))
                 .cleanupStoreOnKeepAlive()
-                .storeFactory(t -> new InMemoryResumableFramesStore("server", 500_000)))
+                .storeFactory(t -> new InMemoryResumableFramesStore("server", t, 500_000)))
         .bind(serverTransport(SERVER_HOST, SERVER_PORT));
   }
 
@@ -212,7 +212,7 @@ public class ResumeIntegrationTest {
       return duplicate(
               Flux.interval(Duration.ofMillis(1))
                   .onBackpressureLatest()
-                  .publishOn(Schedulers.elastic()),
+                  .publishOn(Schedulers.boundedElastic()),
               20)
           .map(v -> DefaultPayload.create(String.valueOf(counter.getAndIncrement())))
           .takeUntilOther(Flux.from(payloads).then());

--- a/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalResumableWithFragmentationTransportTest.java
+++ b/rsocket-transport-local/src/test/java/io/rsocket/transport/local/LocalResumableWithFragmentationTransportTest.java
@@ -20,14 +20,14 @@ import io.rsocket.test.TransportTest;
 import java.time.Duration;
 import java.util.UUID;
 
-final class LocalResumableTransportTest implements TransportTest {
+final class LocalResumableWithFragmentationTransportTest implements TransportTest {
 
   private final TransportPair transportPair =
       new TransportPair<>(
           () -> "test-" + UUID.randomUUID(),
           (address, server, allocator) -> LocalClientTransport.create(address, allocator),
           (address, allocator) -> LocalServerTransport.create(address),
-          false,
+          true,
           true);
 
   @Override

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/TcpResumableWithFragmentationTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/TcpResumableWithFragmentationTransportTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.transport.netty;
+
+import io.netty.channel.ChannelOption;
+import io.rsocket.test.TransportTest;
+import io.rsocket.transport.netty.client.TcpClientTransport;
+import io.rsocket.transport.netty.server.TcpServerTransport;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpServer;
+
+final class TcpResumableWithFragmentationTransportTest implements TransportTest {
+
+  private final TransportPair transportPair =
+      new TransportPair<>(
+          () -> InetSocketAddress.createUnresolved("localhost", 0),
+          (address, server, allocator) ->
+              TcpClientTransport.create(
+                  TcpClient.create()
+                      .remoteAddress(server::address)
+                      .option(ChannelOption.ALLOCATOR, allocator)),
+          (address, allocator) ->
+              TcpServerTransport.create(
+                  TcpServer.create()
+                      .bindAddress(() -> address)
+                      .option(ChannelOption.ALLOCATOR, allocator)),
+          true,
+          true);
+
+  @Override
+  public Duration getTimeout() {
+    return Duration.ofMinutes(3);
+  }
+
+  @Override
+  public TransportPair getTransportPair() {
+    return transportPair;
+  }
+}

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketResumableTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketResumableTransportTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.transport.netty;
+
+import io.netty.channel.ChannelOption;
+import io.rsocket.test.TransportTest;
+import io.rsocket.transport.netty.client.WebsocketClientTransport;
+import io.rsocket.transport.netty.server.WebsocketServerTransport;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
+
+final class WebsocketResumableTransportTest implements TransportTest {
+
+  private final TransportPair transportPair =
+      new TransportPair<>(
+          () -> InetSocketAddress.createUnresolved("localhost", 0),
+          (address, server, allocator) ->
+              WebsocketClientTransport.create(
+                  HttpClient.create()
+                      .host(server.address().getHostName())
+                      .port(server.address().getPort())
+                      .option(ChannelOption.ALLOCATOR, allocator),
+                  ""),
+          (address, allocator) ->
+              WebsocketServerTransport.create(
+                  HttpServer.create()
+                      .host(address.getHostName())
+                      .port(address.getPort())
+                      .option(ChannelOption.ALLOCATOR, allocator)),
+          false,
+          true);
+
+  @Override
+  public Duration getTimeout() {
+    return Duration.ofMinutes(3);
+  }
+
+  @Override
+  public TransportPair getTransportPair() {
+    return transportPair;
+  }
+}

--- a/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketResumableWithFragmentationTransportTest.java
+++ b/rsocket-transport-netty/src/test/java/io/rsocket/transport/netty/WebsocketResumableWithFragmentationTransportTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.transport.netty;
+
+import io.netty.channel.ChannelOption;
+import io.rsocket.test.TransportTest;
+import io.rsocket.transport.netty.client.WebsocketClientTransport;
+import io.rsocket.transport.netty.server.WebsocketServerTransport;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
+
+final class WebsocketResumableWithFragmentationTransportTest implements TransportTest {
+
+  private final TransportPair transportPair =
+      new TransportPair<>(
+          () -> InetSocketAddress.createUnresolved("localhost", 0),
+          (address, server, allocator) ->
+              WebsocketClientTransport.create(
+                  HttpClient.create()
+                      .host(server.address().getHostName())
+                      .port(server.address().getPort())
+                      .option(ChannelOption.ALLOCATOR, allocator),
+                  ""),
+          (address, allocator) ->
+              WebsocketServerTransport.create(
+                  HttpServer.create()
+                      .host(address.getHostName())
+                      .port(address.getPort())
+                      .option(ChannelOption.ALLOCATOR, allocator)),
+          true,
+          true);
+
+  @Override
+  public Duration getTimeout() {
+    return Duration.ofMinutes(3);
+  }
+
+  @Override
+  public TransportPair getTransportPair() {
+    return transportPair;
+  }
+}


### PR DESCRIPTION
# Main Changes Description

At the moment Resumability implementation is unstable due to its non-well-covered reworked impl.

As it was uncovered, the main root-cause of the problem is the incorrect state synchronization in InMemoryResumableFrameStore when it comes to the connection reestablishment (e.g. the previous connection was lost so we need to go through the resume handshake phase). 

As it was observed, the local producers may produce more elements while the new subscriber iterating over the cached value may miss some updates.

To resolve the mentioned problem, InmemoryResumableFrameStore is reworked again with the thought of **backpressure (via ASYNC fusion)** and fully **sequentially signals processing** (using WorkInProgress pattern). 

The first improvements allow draining elements from the upfront `Publisher` (_at the moment **UnboundedProcessor** which does not support backpressure but we should have a proper once #752 is implemented_) only when there is an active connection. In general, relying on `queue.poll` only (instead of handling data from `onNext`) decreases the amount of potentially concurrent signals we have to deal with and ensures that the new connection does not have to mess with duplicates-checking logic. 

The second improvement eliminates the need for `synchronized` keyword and replaces it with `volatile long state` machine over which we can expose various changes without introducing an expensive MpScQueue

# Side Changes Description

There are some LocalDuplexConnection and UnboundedProcessor modifications as a part of this PR. These modifications are mainly to ensure that e2e resumability tests pass with LocalTransport. `LocalDuplexConnection` (used in LocalClient/ServerTransport) embraces UnboundedProcessor to exchange frames between peers. Before these changes, it was not possible to track when all the frames are delivered / discarded. Thus, it was not possible to notify about the real termination of the DuplexConnection. The modifications to UnboundedProcessor provide a `ondisposehook` handle which allows tracking when the queue is cleaned and closed - hence notify the duplex connection that it can be terminated as well.