### PR TITLE
Fix #1050: Dispose of subscriptions in RSocketRequester and Responder

### DIFF
--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTerminationTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTerminationTest.java
@@ -9,12 +9,15 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RSocketRequesterTerminationTest {
 
@@ -49,6 +52,17 @@ public class RSocketRequesterTerminationTest {
         .expectError(ClosedChannelException.class)
         .verify(Duration.ofSeconds(5));
   }
+
+    @Test
+    void disposingShouldDisposeOfIncomingFramesDisposable() {
+        RSocketRequester rSocketRequester = rule.socket;
+        assertThat(rSocketRequester.isDisposed()).isFalse();
+
+        rSocketRequester.dispose();
+
+        assertThat(rSocketRequester.isDisposed()).isTrue();
+        assertThat(rSocketRequester.getIncomingFramesDisposable().isDisposed()).isTrue();
+    }
 
   public static Iterable<Function<RSocket, ? extends Publisher<?>>> rsocketInteractions() {
     EmptyPayload payload = EmptyPayload.INSTANCE;

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
@@ -1179,6 +1179,17 @@ public class RSocketResponderTest {
     rule.assertHasNoLeaks();
   }
 
+    @Test
+    void disposingShouldDisposeOfFramesDisposable() {
+        RSocketResponder rSocketResponder = rule.socket;
+        assertThat(rSocketResponder.isDisposed()).isFalse();
+
+        rSocketResponder.dispose();
+
+        assertThat(rSocketResponder.isDisposed()).isTrue();
+        assertThat(rSocketResponder.getFramesDisposable().isDisposed()).isTrue();
+    }
+
   public static class ServerSocketRule extends AbstractSocketRule<RSocketResponder> {
 
     private RSocket acceptingSocket;


### PR DESCRIPTION
Fix #1050: Dispose of subscriptions in RSocketRequester and Responder

### Motivation:

Properly dispose inner subscriptions when terminating a connection.

### Modifications:

Calling `dispose` on `Disposable`.

### Result:

No further Reactor leaks on client disconnects.