### PR TITLE
#1077 type safe discard element consumer

### DIFF
--- a/rsocket-core/src/test/java/io/rsocket/core/SendUtilsTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/SendUtilsTest.java
@@ -1,0 +1,32 @@
+package io.rsocket.core;
+
+import io.netty.util.ReferenceCounted;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+import static org.mockito.Mockito.*;
+
+class SendUtilsTest {
+
+    @Test
+    void droppedElementsConsumerShouldAcceptOtherTypesThanReferenceCounted() {
+        Consumer value = extractDroppedElementConsumer();
+        value.accept(new Object());
+    }
+
+    @Test
+    void droppedElementsConsumerReleaseReference() {
+        ReferenceCounted referenceCounted =  mock(ReferenceCounted.class);
+        when(referenceCounted.release()).thenReturn(true);
+
+        Consumer value = extractDroppedElementConsumer();
+        value.accept(referenceCounted);
+
+        verify(referenceCounted).release();
+    }
+
+    private static Consumer<?> extractDroppedElementConsumer() {
+        return (Consumer<?>) SendUtils.DISCARD_CONTEXT.stream().findAny().get().getValue();
+    }
+}


### PR DESCRIPTION
Discard element consumer is accepting other elements than ReferenceCounted

### Motivation:
When I use DefaultRSocketClient in logs files I see warning log entries like:

```
] WARN  reactor.core.publisher.Operators        : Error in discard hook
java.lang.ClassCastException: class org.springframework.core.io.buffer.NettyDataBuffer cannot be cast to class io.netty.util.ReferenceCounted (org.springframework.core.io.buffer.NettyDataBuffer and io.netty.util.ReferenceCounted are in unnamed module of loader 'app')
```

### Modifications:
Make discard consumer accept other types than ReferenceCounted parameter and avoid having warnings in logs

### Result:

The warning log entries are not created by DefaultRSocketClient.
