### PR TITLE
Select RSocket from the pool when retrying requestChannel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ subprojects {
         maven {
             url 'https://repo.spring.io/milestone'
             content {
+                includeGroup "io.micrometer"
                 includeGroup "io.projectreactor"
                 includeGroup "io.projectreactor.netty"
             }
@@ -114,6 +115,7 @@ subprojects {
         maven {
             url 'https://repo.spring.io/snapshot'
             content {
+                includeGroup "io.micrometer"
                 includeGroup "io.projectreactor"
                 includeGroup "io.projectreactor.netty"
             }

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ subprojects {
     ext['slf4j.version'] = '1.7.36'
     ext['jmh.version'] = '1.33'
     ext['junit.version'] = '5.8.1'
-    ext['micrometer.version'] = '1.8.4'
+    ext['micrometer.version'] = '1.10.0-SNAPSHOT'
+    ext['micrometer-tracing.version'] = '1.0.0-SNAPSHOT'
     ext['assertj.version'] = '3.22.0'
     ext['netflix.limits.version'] = '0.3.6'
     ext['bouncycastle-bcpkix.version'] = '1.70'
@@ -77,6 +78,10 @@ subprojects {
             dependency "io.netty:netty-tcnative-boringssl-static:${ext['netty-boringssl.version']}"
             dependency "org.bouncycastle:bcpkix-jdk15on:${ext['bouncycastle-bcpkix.version']}"
             dependency "io.micrometer:micrometer-core:${ext['micrometer.version']}"
+            dependency "io.micrometer:micrometer-observation:${ext['micrometer.version']}"
+            dependency "io.micrometer:micrometer-test:${ext['micrometer.version']}"
+            dependency "io.micrometer:micrometer-tracing:${ext['micrometer-tracing.version']}"
+            dependency "io.micrometer:micrometer-tracing-integration-test:${ext['micrometer-tracing.version']}"
             dependency "org.assertj:assertj-core:${ext['assertj.version']}"
             dependency "org.hdrhistogram:HdrHistogram:${ext['hdrhistogram.version']}"
             dependency "org.slf4j:slf4j-api:${ext['slf4j.version']}"
@@ -117,6 +122,7 @@ subprojects {
         if (version.endsWith('SNAPSHOT') || project.hasProperty('versionSuffix')) {
             maven { url 'https://repo.spring.io/libs-snapshot' }
             maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local' }
+            mavenLocal()
         }
     }
 
@@ -256,4 +262,31 @@ description = 'RSocket: Stream Oriented Messaging Passing with Reactive Stream S
 
 repositories {
     mavenCentral()
+
+    maven { url 'https://repo.spring.io/snapshot' }
+    mavenLocal()
+}
+
+configurations {
+    adoc
+}
+
+dependencies {
+    adoc "io.micrometer:micrometer-docs-generator-spans:1.0.0-SNAPSHOT"
+    adoc "io.micrometer:micrometer-docs-generator-metrics:1.0.0-SNAPSHOT"
+}
+
+task generateObservabilityDocs(dependsOn: ["generateObservabilityMetricsDocs", "generateObservabilitySpansDocs"]) {
+}
+
+task generateObservabilityMetricsDocs(type: JavaExec) {
+    mainClass = "io.micrometer.docs.metrics.DocsFromSources"
+    classpath configurations.adoc
+    args project.rootDir.getAbsolutePath(), ".*", project.rootProject.buildDir.getAbsolutePath()
+}
+
+task generateObservabilitySpansDocs(type: JavaExec) {
+    mainClass = "io.micrometer.docs.spans.DocsFromSources"
+    classpath configurations.adoc
+    args project.rootDir.getAbsolutePath(), ".*", project.rootProject.buildDir.getAbsolutePath()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version=1.1.2
+version=1.2.0-SNAPSHOT
 perfBaselineVersion=1.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version=1.2.0-SNAPSHOT
+version=1.2.0
 perfBaselineVersion=1.1.1

--- a/rsocket-core/build.gradle
+++ b/rsocket-core/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
-    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.awaitility:awaitility'
 
     testRuntimeOnly 'ch.qos.logback:logback-classic'

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketRequester.java
@@ -345,15 +345,17 @@ class RSocketRequester extends RequesterResponderSupport implements RSocket {
       requesterLeaseTracker.dispose(e);
     }
 
+    final Collection<FrameHandler> activeStreamsCopy;
     synchronized (this) {
       final IntObjectMap<FrameHandler> activeStreams = this.activeStreams;
-      final Collection<FrameHandler> activeStreamsCopy = new ArrayList<>(activeStreams.values());
-      for (FrameHandler handler : activeStreamsCopy) {
-        if (handler != null) {
-          try {
-            handler.handleError(e);
-          } catch (Throwable ignored) {
-          }
+      activeStreamsCopy = new ArrayList<>(activeStreams.values());
+    }
+
+    for (FrameHandler handler : activeStreamsCopy) {
+      if (handler != null) {
+        try {
+          handler.handleError(e);
+        } catch (Throwable ignored) {
         }
       }
     }

--- a/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/RSocketResponder.java
@@ -185,15 +185,18 @@ class RSocketResponder extends RequesterResponderSupport implements RSocket {
     requestHandler.dispose();
   }
 
-  private synchronized void cleanUpSendingSubscriptions() {
-    final IntObjectMap<FrameHandler> activeStreams = this.activeStreams;
-    final Collection<FrameHandler> activeStreamsCopy = new ArrayList<>(activeStreams.values());
+  private void cleanUpSendingSubscriptions() {
+    final Collection<FrameHandler> activeStreamsCopy;
+    synchronized (this) {
+      final IntObjectMap<FrameHandler> activeStreams = this.activeStreams;
+      activeStreamsCopy = new ArrayList<>(activeStreams.values());
+    }
+
     for (FrameHandler handler : activeStreamsCopy) {
       if (handler != null) {
         handler.handleCancel();
       }
     }
-    activeStreams.clear();
   }
 
   final void handleFrame(ByteBuf frame) {

--- a/rsocket-core/src/main/java/io/rsocket/loadbalance/LoadbalanceRSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/loadbalance/LoadbalanceRSocketClient.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 /**
- * An implementation of {@link RSocketClient backed by a pool of {@code RSocket} instances and using a {@link
+ * An implementation of {@link RSocketClient} backed by a pool of {@code RSocket} instances and using a {@link
  * LoadbalanceStrategy} to select the {@code RSocket} to use for a given request.
  *
  * @since 1.1
@@ -73,7 +73,7 @@ public class LoadbalanceRSocketClient implements RSocketClient {
 
   @Override
   public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
-    return rSocketPool.select().requestChannel(payloads);
+    return source().flatMapMany(rSocket -> rSocket.requestChannel(payloads));
   }
 
   @Override

--- a/rsocket-core/src/main/java/io/rsocket/loadbalance/LoadbalanceRSocketClient.java
+++ b/rsocket-core/src/main/java/io/rsocket/loadbalance/LoadbalanceRSocketClient.java
@@ -27,8 +27,8 @@ import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 /**
- * An implementation of {@link RSocketClient} backed by a pool of {@code RSocket} instances and using a {@link
- * LoadbalanceStrategy} to select the {@code RSocket} to use for a given request.
+ * An implementation of {@link RSocketClient} backed by a pool of {@code RSocket} instances and
+ * using a {@link LoadbalanceStrategy} to select the {@code RSocket} to use for a given request.
  *
  * @since 1.1
  */

--- a/rsocket-core/src/test/java/io/rsocket/loadbalance/LoadbalanceRSocketClientTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/loadbalance/LoadbalanceRSocketClientTest.java
@@ -1,0 +1,91 @@
+package io.rsocket.loadbalance;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.core.RSocketClient;
+import io.rsocket.core.RSocketConnector;
+import io.rsocket.transport.ClientTransport;
+import io.rsocket.util.DefaultPayload;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class LoadbalanceRSocketClientTest {
+
+  @Mock private ClientTransport clientTransport;
+  @Mock private RSocketConnector rSocketConnector;
+
+  public static final Duration SHORT_DURATION = Duration.ofMillis(25);
+  public static final Duration LONG_DURATION = Duration.ofMillis(75);
+
+  private static final Publisher<Payload> SOURCE =
+      Flux.interval(SHORT_DURATION).map(String::valueOf).map(DefaultPayload::create);
+
+  private static final Mono<RSocket> PROGRESSING_HANDLER =
+      Mono.just(
+          new RSocket() {
+            private final AtomicInteger i = new AtomicInteger();
+
+            @Override
+            public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+              return Flux.from(payloads)
+                  .delayElements(SHORT_DURATION)
+                  .map(Payload::getDataUtf8)
+                  .map(DefaultPayload::create)
+                  .take(i.incrementAndGet());
+            }
+          });
+
+  @Test
+  void testChannelReconnection() {
+    when(rSocketConnector.connect(clientTransport)).thenReturn(PROGRESSING_HANDLER);
+
+    RSocketClient client =
+        LoadbalanceRSocketClient.create(
+            rSocketConnector,
+            Mono.just(singletonList(LoadbalanceTarget.from("key", clientTransport))));
+
+    Publisher<String> result =
+        client
+            .requestChannel(SOURCE)
+            .repeatWhen(longFlux -> longFlux.delayElements(LONG_DURATION).take(5))
+            .map(Payload::getDataUtf8)
+            .log();
+
+    StepVerifier.create(result)
+        .expectSubscription()
+        .assertNext(s -> assertThat(s).isEqualTo("0"))
+        .assertNext(s -> assertThat(s).isEqualTo("0"))
+        .assertNext(s -> assertThat(s).isEqualTo("1"))
+        .assertNext(s -> assertThat(s).isEqualTo("0"))
+        .assertNext(s -> assertThat(s).isEqualTo("1"))
+        .assertNext(s -> assertThat(s).isEqualTo("2"))
+        .assertNext(s -> assertThat(s).isEqualTo("0"))
+        .assertNext(s -> assertThat(s).isEqualTo("1"))
+        .assertNext(s -> assertThat(s).isEqualTo("2"))
+        .assertNext(s -> assertThat(s).isEqualTo("3"))
+        .assertNext(s -> assertThat(s).isEqualTo("0"))
+        .assertNext(s -> assertThat(s).isEqualTo("1"))
+        .assertNext(s -> assertThat(s).isEqualTo("2"))
+        .assertNext(s -> assertThat(s).isEqualTo("3"))
+        .assertNext(s -> assertThat(s).isEqualTo("4"))
+        .verifyComplete();
+
+    verify(rSocketConnector).connect(clientTransport);
+    verifyNoMoreInteractions(rSocketConnector, clientTransport);
+  }
+}

--- a/rsocket-examples/build.gradle
+++ b/rsocket-examples/build.gradle
@@ -24,6 +24,11 @@ dependencies {
     implementation project(':rsocket-transport-local')
     implementation project(':rsocket-transport-netty')
 
+    implementation "io.micrometer:micrometer-core"
+    implementation "io.micrometer:micrometer-tracing"
+    implementation project(":rsocket-micrometer")
+    testImplementation 'org.awaitility:awaitility'
+
     implementation 'com.netflix.concurrency-limits:concurrency-limits-core'
 
     runtimeOnly 'ch.qos.logback:logback-classic'
@@ -33,6 +38,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation "io.micrometer:micrometer-test"
+    testImplementation "io.micrometer:micrometer-tracing-integration-test"
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/rsocket-examples/src/test/java/io/rsocket/integration/observation/ObservationIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/observation/ObservationIntegrationTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.integration.observation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.tck.MeterRegistryAssert;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.test.SampleTestRunner;
+import io.micrometer.tracing.test.reporter.BuildingBlocks;
+import io.micrometer.tracing.test.simple.SpansAssert;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.core.RSocketConnector;
+import io.rsocket.core.RSocketServer;
+import io.rsocket.micrometer.observation.ByteBufGetter;
+import io.rsocket.micrometer.observation.ByteBufSetter;
+import io.rsocket.micrometer.observation.ObservationRequesterRSocketProxy;
+import io.rsocket.micrometer.observation.ObservationResponderRSocketProxy;
+import io.rsocket.micrometer.observation.RSocketRequesterTracingObservationHandler;
+import io.rsocket.micrometer.observation.RSocketResponderTracingObservationHandler;
+import io.rsocket.plugins.RSocketInterceptor;
+import io.rsocket.transport.netty.client.TcpClientTransport;
+import io.rsocket.transport.netty.server.CloseableChannel;
+import io.rsocket.transport.netty.server.TcpServerTransport;
+import io.rsocket.util.DefaultPayload;
+import java.time.Duration;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class ObservationIntegrationTest extends SampleTestRunner {
+  private static final MeterRegistry registry = new SimpleMeterRegistry();
+  private static final ObservationRegistry observationRegistry = ObservationRegistry.create();
+
+  static {
+    observationRegistry
+        .observationConfig()
+        .observationHandler(new DefaultMeterObservationHandler(registry));
+  }
+
+  private final RSocketInterceptor requesterInterceptor;
+  private final RSocketInterceptor responderInterceptor;
+
+  ObservationIntegrationTest() {
+    super(SampleRunnerConfig.builder().build(), observationRegistry, registry);
+    requesterInterceptor =
+        reactiveSocket -> new ObservationRequesterRSocketProxy(reactiveSocket, observationRegistry);
+
+    responderInterceptor =
+        reactiveSocket -> new ObservationResponderRSocketProxy(reactiveSocket, observationRegistry);
+  }
+
+  private CloseableChannel server;
+  private RSocket client;
+  private AtomicInteger counter;
+
+  @Override
+  public BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>>
+      customizeObservationHandlers() {
+    return (buildingBlocks, observationHandlers) -> {
+      observationHandlers.addFirst(
+          new RSocketRequesterTracingObservationHandler(
+              buildingBlocks.getTracer(),
+              buildingBlocks.getPropagator(),
+              new ByteBufSetter(),
+              false));
+      observationHandlers.addFirst(
+          new RSocketResponderTracingObservationHandler(
+              buildingBlocks.getTracer(),
+              buildingBlocks.getPropagator(),
+              new ByteBufGetter(),
+              false));
+    };
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (server != null) {
+      server.dispose();
+    }
+  }
+
+  private void testRequest() {
+    counter.set(0);
+    client.requestResponse(DefaultPayload.create("REQUEST", "META")).block();
+    assertThat(counter).as("Server did not see the request.").hasValue(1);
+  }
+
+  private void testStream() {
+    counter.set(0);
+    client.requestStream(DefaultPayload.create("start")).blockLast();
+
+    assertThat(counter).as("Server did not see the request.").hasValue(1);
+  }
+
+  private void testRequestChannel() {
+    counter.set(0);
+    client.requestChannel(Mono.just(DefaultPayload.create("start"))).blockFirst();
+    assertThat(counter).as("Server did not see the request.").hasValue(1);
+  }
+
+  private void testFireAndForget() {
+    counter.set(0);
+    client.fireAndForget(DefaultPayload.create("start")).subscribe();
+    Awaitility.await().atMost(Duration.ofSeconds(50)).until(() -> counter.get() == 1);
+    assertThat(counter).as("Server did not see the request.").hasValue(1);
+  }
+
+  @Override
+  public SampleTestRunnerConsumer yourCode() {
+    return (bb, meterRegistry) -> {
+      counter = new AtomicInteger();
+      server =
+          RSocketServer.create(
+                  (setup, sendingSocket) -> {
+                    sendingSocket.onClose().subscribe();
+
+                    return Mono.just(
+                        new RSocket() {
+                          @Override
+                          public Mono<Payload> requestResponse(Payload payload) {
+                            payload.release();
+                            counter.incrementAndGet();
+                            return Mono.just(DefaultPayload.create("RESPONSE", "METADATA"));
+                          }
+
+                          @Override
+                          public Flux<Payload> requestStream(Payload payload) {
+                            payload.release();
+                            counter.incrementAndGet();
+                            return Flux.range(1, 10_000)
+                                .map(i -> DefaultPayload.create("data -> " + i));
+                          }
+
+                          @Override
+                          public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+                            counter.incrementAndGet();
+                            return Flux.from(payloads);
+                          }
+
+                          @Override
+                          public Mono<Void> fireAndForget(Payload payload) {
+                            payload.release();
+                            counter.incrementAndGet();
+                            return Mono.empty();
+                          }
+                        });
+                  })
+              .interceptors(registry -> registry.forResponder(responderInterceptor))
+              .bind(TcpServerTransport.create("localhost", 0))
+              .block();
+
+      client =
+          RSocketConnector.create()
+              .interceptors(registry -> registry.forRequester(requesterInterceptor))
+              .connect(TcpClientTransport.create(server.address()))
+              .block();
+
+      testRequest();
+
+      testStream();
+
+      testRequestChannel();
+
+      testFireAndForget();
+
+      // @formatter:off
+      SpansAssert.assertThat(bb.getFinishedSpans())
+          .haveSameTraceId()
+          // "request_*" + "handle" x 4
+          .hasNumberOfSpansEqualTo(8)
+          .hasNumberOfSpansWithNameEqualTo("handle", 4)
+          .forAllSpansWithNameEqualTo("handle", span -> span.hasTagWithKey("rsocket.request-type"))
+          .hasASpanWithNameIgnoreCase("request_stream")
+          .thenASpanWithNameEqualToIgnoreCase("request_stream")
+          .hasTag("rsocket.request-type", "REQUEST_STREAM")
+          .backToSpans()
+          .hasASpanWithNameIgnoreCase("request_channel")
+          .thenASpanWithNameEqualToIgnoreCase("request_channel")
+          .hasTag("rsocket.request-type", "REQUEST_CHANNEL")
+          .backToSpans()
+          .hasASpanWithNameIgnoreCase("request_fnf")
+          .thenASpanWithNameEqualToIgnoreCase("request_fnf")
+          .hasTag("rsocket.request-type", "REQUEST_FNF")
+          .backToSpans()
+          .hasASpanWithNameIgnoreCase("request_response")
+          .thenASpanWithNameEqualToIgnoreCase("request_response")
+          .hasTag("rsocket.request-type", "REQUEST_RESPONSE");
+
+      MeterRegistryAssert.assertThat(registry)
+          .hasTimerWithNameAndTags(
+              "rsocket.response",
+              Tags.of(Tag.of("error", "none"), Tag.of("rsocket.request-type", "REQUEST_RESPONSE")))
+          .hasTimerWithNameAndTags(
+              "rsocket.fnf",
+              Tags.of(Tag.of("error", "none"), Tag.of("rsocket.request-type", "REQUEST_FNF")))
+          .hasTimerWithNameAndTags(
+              "rsocket.request",
+              Tags.of(Tag.of("error", "none"), Tag.of("rsocket.request-type", "REQUEST_RESPONSE")))
+          .hasTimerWithNameAndTags(
+              "rsocket.channel",
+              Tags.of(Tag.of("error", "none"), Tag.of("rsocket.request-type", "REQUEST_CHANNEL")))
+          .hasTimerWithNameAndTags(
+              "rsocket.stream",
+              Tags.of(Tag.of("error", "none"), Tag.of("rsocket.request-type", "REQUEST_STREAM")));
+      // @formatter:on
+    };
+  }
+}

--- a/rsocket-examples/src/test/java/io/rsocket/integration/observation/ObservationIntegrationTest.java
+++ b/rsocket-examples/src/test/java/io/rsocket/integration/observation/ObservationIntegrationTest.java
@@ -69,7 +69,7 @@ public class ObservationIntegrationTest extends SampleTestRunner {
   private final RSocketInterceptor responderInterceptor;
 
   ObservationIntegrationTest() {
-    super(SampleRunnerConfig.builder().build(), observationRegistry, registry);
+    super(SampleRunnerConfig.builder().build());
     requesterInterceptor =
         reactiveSocket -> new ObservationRequesterRSocketProxy(reactiveSocket, observationRegistry);
 
@@ -232,5 +232,15 @@ public class ObservationIntegrationTest extends SampleTestRunner {
               Tags.of(Tag.of("error", "none"), Tag.of("rsocket.request-type", "REQUEST_STREAM")));
       // @formatter:on
     };
+  }
+
+  @Override
+  protected MeterRegistry getMeterRegistry() {
+    return registry;
+  }
+
+  @Override
+  protected ObservationRegistry getObservationRegistry() {
+    return observationRegistry;
   }
 }

--- a/rsocket-micrometer/build.gradle
+++ b/rsocket-micrometer/build.gradle
@@ -22,7 +22,9 @@ plugins {
 
 dependencies {
     api project(':rsocket-core')
+    api 'io.micrometer:micrometer-observation'
     api 'io.micrometer:micrometer-core'
+    compileOnly 'io.micrometer:micrometer-tracing'
 
     implementation 'org.slf4j:slf4j-api'
 

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/ByteBufGetter.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/ByteBufGetter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.tracing.propagation.Propagator;
+import io.netty.buffer.ByteBuf;
+import io.netty.util.CharsetUtil;
+import io.rsocket.metadata.CompositeMetadata;
+
+public class ByteBufGetter implements Propagator.Getter<ByteBuf> {
+
+  @Override
+  public String get(ByteBuf carrier, String key) {
+    final CompositeMetadata compositeMetadata = new CompositeMetadata(carrier, false);
+    for (CompositeMetadata.Entry entry : compositeMetadata) {
+      if (key.equals(entry.getMimeType())) {
+        return entry.getContent().toString(CharsetUtil.UTF_8);
+      }
+    }
+    return null;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/ByteBufSetter.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/ByteBufSetter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.tracing.propagation.Propagator;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.CompositeByteBuf;
+import io.rsocket.metadata.CompositeMetadataCodec;
+
+public class ByteBufSetter implements Propagator.Setter<CompositeByteBuf> {
+
+  @Override
+  public void set(CompositeByteBuf carrier, String key, String value) {
+    final ByteBufAllocator alloc = carrier.alloc();
+    CompositeMetadataCodec.encodeAndAddMetadataWithCompression(
+        carrier, alloc, key, ByteBufUtil.writeUtf8(alloc, value));
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/CompositeMetadataUtils.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/CompositeMetadataUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.core.lang.Nullable;
+import io.netty.buffer.ByteBuf;
+import io.rsocket.metadata.CompositeMetadata;
+
+final class CompositeMetadataUtils {
+
+  private CompositeMetadataUtils() {
+    throw new IllegalStateException("Can't instantiate a utility class");
+  }
+
+  @Nullable
+  static ByteBuf extract(ByteBuf metadata, String key) {
+    final CompositeMetadata compositeMetadata = new CompositeMetadata(metadata, false);
+    for (CompositeMetadata.Entry entry : compositeMetadata) {
+      final String entryKey = entry.getMimeType();
+      if (key.equals(entryKey)) {
+        return entry.getContent();
+      }
+    }
+    return null;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/DefaultRSocketObservationConvention.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/DefaultRSocketObservationConvention.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.rsocket.frame.FrameType;
+
+/**
+ * Default {@link RSocketRequesterObservationConvention} implementation.
+ *
+ * @author Marcin Grzejszczak
+ * @since 2.0.0
+ */
+class DefaultRSocketObservationConvention {
+
+  private final RSocketContext rSocketContext;
+
+  public DefaultRSocketObservationConvention(RSocketContext rSocketContext) {
+    this.rSocketContext = rSocketContext;
+  }
+
+  String getName() {
+    if (this.rSocketContext.frameType == FrameType.REQUEST_FNF) {
+      return "rsocket.fnf";
+    } else if (this.rSocketContext.frameType == FrameType.REQUEST_STREAM) {
+      return "rsocket.stream";
+    } else if (this.rSocketContext.frameType == FrameType.REQUEST_CHANNEL) {
+      return "rsocket.channel";
+    }
+    return "%s";
+  }
+
+  protected RSocketContext getRSocketContext() {
+    return this.rSocketContext;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/DefaultRSocketRequesterObservationConvention.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/DefaultRSocketRequesterObservationConvention.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.observation.Observation;
+import io.rsocket.frame.FrameType;
+
+/**
+ * Default {@link RSocketRequesterObservationConvention} implementation.
+ *
+ * @author Marcin Grzejszczak
+ * @since 2.0.0
+ */
+public class DefaultRSocketRequesterObservationConvention
+    extends DefaultRSocketObservationConvention implements RSocketRequesterObservationConvention {
+
+  public DefaultRSocketRequesterObservationConvention(RSocketContext rSocketContext) {
+    super(rSocketContext);
+  }
+
+  @Override
+  public KeyValues getLowCardinalityKeyValues(RSocketContext context) {
+    KeyValues values =
+        KeyValues.of(
+            RSocketDocumentedObservation.ResponderTags.REQUEST_TYPE.withValue(
+                context.frameType.name()));
+    if (StringUtils.isNotBlank(context.route)) {
+      values =
+          values.and(RSocketDocumentedObservation.ResponderTags.ROUTE.withValue(context.route));
+    }
+    return values;
+  }
+
+  @Override
+  public boolean supportsContext(Observation.Context context) {
+    return context instanceof RSocketContext;
+  }
+
+  @Override
+  public String getName() {
+    if (getRSocketContext().frameType == FrameType.REQUEST_RESPONSE) {
+      return "rsocket.request";
+    }
+    return super.getName();
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/DefaultRSocketResponderObservationConvention.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/DefaultRSocketResponderObservationConvention.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.observation.Observation;
+import io.rsocket.frame.FrameType;
+
+/**
+ * Default {@link RSocketRequesterObservationConvention} implementation.
+ *
+ * @author Marcin Grzejszczak
+ * @since 2.0.0
+ */
+public class DefaultRSocketResponderObservationConvention
+    extends DefaultRSocketObservationConvention implements RSocketResponderObservationConvention {
+
+  public DefaultRSocketResponderObservationConvention(RSocketContext rSocketContext) {
+    super(rSocketContext);
+  }
+
+  @Override
+  public KeyValues getLowCardinalityKeyValues(RSocketContext context) {
+    KeyValues tags =
+        KeyValues.of(
+            RSocketDocumentedObservation.ResponderTags.REQUEST_TYPE.withValue(
+                context.frameType.name()));
+    if (StringUtils.isNotBlank(context.route)) {
+      tags = tags.and(RSocketDocumentedObservation.ResponderTags.ROUTE.withValue(context.route));
+    }
+    return tags;
+  }
+
+  @Override
+  public boolean supportsContext(Observation.Context context) {
+    return context instanceof RSocketContext;
+  }
+
+  @Override
+  public String getName() {
+    if (getRSocketContext().frameType == FrameType.REQUEST_RESPONSE) {
+      return "rsocket.response";
+    }
+    return super.getName();
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/ObservationRequesterRSocketProxy.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/ObservationRequesterRSocketProxy.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.docs.DocumentedObservation;
+import io.netty.buffer.ByteBuf;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.frame.FrameType;
+import io.rsocket.metadata.RoutingMetadata;
+import io.rsocket.metadata.WellKnownMimeType;
+import io.rsocket.util.RSocketProxy;
+import java.util.Iterator;
+import java.util.function.Function;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.context.ContextView;
+
+/**
+ * Tracing representation of a {@link RSocketProxy} for the requester.
+ *
+ * @author Marcin Grzejszczak
+ * @author Oleh Dokuka
+ * @since 3.1.0
+ */
+public class ObservationRequesterRSocketProxy extends RSocketProxy {
+
+  private final ObservationRegistry observationRegistry;
+
+  private RSocketRequesterObservationConvention observationConvention;
+
+  public ObservationRequesterRSocketProxy(RSocket source, ObservationRegistry observationRegistry) {
+    super(source);
+    this.observationRegistry = observationRegistry;
+  }
+
+  @Override
+  public Mono<Void> fireAndForget(Payload payload) {
+    return setObservation(
+        super::fireAndForget,
+        payload,
+        FrameType.REQUEST_FNF,
+        RSocketDocumentedObservation.RSOCKET_REQUESTER_FNF);
+  }
+
+  @Override
+  public Mono<Payload> requestResponse(Payload payload) {
+    return setObservation(
+        super::requestResponse,
+        payload,
+        FrameType.REQUEST_RESPONSE,
+        RSocketDocumentedObservation.RSOCKET_REQUESTER_REQUEST_RESPONSE);
+  }
+
+  <T> Mono<T> setObservation(
+      Function<Payload, Mono<T>> input,
+      Payload payload,
+      FrameType frameType,
+      DocumentedObservation observation) {
+    return Mono.deferContextual(
+        contextView -> {
+          if (contextView.hasKey(Observation.class)) {
+            Observation parent = contextView.get(Observation.class);
+            try (Observation.Scope scope = parent.openScope()) {
+              return observe(input, payload, frameType, observation);
+            }
+          }
+          return observe(input, payload, frameType, observation);
+        });
+  }
+
+  private String route(Payload payload) {
+    if (payload.hasMetadata()) {
+      try {
+        ByteBuf extracted =
+            CompositeMetadataUtils.extract(
+                payload.sliceMetadata(), WellKnownMimeType.MESSAGE_RSOCKET_ROUTING.getString());
+        final RoutingMetadata routingMetadata = new RoutingMetadata(extracted);
+        final Iterator<String> iterator = routingMetadata.iterator();
+        return iterator.next();
+      } catch (Exception e) {
+
+      }
+    }
+    return null;
+  }
+
+  private <T> Mono<T> observe(
+      Function<Payload, Mono<T>> input,
+      Payload payload,
+      FrameType frameType,
+      DocumentedObservation obs) {
+    String route = route(payload);
+    RSocketContext rSocketContext =
+        new RSocketContext(
+            payload, payload.sliceMetadata(), frameType, route, RSocketContext.Side.REQUESTER);
+    Observation observation =
+        obs.start(
+            this.observationConvention,
+            new DefaultRSocketRequesterObservationConvention(rSocketContext),
+            rSocketContext,
+            observationRegistry);
+    setContextualName(frameType, route, observation);
+    Payload newPayload = payload;
+    if (rSocketContext.modifiedPayload != null) {
+      newPayload = rSocketContext.modifiedPayload;
+    }
+    return input
+        .apply(newPayload)
+        .doOnError(observation::error)
+        .doFinally(signalType -> observation.stop());
+  }
+
+  private Observation observation(ContextView contextView) {
+    if (contextView.hasKey(Observation.class)) {
+      return contextView.get(Observation.class);
+    }
+    return null;
+  }
+
+  @Override
+  public Flux<Payload> requestStream(Payload payload) {
+    return Flux.deferContextual(
+        contextView ->
+            setObservation(
+                super::requestStream,
+                payload,
+                contextView,
+                FrameType.REQUEST_STREAM,
+                RSocketDocumentedObservation.RSOCKET_REQUESTER_REQUEST_STREAM));
+  }
+
+  @Override
+  public Flux<Payload> requestChannel(Publisher<Payload> inbound) {
+    return Flux.from(inbound)
+        .switchOnFirst(
+            (firstSignal, flux) -> {
+              final Payload firstPayload = firstSignal.get();
+              if (firstPayload != null) {
+                return setObservation(
+                    p -> super.requestChannel(flux.skip(1).startWith(p)),
+                    firstPayload,
+                    firstSignal.getContextView(),
+                    FrameType.REQUEST_CHANNEL,
+                    RSocketDocumentedObservation.RSOCKET_REQUESTER_REQUEST_CHANNEL);
+              }
+              return flux;
+            });
+  }
+
+  private Flux<Payload> setObservation(
+      Function<Payload, Flux<Payload>> input,
+      Payload payload,
+      ContextView contextView,
+      FrameType frameType,
+      DocumentedObservation obs) {
+    Observation parentObservation = observation(contextView);
+    if (parentObservation == null) {
+      return observationFlux(input, payload, frameType, obs);
+    }
+    try (Observation.Scope scope = parentObservation.openScope()) {
+      return observationFlux(input, payload, frameType, obs);
+    }
+  }
+
+  private Flux<Payload> observationFlux(
+      Function<Payload, Flux<Payload>> input,
+      Payload payload,
+      FrameType frameType,
+      DocumentedObservation obs) {
+    return Flux.deferContextual(
+        contextView -> {
+          String route = route(payload);
+          RSocketContext rSocketContext =
+              new RSocketContext(
+                  payload,
+                  payload.sliceMetadata(),
+                  frameType,
+                  route,
+                  RSocketContext.Side.REQUESTER);
+          Observation newObservation =
+              obs.start(
+                  this.observationConvention,
+                  new DefaultRSocketRequesterObservationConvention(rSocketContext),
+                  rSocketContext,
+                  this.observationRegistry);
+          setContextualName(frameType, route, newObservation);
+          return input
+              .apply(rSocketContext.modifiedPayload)
+              .doOnError(newObservation::error)
+              .doFinally(signalType -> newObservation.stop());
+        });
+  }
+
+  private void setContextualName(FrameType frameType, String route, Observation newObservation) {
+    if (StringUtils.isNotBlank(route)) {
+      newObservation.contextualName(frameType.name() + " " + route);
+    } else {
+      newObservation.contextualName(frameType.name());
+    }
+  }
+
+  public void setObservationConvention(RSocketRequesterObservationConvention convention) {
+    this.observationConvention = convention;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/ObservationResponderRSocketProxy.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/ObservationResponderRSocketProxy.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.netty.buffer.ByteBuf;
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.frame.FrameType;
+import io.rsocket.metadata.RoutingMetadata;
+import io.rsocket.metadata.WellKnownMimeType;
+import io.rsocket.util.RSocketProxy;
+import java.util.Iterator;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Tracing representation of a {@link RSocketProxy} for the responder.
+ *
+ * @author Marcin Grzejszczak
+ * @author Oleh Dokuka
+ * @since 3.1.0
+ */
+public class ObservationResponderRSocketProxy extends RSocketProxy {
+
+  private final ObservationRegistry observationRegistry;
+
+  private RSocketResponderObservationConvention observationConvention;
+
+  public ObservationResponderRSocketProxy(RSocket source, ObservationRegistry observationRegistry) {
+    super(source);
+    this.observationRegistry = observationRegistry;
+  }
+
+  @Override
+  public Mono<Void> fireAndForget(Payload payload) {
+    // called on Netty EventLoop
+    // there can't be observation in thread local here
+    ByteBuf sliceMetadata = payload.sliceMetadata();
+    String route = route(payload, sliceMetadata);
+    RSocketContext rSocketContext =
+        new RSocketContext(
+            payload,
+            payload.sliceMetadata(),
+            FrameType.REQUEST_FNF,
+            route,
+            RSocketContext.Side.RESPONDER);
+    Observation newObservation =
+        startObservation(RSocketDocumentedObservation.RSOCKET_RESPONDER_FNF, rSocketContext);
+    return super.fireAndForget(rSocketContext.modifiedPayload)
+        .doOnError(newObservation::error)
+        .doFinally(signalType -> newObservation.stop());
+  }
+
+  private Observation startObservation(
+      RSocketDocumentedObservation observation, RSocketContext rSocketContext) {
+    return observation.start(
+        this.observationConvention,
+        new DefaultRSocketResponderObservationConvention(rSocketContext),
+        rSocketContext,
+        this.observationRegistry);
+  }
+
+  @Override
+  public Mono<Payload> requestResponse(Payload payload) {
+    ByteBuf sliceMetadata = payload.sliceMetadata();
+    String route = route(payload, sliceMetadata);
+    RSocketContext rSocketContext =
+        new RSocketContext(
+            payload,
+            payload.sliceMetadata(),
+            FrameType.REQUEST_RESPONSE,
+            route,
+            RSocketContext.Side.RESPONDER);
+    Observation newObservation =
+        startObservation(
+            RSocketDocumentedObservation.RSOCKET_RESPONDER_REQUEST_RESPONSE, rSocketContext);
+    return super.requestResponse(rSocketContext.modifiedPayload)
+        .doOnError(newObservation::error)
+        .doFinally(signalType -> newObservation.stop());
+  }
+
+  @Override
+  public Flux<Payload> requestStream(Payload payload) {
+    ByteBuf sliceMetadata = payload.sliceMetadata();
+    String route = route(payload, sliceMetadata);
+    RSocketContext rSocketContext =
+        new RSocketContext(
+            payload, sliceMetadata, FrameType.REQUEST_STREAM, route, RSocketContext.Side.RESPONDER);
+    Observation newObservation =
+        startObservation(
+            RSocketDocumentedObservation.RSOCKET_RESPONDER_REQUEST_STREAM, rSocketContext);
+    return super.requestStream(rSocketContext.modifiedPayload)
+        .doOnError(newObservation::error)
+        .doFinally(signalType -> newObservation.stop());
+  }
+
+  @Override
+  public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
+    return Flux.from(payloads)
+        .switchOnFirst(
+            (firstSignal, flux) -> {
+              final Payload firstPayload = firstSignal.get();
+              if (firstPayload != null) {
+                ByteBuf sliceMetadata = firstPayload.sliceMetadata();
+                String route = route(firstPayload, sliceMetadata);
+                RSocketContext rSocketContext =
+                    new RSocketContext(
+                        firstPayload,
+                        firstPayload.sliceMetadata(),
+                        FrameType.REQUEST_CHANNEL,
+                        route,
+                        RSocketContext.Side.RESPONDER);
+                Observation newObservation =
+                    startObservation(
+                        RSocketDocumentedObservation.RSOCKET_RESPONDER_REQUEST_CHANNEL,
+                        rSocketContext);
+                if (StringUtils.isNotBlank(route)) {
+                  newObservation.contextualName(rSocketContext.frameType.name() + " " + route);
+                }
+                return super.requestChannel(flux.skip(1).startWith(rSocketContext.modifiedPayload))
+                    .doOnError(newObservation::error)
+                    .doFinally(signalType -> newObservation.stop());
+              }
+              return flux;
+            });
+  }
+
+  private String route(Payload payload, ByteBuf headers) {
+    if (payload.hasMetadata()) {
+      try {
+        final ByteBuf extract =
+            CompositeMetadataUtils.extract(
+                headers, WellKnownMimeType.MESSAGE_RSOCKET_ROUTING.getString());
+        if (extract != null) {
+          final RoutingMetadata routingMetadata = new RoutingMetadata(extract);
+          final Iterator<String> iterator = routingMetadata.iterator();
+          return iterator.next();
+        }
+      } catch (Exception e) {
+
+      }
+    }
+    return null;
+  }
+
+  public void setObservationConvention(RSocketResponderObservationConvention convention) {
+    this.observationConvention = convention;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/PayloadUtils.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/PayloadUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.rsocket.Payload;
+import io.rsocket.metadata.CompositeMetadata;
+import io.rsocket.metadata.CompositeMetadata.Entry;
+import io.rsocket.metadata.CompositeMetadataCodec;
+import io.rsocket.metadata.WellKnownMimeType;
+import io.rsocket.util.ByteBufPayload;
+import io.rsocket.util.DefaultPayload;
+import java.util.HashSet;
+import java.util.Set;
+
+final class PayloadUtils {
+
+  private PayloadUtils() {
+    throw new IllegalStateException("Can't instantiate a utility class");
+  }
+
+  static CompositeByteBuf cleanTracingMetadata(Payload payload, Set<String> fields) {
+    Set<String> fieldsWithDefaultZipkin = new HashSet<>(fields);
+    fieldsWithDefaultZipkin.add(WellKnownMimeType.MESSAGE_RSOCKET_TRACING_ZIPKIN.getString());
+    final CompositeByteBuf metadata = ByteBufAllocator.DEFAULT.compositeBuffer();
+    if (payload.hasMetadata()) {
+      try {
+        final CompositeMetadata entries = new CompositeMetadata(payload.metadata(), false);
+        for (Entry entry : entries) {
+          if (!fieldsWithDefaultZipkin.contains(entry.getMimeType())) {
+            CompositeMetadataCodec.encodeAndAddMetadataWithCompression(
+                metadata,
+                ByteBufAllocator.DEFAULT,
+                entry.getMimeType(),
+                entry.getContent().retain());
+          }
+        }
+      } catch (Exception e) {
+
+      }
+    }
+    return metadata;
+  }
+
+  static Payload payload(Payload payload, CompositeByteBuf metadata) {
+    final Payload newPayload;
+    try {
+      if (payload instanceof ByteBufPayload) {
+        newPayload = ByteBufPayload.create(payload.data().retain(), metadata);
+      } else {
+        newPayload = DefaultPayload.create(payload.data().retain(), metadata);
+      }
+    } finally {
+      payload.release();
+    }
+    return newPayload;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketContext.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketContext.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.observation.Observation;
+import io.netty.buffer.ByteBuf;
+import io.rsocket.Payload;
+import io.rsocket.frame.FrameType;
+
+public class RSocketContext extends Observation.Context {
+
+  final Payload payload;
+
+  final ByteBuf metadata;
+
+  final FrameType frameType;
+
+  final String route;
+
+  final Side side;
+
+  Payload modifiedPayload;
+
+  RSocketContext(
+      Payload payload, ByteBuf metadata, FrameType frameType, @Nullable String route, Side side) {
+    this.payload = payload;
+    this.metadata = metadata;
+    this.frameType = frameType;
+    this.route = route;
+    this.side = side;
+  }
+
+  public enum Side {
+    REQUESTER,
+    RESPONDER
+  }
+
+  public Payload getPayload() {
+    return payload;
+  }
+
+  public ByteBuf getMetadata() {
+    return metadata;
+  }
+
+  public FrameType getFrameType() {
+    return frameType;
+  }
+
+  public String getRoute() {
+    return route;
+  }
+
+  public Side getSide() {
+    return side;
+  }
+
+  public Payload getModifiedPayload() {
+    return modifiedPayload;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketDocumentedObservation.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketDocumentedObservation.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.docs.DocumentedObservation;
+
+enum RSocketDocumentedObservation implements DocumentedObservation {
+
+  /** Observation created on the RSocket responder side. */
+  RSOCKET_RESPONDER {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketResponderObservationConvention.class;
+    }
+  },
+
+  /** Observation created on the RSocket requester side for Fire and Forget frame type. */
+  RSOCKET_REQUESTER_FNF {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketRequesterObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return RequesterTags.values();
+    }
+
+    @Override
+    public String getPrefix() {
+      return "rsocket.";
+    }
+  },
+
+  /** Observation created on the RSocket responder side for Fire and Forget frame type. */
+  RSOCKET_RESPONDER_FNF {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketResponderObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return ResponderTags.values();
+    }
+
+    @Override
+    public String getPrefix() {
+      return "rsocket.";
+    }
+  },
+
+  /** Observation created on the RSocket requester side for Request Response frame type. */
+  RSOCKET_REQUESTER_REQUEST_RESPONSE {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketRequesterObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return RequesterTags.values();
+    }
+
+    @Override
+    public String getPrefix() {
+      return "rsocket.";
+    }
+  },
+
+  /** Observation created on the RSocket responder side for Request Response frame type. */
+  RSOCKET_RESPONDER_REQUEST_RESPONSE {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketResponderObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return ResponderTags.values();
+    }
+
+    @Override
+    public String getPrefix() {
+      return "rsocket.";
+    }
+  },
+
+  /** Observation created on the RSocket requester side for Request Stream frame type. */
+  RSOCKET_REQUESTER_REQUEST_STREAM {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketRequesterObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return RequesterTags.values();
+    }
+
+    @Override
+    public String getPrefix() {
+      return "rsocket.";
+    }
+  },
+
+  /** Observation created on the RSocket responder side for Request Stream frame type. */
+  RSOCKET_RESPONDER_REQUEST_STREAM {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketResponderObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return ResponderTags.values();
+    }
+
+    @Override
+    public String getPrefix() {
+      return "rsocket.";
+    }
+  },
+
+  /** Observation created on the RSocket requester side for Request Channel frame type. */
+  RSOCKET_REQUESTER_REQUEST_CHANNEL {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketRequesterObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return RequesterTags.values();
+    }
+
+    @Override
+    public String getPrefix() {
+      return "rsocket.";
+    }
+  },
+
+  /** Observation created on the RSocket responder side for Request Channel frame type. */
+  RSOCKET_RESPONDER_REQUEST_CHANNEL {
+    @Override
+    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRSocketResponderObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return ResponderTags.values();
+    }
+
+    @Override
+    public String getPrefix() {
+      return "rsocket.";
+    }
+  };
+
+  enum RequesterTags implements KeyName {
+
+    /** Name of the RSocket route. */
+    ROUTE {
+      @Override
+      public String asString() {
+        return "rsocket.route";
+      }
+    },
+
+    /** Name of the RSocket request type. */
+    REQUEST_TYPE {
+      @Override
+      public String asString() {
+        return "rsocket.request-type";
+      }
+    },
+
+    /** Name of the RSocket content type. */
+    CONTENT_TYPE {
+      @Override
+      public String asString() {
+        return "rsocket.content-type";
+      }
+    }
+  }
+
+  enum ResponderTags implements KeyName {
+
+    /** Name of the RSocket route. */
+    ROUTE {
+      @Override
+      public String asString() {
+        return "rsocket.route";
+      }
+    },
+
+    /** Name of the RSocket request type. */
+    REQUEST_TYPE {
+      @Override
+      public String asString() {
+        return "rsocket.request-type";
+      }
+    }
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketDocumentedObservation.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketDocumentedObservation.java
@@ -18,6 +18,7 @@ package io.rsocket.micrometer.observation;
 
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.docs.DocumentedObservation;
 
 enum RSocketDocumentedObservation implements DocumentedObservation {
@@ -25,7 +26,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket responder side. */
   RSOCKET_RESPONDER {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketResponderObservationConvention.class;
     }
@@ -34,7 +35,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket requester side for Fire and Forget frame type. */
   RSOCKET_REQUESTER_FNF {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketRequesterObservationConvention.class;
     }
@@ -53,7 +54,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket responder side for Fire and Forget frame type. */
   RSOCKET_RESPONDER_FNF {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketResponderObservationConvention.class;
     }
@@ -72,7 +73,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket requester side for Request Response frame type. */
   RSOCKET_REQUESTER_REQUEST_RESPONSE {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketRequesterObservationConvention.class;
     }
@@ -91,7 +92,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket responder side for Request Response frame type. */
   RSOCKET_RESPONDER_REQUEST_RESPONSE {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketResponderObservationConvention.class;
     }
@@ -110,7 +111,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket requester side for Request Stream frame type. */
   RSOCKET_REQUESTER_REQUEST_STREAM {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketRequesterObservationConvention.class;
     }
@@ -129,7 +130,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket responder side for Request Stream frame type. */
   RSOCKET_RESPONDER_REQUEST_STREAM {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketResponderObservationConvention.class;
     }
@@ -148,7 +149,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket requester side for Request Channel frame type. */
   RSOCKET_REQUESTER_REQUEST_CHANNEL {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketRequesterObservationConvention.class;
     }
@@ -167,7 +168,7 @@ enum RSocketDocumentedObservation implements DocumentedObservation {
   /** Observation created on the RSocket responder side for Request Channel frame type. */
   RSOCKET_RESPONDER_REQUEST_CHANNEL {
     @Override
-    public Class<? extends Observation.ObservationConvention<? extends Observation.Context>>
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
         getDefaultConvention() {
       return DefaultRSocketResponderObservationConvention.class;
     }

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketRequesterObservationConvention.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketRequesterObservationConvention.java
@@ -17,15 +17,16 @@
 package io.rsocket.micrometer.observation;
 
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
 
 /**
- * {@link Observation.ObservationConvention} for RSocket requester {@link RSocketContext}.
+ * {@link ObservationConvention} for RSocket requester {@link RSocketContext}.
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
  */
 public interface RSocketRequesterObservationConvention
-    extends Observation.ObservationConvention<RSocketContext> {
+    extends ObservationConvention<RSocketContext> {
 
   @Override
   default boolean supportsContext(Observation.Context context) {

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketRequesterObservationConvention.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketRequesterObservationConvention.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.observation.Observation;
+
+/**
+ * {@link Observation.ObservationConvention} for RSocket requester {@link RSocketContext}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 2.0.0
+ */
+public interface RSocketRequesterObservationConvention
+    extends Observation.ObservationConvention<RSocketContext> {
+
+  @Override
+  default boolean supportsContext(Observation.Context context) {
+    return context instanceof RSocketContext
+        && ((RSocketContext) context).side == RSocketContext.Side.REQUESTER;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketRequesterTracingObservationHandler.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketRequesterTracingObservationHandler.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.TracingObservationHandler;
+import io.micrometer.tracing.internal.EncodingUtils;
+import io.micrometer.tracing.propagation.Propagator;
+import io.netty.buffer.CompositeByteBuf;
+import io.rsocket.Payload;
+import io.rsocket.metadata.TracingMetadataCodec;
+import java.util.HashSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RSocketRequesterTracingObservationHandler
+    implements TracingObservationHandler<RSocketContext> {
+  private static final Logger log =
+      LoggerFactory.getLogger(RSocketRequesterTracingObservationHandler.class);
+
+  private final Propagator propagator;
+
+  private final Propagator.Setter<CompositeByteBuf> setter;
+
+  private final Tracer tracer;
+
+  private final boolean isZipkinPropagationEnabled;
+
+  public RSocketRequesterTracingObservationHandler(
+      Tracer tracer,
+      Propagator propagator,
+      Propagator.Setter<CompositeByteBuf> setter,
+      boolean isZipkinPropagationEnabled) {
+    this.tracer = tracer;
+    this.propagator = propagator;
+    this.setter = setter;
+    this.isZipkinPropagationEnabled = isZipkinPropagationEnabled;
+  }
+
+  @Override
+  public boolean supportsContext(Observation.Context context) {
+    return context instanceof RSocketContext
+        && ((RSocketContext) context).side == RSocketContext.Side.REQUESTER;
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return this.tracer;
+  }
+
+  @Override
+  public void onStart(RSocketContext context) {
+    Payload payload = context.payload;
+    Span.Builder spanBuilder = this.tracer.spanBuilder();
+    Span span = spanBuilder.kind(Span.Kind.PRODUCER).start();
+    log.debug("Extracted result from context or thread local {}", span);
+    // TODO: newmetadata returns an empty composite byte buf
+    final CompositeByteBuf newMetadata =
+        PayloadUtils.cleanTracingMetadata(payload, new HashSet<>(propagator.fields()));
+    TraceContext traceContext = span.context();
+    if (this.isZipkinPropagationEnabled) {
+      injectDefaultZipkinRSocketHeaders(newMetadata, traceContext);
+    }
+    this.propagator.inject(traceContext, newMetadata, this.setter);
+    context.modifiedPayload = PayloadUtils.payload(payload, newMetadata);
+    getTracingContext(context).setSpan(span);
+  }
+
+  @Override
+  public void onError(RSocketContext context) {
+    context.getError().ifPresent(throwable -> getRequiredSpan(context).error(throwable));
+  }
+
+  @Override
+  public void onStop(RSocketContext context) {
+    Span span = getRequiredSpan(context);
+    tagSpan(context, span);
+    span.name(context.getContextualName()).end();
+  }
+
+  private void injectDefaultZipkinRSocketHeaders(
+      CompositeByteBuf newMetadata, TraceContext traceContext) {
+    TracingMetadataCodec.Flags flags =
+        traceContext.sampled() == null
+            ? TracingMetadataCodec.Flags.UNDECIDED
+            : traceContext.sampled()
+                ? TracingMetadataCodec.Flags.SAMPLE
+                : TracingMetadataCodec.Flags.NOT_SAMPLE;
+    String traceId = traceContext.traceId();
+    long[] traceIds = EncodingUtils.fromString(traceId);
+    long[] spanId = EncodingUtils.fromString(traceContext.spanId());
+    long[] parentSpanId = EncodingUtils.fromString(traceContext.parentId());
+    boolean isTraceId128Bit = traceIds.length == 2;
+    if (isTraceId128Bit) {
+      TracingMetadataCodec.encode128(
+          newMetadata.alloc(),
+          traceIds[0],
+          traceIds[1],
+          spanId[0],
+          EncodingUtils.fromString(traceContext.parentId())[0],
+          flags);
+    } else {
+      TracingMetadataCodec.encode64(
+          newMetadata.alloc(), traceIds[0], spanId[0], parentSpanId[0], flags);
+    }
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketResponderObservationConvention.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketResponderObservationConvention.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.observation.Observation;
+
+/**
+ * {@link Observation.ObservationConvention} for RSocket responder {@link RSocketContext}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 2.0.0
+ */
+public interface RSocketResponderObservationConvention
+    extends Observation.ObservationConvention<RSocketContext> {
+
+  @Override
+  default boolean supportsContext(Observation.Context context) {
+    return context instanceof RSocketContext
+        && ((RSocketContext) context).side == RSocketContext.Side.RESPONDER;
+  }
+}

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketResponderObservationConvention.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketResponderObservationConvention.java
@@ -17,15 +17,16 @@
 package io.rsocket.micrometer.observation;
 
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
 
 /**
- * {@link Observation.ObservationConvention} for RSocket responder {@link RSocketContext}.
+ * {@link ObservationConvention} for RSocket responder {@link RSocketContext}.
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
  */
 public interface RSocketResponderObservationConvention
-    extends Observation.ObservationConvention<RSocketContext> {
+    extends ObservationConvention<RSocketContext> {
 
   @Override
   default boolean supportsContext(Observation.Context context) {

--- a/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketResponderTracingObservationHandler.java
+++ b/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/RSocketResponderTracingObservationHandler.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.micrometer.observation;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.TracingObservationHandler;
+import io.micrometer.tracing.internal.EncodingUtils;
+import io.micrometer.tracing.propagation.Propagator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.rsocket.Payload;
+import io.rsocket.frame.FrameType;
+import io.rsocket.metadata.RoutingMetadata;
+import io.rsocket.metadata.TracingMetadata;
+import io.rsocket.metadata.TracingMetadataCodec;
+import io.rsocket.metadata.WellKnownMimeType;
+import java.util.HashSet;
+import java.util.Iterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RSocketResponderTracingObservationHandler
+    implements TracingObservationHandler<RSocketContext> {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(RSocketResponderTracingObservationHandler.class);
+
+  private final Propagator propagator;
+
+  private final Propagator.Getter<ByteBuf> getter;
+
+  private final Tracer tracer;
+
+  private final boolean isZipkinPropagationEnabled;
+
+  public RSocketResponderTracingObservationHandler(
+      Tracer tracer,
+      Propagator propagator,
+      Propagator.Getter<ByteBuf> getter,
+      boolean isZipkinPropagationEnabled) {
+    this.tracer = tracer;
+    this.propagator = propagator;
+    this.getter = getter;
+    this.isZipkinPropagationEnabled = isZipkinPropagationEnabled;
+  }
+
+  @Override
+  public void onStart(RSocketContext context) {
+    Span handle = consumerSpanBuilder(context.payload, context.metadata, context.frameType);
+    CompositeByteBuf bufs =
+        PayloadUtils.cleanTracingMetadata(context.payload, new HashSet<>(propagator.fields()));
+    context.modifiedPayload = PayloadUtils.payload(context.payload, bufs);
+    getTracingContext(context).setSpan(handle);
+  }
+
+  @Override
+  public void onError(RSocketContext context) {
+    context.getError().ifPresent(throwable -> getRequiredSpan(context).error(throwable));
+  }
+
+  @Override
+  public void onStop(RSocketContext context) {
+    Span span = getRequiredSpan(context);
+    tagSpan(context, span);
+    span.end();
+  }
+
+  @Override
+  public boolean supportsContext(Observation.Context context) {
+    return context instanceof RSocketContext
+        && ((RSocketContext) context).side == RSocketContext.Side.RESPONDER;
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return this.tracer;
+  }
+
+  private Span consumerSpanBuilder(Payload payload, ByteBuf headers, FrameType requestType) {
+    Span.Builder consumerSpanBuilder = consumerSpanBuilder(payload, headers);
+    log.debug("Extracted result from headers {}", consumerSpanBuilder);
+    String name = "handle";
+    if (payload.hasMetadata()) {
+      try {
+        final ByteBuf extract =
+            CompositeMetadataUtils.extract(
+                headers, WellKnownMimeType.MESSAGE_RSOCKET_ROUTING.getString());
+        if (extract != null) {
+          final RoutingMetadata routingMetadata = new RoutingMetadata(extract);
+          final Iterator<String> iterator = routingMetadata.iterator();
+          name = requestType.name() + " " + iterator.next();
+        }
+      } catch (Exception e) {
+
+      }
+    }
+    return consumerSpanBuilder.kind(Span.Kind.CONSUMER).name(name).start();
+  }
+
+  private Span.Builder consumerSpanBuilder(Payload payload, ByteBuf headers) {
+    if (this.isZipkinPropagationEnabled && payload.hasMetadata()) {
+      try {
+        ByteBuf extract =
+            CompositeMetadataUtils.extract(
+                headers, WellKnownMimeType.MESSAGE_RSOCKET_TRACING_ZIPKIN.getString());
+        if (extract != null) {
+          TracingMetadata tracingMetadata = TracingMetadataCodec.decode(extract);
+          Span.Builder builder = this.tracer.spanBuilder();
+          String traceId = EncodingUtils.fromLong(tracingMetadata.traceId());
+          long traceIdHigh = tracingMetadata.traceIdHigh();
+          if (traceIdHigh != 0L) {
+            // ExtendedTraceId
+            traceId = EncodingUtils.fromLong(traceIdHigh) + traceId;
+          }
+          TraceContext.Builder parentBuilder =
+              this.tracer
+                  .traceContextBuilder()
+                  .sampled(tracingMetadata.isDebug() || tracingMetadata.isSampled())
+                  .traceId(traceId)
+                  .spanId(EncodingUtils.fromLong(tracingMetadata.spanId()))
+                  .parentId(EncodingUtils.fromLong(tracingMetadata.parentId()));
+          return builder.setParent(parentBuilder.build());
+        } else {
+          return this.propagator.extract(headers, this.getter);
+        }
+      } catch (Exception e) {
+
+      }
+    }
+    return this.propagator.extract(headers, this.getter);
+  }
+}


### PR DESCRIPTION
`rSocketPool.select()` in method `requestChannel` should be called on each subscription as it is done in other methods of the class.

### Motivation:

When server restarts while client is still connected, `LoadbalanceRSocketClient` is not able to reconnect when retrying `requestChannel` Flux. Retry fails with the error "Only a single Subscriber allowed".

### Modifications:

Wrap `rSocketPool.select()` in Mono.

### Result:

Retrying `requestChannel` Flux should trigger connection attempt.

### Target branch:

I cannot create a new base branch in rsocket-java as described in contribution guidelines. Creating the PR on master instead.
