### PR TITLE
Adds reflection hints for native-image support 1.1.x

### DIFF
--- a/rsocket-core/src/main/resources/META-INF/native-image/io.rsocket/rsocket-core/reflect-config.json
+++ b/rsocket-core/src/main/resources/META-INF/native-image/io.rsocket/rsocket-core/reflect-config.json
@@ -1,0 +1,130 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.BaseLinkedQueueConsumerNodeRef"
+    },
+    "name": "io.rsocket.internal.jctools.queues.BaseLinkedQueueConsumerNodeRef",
+    "fields": [
+      {
+        "name": "consumerNode"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.BaseLinkedQueueProducerNodeRef"
+    },
+    "name": "io.rsocket.internal.jctools.queues.BaseLinkedQueueProducerNodeRef",
+    "fields": [
+      {
+        "name": "producerNode"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields"
+    },
+    "name": "io.rsocket.internal.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+    "fields": [
+      {
+        "name": "producerLimit"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields"
+    },
+    "name": "io.rsocket.internal.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+    "fields": [
+      {
+        "name": "consumerIndex"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.BaseMpscLinkedArrayQueueProducerFields"
+    },
+    "name": "io.rsocket.internal.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+    "fields": [
+      {
+        "name": "producerIndex"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.LinkedQueueNode"
+    },
+    "name": "io.rsocket.internal.jctools.queues.LinkedQueueNode",
+    "fields": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.MpscArrayQueueConsumerIndexField"
+    },
+    "name": "io.rsocket.internal.jctools.queues.MpscArrayQueueConsumerIndexField",
+    "fields": [
+      {
+        "name": "consumerIndex"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.MpscArrayQueueProducerIndexField"
+    },
+    "name": "io.rsocket.internal.jctools.queues.MpscArrayQueueProducerIndexField",
+    "fields": [
+      {
+        "name": "producerIndex"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.MpscArrayQueueProducerLimitField"
+    },
+    "name": "io.rsocket.internal.jctools.queues.MpscArrayQueueProducerLimitField",
+    "fields": [
+      {
+        "name": "producerLimit"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.internal.jctools.queues.UnsafeAccess"
+    },
+    "name": "sun.misc.Unsafe",
+    "fields": [
+      {
+        "name": "theUnsafe"
+      }
+    ],
+    "queriedMethods": [
+      {
+        "name": "getAndAddLong",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "getAndSetObject",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  }
+]

--- a/rsocket-transport-netty/src/main/resources/META-INF/native-image/io.rsocket/rsocket-transport-netty/reflect-config.json
+++ b/rsocket-transport-netty/src/main/resources/META-INF/native-image/io.rsocket/rsocket-transport-netty/reflect-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.transport.netty.RSocketLengthCodec"
+    },
+    "name": "io.rsocket.transport.netty.RSocketLengthCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.rsocket.transport.netty.server.BaseWebsocketServerTransport$PongHandler"
+    },
+    "name": "io.rsocket.transport.netty.server.BaseWebsocketServerTransport$PongHandler",
+    "queryAllPublicMethods": true
+  }
+]


### PR DESCRIPTION
### Motivation:

The issues below are observed when trying to test rsocket native-image support 
1.
```
Caused by: java.lang.RuntimeException: java.lang.NoSuchFieldException: producerIndex",
    "	at io.rsocket.internal.jctools.queues.UnsafeAccess.fieldOffset(UnsafeAccess.java:92) ~[na:na]",
    "	at io.rsocket.internal.jctools.queues.BaseMpscLinkedArrayQueueProducerFields.<clinit>(BaseMpscLinkedArrayQueue.java:53) ~[rsocket:na]",
    "	... 34 common frames omitted",
    "Caused by: java.lang.NoSuchFieldException: producerIndex",
    "	at java.lang.Class.getDeclaredField(DynamicHub.java:968) ~[rsocket:na]",
    "	at io.rsocket.internal.jctools.queues.UnsafeAccess.fieldOffset(UnsafeAccess.java:90) ~[na:na]",
    "	... 35 common frames omitted",
```

2. When a `ChannelHandler` is added to the `Netty` channel pipeline,
`io.netty.channel.ChannelHandlerMask#mask0` will inspect the `ChannelHandler's` methods for
`io.netty.channel.ChannelHandlerMask.Skip` annotation.
When there are no reflection hints, `NoSuchMethodException` is thrown when trying to query the methods.
This will lead to methods marked as not skippable, although the program will be able to run
without any problems, when all methods are marked as not skippable, one might observe performance issues.

### Modifications:
- Add reflection hints for `jctools queues`
- Add reflection hints for `ChannelHandler's`

### Result:

No issues when testing rsocket native-image support