### PR TITLE
moves error propagation out of the synchronise to avoid deadlock (#1060)

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -345,15 +345,17 @@ class RSocketRequester extends RequesterResponderSupport implements RSocket {
       requesterLeaseTracker.dispose(e);
     }
 
+    final Collection<FrameHandler> activeStreamsCopy;
     synchronized (this) {
       final IntObjectMap<FrameHandler> activeStreams = this.activeStreams;
-      final Collection<FrameHandler> activeStreamsCopy = new ArrayList<>(activeStreams.values());
-      for (FrameHandler handler : activeStreamsCopy) {
-        if (handler != null) {
-          try {
-            handler.handleError(e);
-          } catch (Throwable ignored) {
-          }
+      activeStreamsCopy = new ArrayList<>(activeStreams.values());
+    }
+
+    for (FrameHandler handler : activeStreamsCopy) {
+      if (handler != null) {
+        try {
+          handler.handleError(e);
+        } catch (Throwable ignored) {
         }
       }
     }

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -185,15 +185,18 @@ class RSocketResponder extends RequesterResponderSupport implements RSocket {
     requestHandler.dispose();
   }
 
-  private synchronized void cleanUpSendingSubscriptions() {
-    final IntObjectMap<FrameHandler> activeStreams = this.activeStreams;
-    final Collection<FrameHandler> activeStreamsCopy = new ArrayList<>(activeStreams.values());
+  private void cleanUpSendingSubscriptions() {
+    final Collection<FrameHandler> activeStreamsCopy;
+    synchronized (this) {
+      final IntObjectMap<FrameHandler> activeStreams = this.activeStreams;
+      activeStreamsCopy = new ArrayList<>(activeStreams.values());
+    }
+
     for (FrameHandler handler : activeStreamsCopy) {
       if (handler != null) {
         handler.handleCancel();
       }
     }
-    activeStreams.clear();
   }
 
   final void handleFrame(ByteBuf frame) {


### PR DESCRIPTION
(cherry picked from commit 6426e45619ec32acef0c6c7184020776a9063ffe)

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
