### PR TITLE
makes numbers of repeats of race tests as env constant

### DIFF
--- a/rsocket-core/src/test/java/io/rsocket/RaceTestConstants.java
+++ b/rsocket-core/src/test/java/io/rsocket/RaceTestConstants.java
@@ -1,0 +1,6 @@
+package io.rsocket;
+
+public class RaceTestConstants {
+  public static final int REPEATS =
+      Integer.parseInt(System.getProperty("rsocket.test.race.repeats", "1000"));
+}

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -37,6 +37,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.RaceTestConstants;
 import io.rsocket.TestScheduler;
 import io.rsocket.exceptions.ApplicationErrorException;
 import io.rsocket.exceptions.CustomRSocketException;
@@ -404,7 +405,7 @@ public class RSocketRequesterTest {
   public void checkNoLeaksOnRacing(
       Function<ClientSocketRule, Publisher<Payload>> initiator,
       BiConsumer<AssertSubscriber<Payload>, ClientSocketRule> runner) {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       ClientSocketRule clientSocketRule = new ClientSocketRule();
       try {
         clientSocketRule
@@ -987,7 +988,7 @@ public class RSocketRequesterTest {
       FrameType interactionType2) {
     Assumptions.assumeThat(interactionType1).isNotEqualTo(METADATA_PUSH);
     Assumptions.assumeThat(interactionType2).isNotEqualTo(METADATA_PUSH);
-    for (int i = 1; i < 10000; i += 4) {
+    for (int i = 1; i < RaceTestConstants.REPEATS; i += 4) {
       Payload payload = DefaultPayload.create("test", "test");
       Publisher<?> publisher1 = interaction1.apply(rule, payload);
       Publisher<?> publisher2 = interaction2.apply(rule, payload);
@@ -1072,7 +1073,7 @@ public class RSocketRequesterTest {
       BiFunction<ClientSocketRule, Payload, Publisher<?>> interaction2,
       FrameType interactionType1,
       FrameType interactionType2) {
-    for (int i = 1; i < 10000; i++) {
+    for (int i = 1; i < RaceTestConstants.REPEATS; i++) {
       Payload payload1 = ByteBufPayload.create("test", "test");
       Payload payload2 = ByteBufPayload.create("test", "test");
       AssertSubscriber assertSubscriber1 = AssertSubscriber.create();

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
@@ -39,6 +39,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
+import io.rsocket.RaceTestConstants;
 import io.rsocket.frame.CancelFrameCodec;
 import io.rsocket.frame.ErrorFrameCodec;
 import io.rsocket.frame.FrameHeaderCodec;
@@ -247,7 +248,7 @@ public class RSocketResponderTest {
   @Test
   public void checkNoLeaksOnRacingCancelFromRequestChannelAndNextFromUpstream() {
     ByteBufAllocator allocator = rule.alloc();
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       AssertSubscriber<Payload> assertSubscriber = AssertSubscriber.create();
 
       rule.setAcceptingSocket(
@@ -301,7 +302,7 @@ public class RSocketResponderTest {
   public void checkNoLeaksOnRacingBetweenDownstreamCancelAndOnNextFromRequestChannelTest() {
     Hooks.onErrorDropped((e) -> {});
     ByteBufAllocator allocator = rule.alloc();
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       AssertSubscriber<Payload> assertSubscriber = AssertSubscriber.create();
 
       FluxSink<Payload>[] sinks = new FluxSink[1];
@@ -340,7 +341,7 @@ public class RSocketResponderTest {
   public void checkNoLeaksOnRacingBetweenDownstreamCancelAndOnNextFromRequestChannelTest1() {
     Hooks.onErrorDropped((e) -> {});
     ByteBufAllocator allocator = rule.alloc();
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       AssertSubscriber<Payload> assertSubscriber = AssertSubscriber.create();
 
       FluxSink<Payload>[] sinks = new FluxSink[1];
@@ -382,7 +383,7 @@ public class RSocketResponderTest {
       checkNoLeaksOnRacingBetweenDownstreamCancelAndOnNextFromUpstreamOnErrorFromRequestChannelTest1() {
     Hooks.onErrorDropped((e) -> {});
     ByteBufAllocator allocator = rule.alloc();
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       FluxSink<Payload>[] sinks = new FluxSink[1];
       AssertSubscriber<Payload> assertSubscriber = AssertSubscriber.create();
       rule.setAcceptingSocket(
@@ -474,7 +475,7 @@ public class RSocketResponderTest {
   public void checkNoLeaksOnRacingBetweenDownstreamCancelAndOnNextFromRequestStreamTest1() {
     Hooks.onErrorDropped((e) -> {});
     ByteBufAllocator allocator = rule.alloc();
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       FluxSink<Payload>[] sinks = new FluxSink[1];
 
       rule.setAcceptingSocket(
@@ -509,7 +510,7 @@ public class RSocketResponderTest {
   public void checkNoLeaksOnRacingBetweenDownstreamCancelAndOnNextFromRequestResponseTest1() {
     Hooks.onErrorDropped((e) -> {});
     ByteBufAllocator allocator = rule.alloc();
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       Operators.MonoSubscriber<Payload, Payload>[] sources = new Operators.MonoSubscriber[1];
 
       rule.setAcceptingSocket(

--- a/rsocket-core/src/test/java/io/rsocket/core/ReconnectMonoTests.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/ReconnectMonoTests.java
@@ -18,6 +18,7 @@ package io.rsocket.core;
 
 import static org.junit.Assert.assertEquals;
 
+import io.rsocket.RaceTestConstants;
 import io.rsocket.internal.subscriber.AssertSubscriber;
 import java.io.IOException;
 import java.time.Duration;
@@ -60,7 +61,7 @@ public class ReconnectMonoTests {
   public void shouldExpireValueOnRacingDisposeAndNext() {
     Hooks.onErrorDropped(t -> {});
     Hooks.onNextDropped(System.out::println);
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final int index = i;
       final CoreSubscriber<? super String>[] monoSubscribers = new CoreSubscriber[1];
       Subscription mockSubscription = Mockito.mock(Subscription.class);
@@ -108,7 +109,7 @@ public class ReconnectMonoTests {
   @Test
   public void shouldNotifyAllTheSubscribersUnderRacingBetweenSubscribeAndComplete() {
     Hooks.onErrorDropped(t -> {});
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold =
           TestPublisher.createNoncompliant(TestPublisher.Violation.REQUEST_OVERFLOW);
 
@@ -151,7 +152,7 @@ public class ReconnectMonoTests {
   @Test
   public void shouldNotExpireNewlyResolvedValueIfSubscribeIsRacingWithInvalidate() {
     Hooks.onErrorDropped(t -> {});
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final int index = i;
       final TestPublisher<String> cold =
           TestPublisher.createNoncompliant(TestPublisher.Violation.REQUEST_OVERFLOW);
@@ -214,7 +215,7 @@ public class ReconnectMonoTests {
   @Test
   public void shouldNotExpireNewlyResolvedValueIfSubscribeIsRacingWithInvalidates() {
     Hooks.onErrorDropped(t -> {});
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final int index = i;
       final TestPublisher<String> cold =
           TestPublisher.createNoncompliant(TestPublisher.Violation.REQUEST_OVERFLOW);
@@ -281,7 +282,7 @@ public class ReconnectMonoTests {
   @Test
   public void shouldNotExpireNewlyResolvedValueIfBlockIsRacingWithInvalidate() {
     Hooks.onErrorDropped(t -> {});
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final int index = i;
       final Mono<String> source =
           Mono.fromSupplier(
@@ -347,7 +348,7 @@ public class ReconnectMonoTests {
 
   @Test
   public void shouldEstablishValueOnceInCaseOfRacingBetweenSubscribers() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold = TestPublisher.createCold();
       cold.next("value" + i);
 
@@ -394,7 +395,7 @@ public class ReconnectMonoTests {
   @Test
   public void shouldEstablishValueOnceInCaseOfRacingBetweenSubscribeAndBlock() {
     Duration timeout = Duration.ofMillis(100);
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold = TestPublisher.createCold();
       cold.next("value" + i);
 
@@ -441,7 +442,7 @@ public class ReconnectMonoTests {
   @Test
   public void shouldEstablishValueOnceInCaseOfRacingBetweenBlocks() {
     Duration timeout = Duration.ofMillis(100);
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold = TestPublisher.createCold();
       cold.next("value" + i);
 
@@ -486,7 +487,7 @@ public class ReconnectMonoTests {
   @Test
   public void shouldExpireValueOnRacingDisposeAndNoValueComplete() {
     Hooks.onErrorDropped(t -> {});
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold =
           TestPublisher.createNoncompliant(TestPublisher.Violation.REQUEST_OVERFLOW);
 
@@ -524,7 +525,7 @@ public class ReconnectMonoTests {
   @Test
   public void shouldExpireValueOnRacingDisposeAndComplete() {
     Hooks.onErrorDropped(t -> {});
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold =
           TestPublisher.createNoncompliant(TestPublisher.Violation.REQUEST_OVERFLOW);
 
@@ -564,7 +565,7 @@ public class ReconnectMonoTests {
   public void shouldExpireValueOnRacingDisposeAndError() {
     Hooks.onErrorDropped(t -> {});
     RuntimeException runtimeException = new RuntimeException("test");
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold =
           TestPublisher.createNoncompliant(TestPublisher.Violation.REQUEST_OVERFLOW);
 
@@ -610,7 +611,7 @@ public class ReconnectMonoTests {
   public void shouldExpireValueOnRacingDisposeAndErrorWithNoBackoff() {
     Hooks.onErrorDropped(t -> {});
     RuntimeException runtimeException = new RuntimeException("test");
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold =
           TestPublisher.createNoncompliant(TestPublisher.Violation.REQUEST_OVERFLOW);
 
@@ -886,7 +887,7 @@ public class ReconnectMonoTests {
 
     final ArrayList<MonoProcessor<String>> processors = new ArrayList<>(200);
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final MonoProcessor<String> subA = MonoProcessor.create();
       final MonoProcessor<String> subB = MonoProcessor.create();
       processors.add(subA);
@@ -894,11 +895,13 @@ public class ReconnectMonoTests {
       RaceTestUtils.race(() -> reconnectMono.subscribe(subA), () -> reconnectMono.subscribe(subB));
     }
 
-    Assertions.assertThat(reconnectMono.resolvingInner.subscribers).hasSize(204);
+    Assertions.assertThat(reconnectMono.resolvingInner.subscribers)
+        .hasSize(RaceTestConstants.REPEATS * 2 + 4);
 
     sub1.dispose();
 
-    Assertions.assertThat(reconnectMono.resolvingInner.subscribers).hasSize(203);
+    Assertions.assertThat(reconnectMono.resolvingInner.subscribers)
+        .hasSize(RaceTestConstants.REPEATS * 2 + 3);
 
     publisher.next("value");
 
@@ -917,7 +920,7 @@ public class ReconnectMonoTests {
 
   @Test
   public void shouldExpireValueExactlyOnceOnRacingBetweenInvalidates() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold = TestPublisher.createCold();
       cold.next("value");
       final int timeout = 10;
@@ -959,7 +962,7 @@ public class ReconnectMonoTests {
 
   @Test
   public void shouldExpireValueExactlyOnceOnRacingBetweenInvalidateAndDispose() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final TestPublisher<String> cold = TestPublisher.createCold();
       cold.next("value");
       final int timeout = 10000;

--- a/rsocket-core/src/test/java/io/rsocket/core/ResolvingOperatorTests.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/ResolvingOperatorTests.java
@@ -16,6 +16,7 @@
 
 package io.rsocket.core;
 
+import io.rsocket.RaceTestConstants;
 import io.rsocket.internal.subscriber.AssertSubscriber;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldExpireValueOnRacingDisposeAndComplete() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final int index = i;
 
       MonoProcessor<String> processor = MonoProcessor.create();
@@ -88,7 +89,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldNotifyAllTheSubscribersUnderRacingBetweenSubscribeAndComplete() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final String valueToSend = "value" + i;
 
       MonoProcessor<String> processor = MonoProcessor.create();
@@ -142,7 +143,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldNotExpireNewlyResolvedValueIfSubscribeIsRacingWithInvalidate() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final String valueToSend = "value" + i;
       final String valueToSend2 = "value2" + i;
 
@@ -223,7 +224,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldNotExpireNewlyResolvedValueIfSubscribeIsRacingWithInvalidates() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final String valueToSend = "value" + i;
       final String valueToSend2 = "value_to_possibly_expire" + i;
 
@@ -330,7 +331,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldNotExpireNewlyResolvedValueIfBlockIsRacingWithInvalidate() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final String valueToSend = "value" + i;
       final String valueToSend2 = "value2" + i;
 
@@ -392,7 +393,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldEstablishValueOnceInCaseOfRacingBetweenSubscribers() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final String valueToSend = "value" + i;
 
       MonoProcessor<String> processor = MonoProcessor.create();
@@ -449,7 +450,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldEstablishValueOnceInCaseOfRacingBetweenSubscribeAndBlock() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final String valueToSend = "value" + i;
 
       MonoProcessor<String> processor = MonoProcessor.create();
@@ -498,7 +499,7 @@ public class ResolvingOperatorTests {
   @Test
   public void shouldEstablishValueOnceInCaseOfRacingBetweenBlocks() {
     Duration timeout = Duration.ofMillis(100);
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final String valueToSend = "value" + i;
 
       MonoProcessor<String> processor = MonoProcessor.create();
@@ -540,7 +541,7 @@ public class ResolvingOperatorTests {
   public void shouldExpireValueOnRacingDisposeAndError() {
     Hooks.onErrorDropped(t -> {});
     RuntimeException runtimeException = new RuntimeException("test");
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       MonoProcessor<String> processor = MonoProcessor.create();
       BiConsumer<String, Throwable> consumer =
           (v, t) -> {
@@ -734,7 +735,8 @@ public class ResolvingOperatorTests {
     final MonoProcessor<String> sub3 = MonoProcessor.create();
     final MonoProcessor<String> sub4 = MonoProcessor.create();
 
-    final ArrayList<MonoProcessor<String>> processors = new ArrayList<>(200);
+    final ArrayList<MonoProcessor<String>> processors =
+        new ArrayList<>(RaceTestConstants.REPEATS * 2);
 
     ResolvingTest.<String>create()
         .assertDisposeCalled(0)
@@ -753,7 +755,7 @@ public class ResolvingOperatorTests {
         .assertPendingSubscribers(4)
         .then(
             self -> {
-              for (int i = 0; i < 100; i++) {
+              for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
                 final MonoProcessor<String> subA = MonoProcessor.create();
                 final MonoProcessor<String> subB = MonoProcessor.create();
                 processors.add(subA);
@@ -764,9 +766,9 @@ public class ResolvingOperatorTests {
               }
             })
         .assertSubscribeCalled(1)
-        .assertPendingSubscribers(204)
+        .assertPendingSubscribers(RaceTestConstants.REPEATS * 2 + 4)
         .then(self -> sub1.dispose())
-        .assertPendingSubscribers(203)
+        .assertPendingSubscribers(RaceTestConstants.REPEATS * 2 + 3)
         .then(
             self -> {
               String valueToSend = "value";
@@ -789,7 +791,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldBeSerialIfRacyMonoInner() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       long[] requested = new long[] {0};
       Subscription mockSubscription = Mockito.mock(Subscription.class);
       Mockito.doAnswer(
@@ -825,7 +827,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldExpireValueExactlyOnceOnRacingBetweenInvalidates() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       ResolvingTest.create()
           .assertNothingExpired()
           .assertNothingReceived()
@@ -839,7 +841,7 @@ public class ResolvingOperatorTests {
 
   @Test
   public void shouldExpireValueExactlyOnceOnRacingBetweenInvalidateAndDispose() {
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       ResolvingTest.create()
           .assertNothingExpired()
           .assertNothingReceived()

--- a/rsocket-core/src/test/java/io/rsocket/exceptions/ExceptionsTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/exceptions/ExceptionsTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.rsocket.RaceTestConstants;
 import io.rsocket.frame.ErrorFrameCodec;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.jupiter.api.DisplayName;
@@ -201,7 +202,7 @@ final class ExceptionsTest {
   @DisplayName("from returns CustomRSocketException")
   @Test
   void fromCustomRSocketException() {
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       int randomCode =
           ThreadLocalRandom.current().nextBoolean()
               ? ThreadLocalRandom.current()

--- a/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/UnboundedProcessorTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
+import io.rsocket.RaceTestConstants;
 import io.rsocket.buffer.LeaksTrackingByteBufAllocator;
 import io.rsocket.internal.subscriber.AssertSubscriber;
 import java.time.Duration;
@@ -89,7 +90,7 @@ public class UnboundedProcessorTest {
   public void testPrioritizedSending(boolean fusedCase) {
     UnboundedProcessor<ByteBuf> processor = new UnboundedProcessor<>();
 
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       processor.onNext(Unpooled.EMPTY_BUFFER);
     }
 
@@ -108,7 +109,7 @@ public class UnboundedProcessorTest {
   public void ensureUnboundedProcessorDisposesQueueProperly(boolean withFusionEnabled) {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
 
       final ByteBuf buffer1 = allocator.buffer(1);
@@ -146,7 +147,7 @@ public class UnboundedProcessorTest {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
     final RuntimeException runtimeException = new RuntimeException("test");
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
 
       final ByteBuf buffer1 = allocator.buffer(1);
@@ -195,7 +196,7 @@ public class UnboundedProcessorTest {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
     final RuntimeException runtimeException = new RuntimeException("test");
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
 
       final ByteBuf buffer1 = allocator.buffer(1);
@@ -242,7 +243,7 @@ public class UnboundedProcessorTest {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
     final RuntimeException runtimeException = new RuntimeException("test");
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
 
       final ByteBuf buffer1 = allocator.buffer(1);
@@ -285,7 +286,7 @@ public class UnboundedProcessorTest {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
     final RuntimeException runtimeException = new RuntimeException("test");
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
 
       final ByteBuf buffer1 = allocator.buffer(1);
@@ -332,7 +333,7 @@ public class UnboundedProcessorTest {
     final LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
 
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < RaceTestConstants.REPEATS; i++) {
       final UnboundedProcessor<ByteBuf> unboundedProcessor = new UnboundedProcessor<>();
       final ByteBuf buffer1 = allocator.buffer(1);
       final ByteBuf buffer2 = allocator.buffer(2);


### PR DESCRIPTION
Makes the number of repeats of race tests as a const which can be set up through the program args 

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <oleh.dokuka@icloud.com>
