### PR TITLE
ensures `onClose` awaits all underlying components to be closed

### DIFF
--- a/rsocket-core/src/jcstress/java/io/rsocket/resume/InMemoryResumableFramesStoreStressTest.java
+++ b/rsocket-core/src/jcstress/java/io/rsocket/resume/InMemoryResumableFramesStoreStressTest.java
@@ -1,0 +1,118 @@
+package io.rsocket.resume;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.rsocket.exceptions.ConnectionErrorException;
+import io.rsocket.frame.ErrorFrameCodec;
+import io.rsocket.frame.PayloadFrameCodec;
+import io.rsocket.internal.UnboundedProcessor;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.LL_Result;
+import reactor.core.Disposable;
+
+public class InMemoryResumableFramesStoreStressTest {
+  boolean storeClosed;
+
+  InMemoryResumableFramesStore store =
+      new InMemoryResumableFramesStore("test", Unpooled.EMPTY_BUFFER, 128);
+  boolean processorClosed;
+  UnboundedProcessor processor = new UnboundedProcessor(() -> processorClosed = true);
+
+  void subscribe() {
+    store.saveFrames(processor).subscribe();
+    store.onClose().subscribe(null, t -> storeClosed = true, () -> storeClosed = true);
+  }
+
+  @JCStressTest
+  @Outcome(
+      id = {"true, true"},
+      expect = ACCEPTABLE)
+  @State
+  public static class TwoSubscribesRaceStressTest extends InMemoryResumableFramesStoreStressTest {
+
+    Disposable d1;
+
+    final ByteBuf b1 =
+        PayloadFrameCodec.encode(
+            ByteBufAllocator.DEFAULT,
+            1,
+            false,
+            true,
+            false,
+            ByteBufUtil.writeUtf8(ByteBufAllocator.DEFAULT, "hello1"),
+            ByteBufUtil.writeUtf8(ByteBufAllocator.DEFAULT, "hello2"));
+    final ByteBuf b2 =
+        PayloadFrameCodec.encode(
+            ByteBufAllocator.DEFAULT,
+            3,
+            false,
+            true,
+            false,
+            ByteBufUtil.writeUtf8(ByteBufAllocator.DEFAULT, "hello3"),
+            ByteBufUtil.writeUtf8(ByteBufAllocator.DEFAULT, "hello4"));
+    final ByteBuf b3 =
+        PayloadFrameCodec.encode(
+            ByteBufAllocator.DEFAULT,
+            5,
+            false,
+            true,
+            false,
+            ByteBufUtil.writeUtf8(ByteBufAllocator.DEFAULT, "hello5"),
+            ByteBufUtil.writeUtf8(ByteBufAllocator.DEFAULT, "hello6"));
+
+    final ByteBuf c1 =
+        ErrorFrameCodec.encode(ByteBufAllocator.DEFAULT, 0, new ConnectionErrorException("closed"));
+
+    {
+      subscribe();
+      d1 = store.doOnDiscard(ByteBuf.class, ByteBuf::release).subscribe(ByteBuf::release, t -> {});
+    }
+
+    @Actor
+    public void producer1() {
+      processor.tryEmitNormal(b1);
+      processor.tryEmitNormal(b2);
+      processor.tryEmitNormal(b3);
+    }
+
+    @Actor
+    public void producer2() {
+      processor.tryEmitFinal(c1);
+    }
+
+    @Actor
+    public void producer3() {
+      d1.dispose();
+      store
+          .doOnDiscard(ByteBuf.class, ByteBuf::release)
+          .subscribe(ByteBuf::release, t -> {})
+          .dispose();
+      store
+          .doOnDiscard(ByteBuf.class, ByteBuf::release)
+          .subscribe(ByteBuf::release, t -> {})
+          .dispose();
+      store.doOnDiscard(ByteBuf.class, ByteBuf::release).subscribe(ByteBuf::release, t -> {});
+    }
+
+    @Actor
+    public void producer4() {
+      store.releaseFrames(0);
+      store.releaseFrames(0);
+      store.releaseFrames(0);
+    }
+
+    @Arbiter
+    public void arbiter(LL_Result r) {
+      r.r1 = storeClosed;
+      r.r2 = processorClosed;
+    }
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/core/ClientServerInputMultiplexer.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ClientServerInputMultiplexer.java
@@ -67,8 +67,8 @@ class ClientServerInputMultiplexer implements CoreSubscriber<ByteBuf>, Closeable
     this.source = source;
     this.isClient = isClient;
 
-    this.serverReceiver = new InternalDuplexConnection(this, source);
-    this.clientReceiver = new InternalDuplexConnection(this, source);
+    this.serverReceiver = new InternalDuplexConnection(Type.SERVER, this, source);
+    this.clientReceiver = new InternalDuplexConnection(Type.CLIENT, this, source);
     this.serverConnection = registry.initConnection(Type.SERVER, serverReceiver);
     this.clientConnection = registry.initConnection(Type.CLIENT, clientReceiver);
   }
@@ -195,8 +195,33 @@ class ClientServerInputMultiplexer implements CoreSubscriber<ByteBuf>, Closeable
     }
   }
 
+  @Override
+  public String toString() {
+    return "ClientServerInputMultiplexer{"
+        + "serverReceiver="
+        + serverReceiver
+        + ", clientReceiver="
+        + clientReceiver
+        + ", serverConnection="
+        + serverConnection
+        + ", clientConnection="
+        + clientConnection
+        + ", source="
+        + source
+        + ", isClient="
+        + isClient
+        + ", s="
+        + s
+        + ", t="
+        + t
+        + ", state="
+        + state
+        + '}';
+  }
+
   private static class InternalDuplexConnection extends Flux<ByteBuf>
       implements Subscription, DuplexConnection {
+    private final Type type;
     private final ClientServerInputMultiplexer clientServerInputMultiplexer;
     private final DuplexConnection source;
 
@@ -207,7 +232,10 @@ class ClientServerInputMultiplexer implements CoreSubscriber<ByteBuf>, Closeable
     CoreSubscriber<? super ByteBuf> actual;
 
     public InternalDuplexConnection(
-        ClientServerInputMultiplexer clientServerInputMultiplexer, DuplexConnection source) {
+        Type type,
+        ClientServerInputMultiplexer clientServerInputMultiplexer,
+        DuplexConnection source) {
+      this.type = type;
       this.clientServerInputMultiplexer = clientServerInputMultiplexer;
       this.source = source;
     }
@@ -303,6 +331,18 @@ class ClientServerInputMultiplexer implements CoreSubscriber<ByteBuf>, Closeable
     @Override
     public double availability() {
       return source.availability();
+    }
+
+    @Override
+    public String toString() {
+      return "InternalDuplexConnection{"
+          + "type="
+          + type
+          + ", source="
+          + source
+          + ", state="
+          + state
+          + '}';
     }
   }
 }

--- a/rsocket-core/src/main/java/io/rsocket/core/ServerSetup.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/ServerSetup.java
@@ -79,7 +79,7 @@ abstract class ServerSetup {
         sendError(duplexConnection, new UnsupportedSetupException("resume not supported"));
         return duplexConnection.onClose();
       } else {
-        return then.apply(new DefaultKeepAliveHandler(duplexConnection), duplexConnection);
+        return then.apply(new DefaultKeepAliveHandler(), duplexConnection);
       }
     }
 
@@ -141,7 +141,7 @@ abstract class ServerSetup {
                 resumableDuplexConnection, serverRSocketSession, serverRSocketSession),
             resumableDuplexConnection);
       } else {
-        return then.apply(new DefaultKeepAliveHandler(duplexConnection), duplexConnection);
+        return then.apply(new DefaultKeepAliveHandler(), duplexConnection);
       }
     }
 

--- a/rsocket-core/src/main/java/io/rsocket/core/SetupHandlingDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/core/SetupHandlingDuplexConnection.java
@@ -168,4 +168,9 @@ class SetupHandlingDuplexConnection extends Flux<ByteBuf>
   public ByteBufAllocator alloc() {
     return source.alloc();
   }
+
+  @Override
+  public String toString() {
+    return "SetupHandlingDuplexConnection{" + "source=" + source + ", done=" + done + '}';
+  }
 }

--- a/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java
@@ -619,13 +619,8 @@ public final class UnboundedProcessor extends Flux<ByteBuf>
 
     t = this.last;
     if (t != null) {
-      try {
-        this.last = null;
-        return t;
-      } finally {
-
-        clearAndFinalize(this);
-      }
+      this.last = null;
+      return t;
     }
 
     return null;

--- a/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAliveHandler.java
+++ b/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAliveHandler.java
@@ -1,7 +1,6 @@
 package io.rsocket.keepalive;
 
 import io.netty.buffer.ByteBuf;
-import io.rsocket.Closeable;
 import io.rsocket.keepalive.KeepAliveSupport.KeepAlive;
 import io.rsocket.resume.RSocketSession;
 import io.rsocket.resume.ResumableDuplexConnection;
@@ -16,18 +15,11 @@ public interface KeepAliveHandler {
       Consumer<KeepAlive> onTimeout);
 
   class DefaultKeepAliveHandler implements KeepAliveHandler {
-    private final Closeable duplexConnection;
-
-    public DefaultKeepAliveHandler(Closeable duplexConnection) {
-      this.duplexConnection = duplexConnection;
-    }
-
     @Override
     public KeepAliveFramesAcceptor start(
         KeepAliveSupport keepAliveSupport,
         Consumer<ByteBuf> onSendKeepAliveFrame,
         Consumer<KeepAlive> onTimeout) {
-      duplexConnection.onClose().doFinally(s -> keepAliveSupport.stop()).subscribe();
       return keepAliveSupport
           .onSendKeepAliveFrame(onSendKeepAliveFrame)
           .onTimeout(onTimeout)

--- a/rsocket-core/src/main/java/io/rsocket/resume/ClientRSocketSession.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ClientRSocketSession.java
@@ -110,17 +110,9 @@ public class ClientRSocketSession
                         position);
                   }
 
-                  return connectionTransformer
-                      .apply(dc)
-                      .doOnDiscard(
-                          Tuple2.class,
-                          tuple2 -> {
-                            if (logger.isDebugEnabled()) {
-                              logger.debug("try to reestablish from discard");
-                            }
-                            tryReestablishSession(tuple2);
-                          });
-                });
+                  return connectionTransformer.apply(dc);
+                })
+            .doOnDiscard(Tuple2.class, this::tryReestablishSession);
     this.resumableFramesStore = resumableFramesStore;
     this.allocator = resumableDuplexConnection.alloc();
     this.resumeSessionDuration = resumeSessionDuration;

--- a/rsocket-core/src/main/java/io/rsocket/resume/ResumableDuplexConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/resume/ResumableDuplexConnection.java
@@ -322,6 +322,26 @@ public class ResumableDuplexConnection extends Flux<ByteBuf>
     return FrameHeaderCodec.streamId(frame) != 0;
   }
 
+  @Override
+  public String toString() {
+    return "ResumableDuplexConnection{"
+        + "side='"
+        + side
+        + '\''
+        + ", session='"
+        + session
+        + '\''
+        + ", remoteAddress="
+        + remoteAddress
+        + ", state="
+        + state
+        + ", activeConnection="
+        + activeConnection
+        + ", connectionIndex="
+        + connectionIndex
+        + '}';
+  }
+
   private static final class DisposedConnection implements DuplexConnection {
 
     static final DisposedConnection INSTANCE = new DisposedConnection();

--- a/rsocket-core/src/test/java/io/rsocket/core/DefaultRSocketClientTests.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/DefaultRSocketClientTests.java
@@ -643,6 +643,8 @@ public class DefaultRSocketClientTests {
     protected Runnable delayer;
     protected Sinks.One<RSocket> producer;
 
+    protected Sinks.Empty<Void> thisClosedSink;
+
     @Override
     protected void doInit() {
       super.doInit();
@@ -660,6 +662,7 @@ public class DefaultRSocketClientTests {
 
     @Override
     protected RSocket newRSocket() {
+      this.thisClosedSink = Sinks.empty();
       return new RSocketRequester(
           connection,
           PayloadDecoder.ZERO_COPY,
@@ -671,7 +674,9 @@ public class DefaultRSocketClientTests {
           Integer.MAX_VALUE,
           null,
           __ -> null,
-          null);
+          null,
+          thisClosedSink,
+          thisClosedSink.asMono());
     }
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketRequesterTest.java
@@ -1453,8 +1453,14 @@ public class RSocketRequesterTest {
   }
 
   public static class ClientSocketRule extends AbstractSocketRule<RSocketRequester> {
+
+    protected Sinks.Empty<Void> thisClosedSink;
+    protected Sinks.Empty<Void> otherClosedSink;
+
     @Override
     protected RSocketRequester newRSocket() {
+      this.thisClosedSink = Sinks.empty();
+      this.otherClosedSink = Sinks.empty();
       return new RSocketRequester(
           connection,
           PayloadDecoder.ZERO_COPY,
@@ -1466,7 +1472,9 @@ public class RSocketRequesterTest {
           Integer.MAX_VALUE,
           null,
           (__) -> null,
-          null);
+          null,
+          thisClosedSink,
+          otherClosedSink.asMono().and(thisClosedSink.asMono()));
     }
 
     public int getStreamIdForRequestType(FrameType expectedFrameType) {

--- a/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/RSocketResponderTest.java
@@ -1184,6 +1184,7 @@ public class RSocketResponderTest {
     private RSocket acceptingSocket;
     private volatile int prefetch;
     private RequestInterceptor requestInterceptor;
+    protected Sinks.Empty<Void> onCloseSink;
 
     @Override
     protected void doInit() {
@@ -1220,6 +1221,7 @@ public class RSocketResponderTest {
 
     @Override
     protected RSocketResponder newRSocket() {
+      onCloseSink = Sinks.empty();
       return new RSocketResponder(
           connection,
           acceptingSocket,
@@ -1228,7 +1230,8 @@ public class RSocketResponderTest {
           0,
           maxFrameLength,
           maxInboundPayloadSize,
-          __ -> requestInterceptor);
+          __ -> requestInterceptor,
+          onCloseSink);
     }
 
     private void sendRequest(int streamId, FrameType frameType) {

--- a/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/core/SetupRejectionTest.java
@@ -69,6 +69,8 @@ public class SetupRejectionTest {
     LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
     TestDuplexConnection conn = new TestDuplexConnection(allocator);
+    Sinks.Empty<Void> onThisSideClosedSink = Sinks.empty();
+
     RSocketRequester rSocket =
         new RSocketRequester(
             conn,
@@ -81,7 +83,9 @@ public class SetupRejectionTest {
             0,
             null,
             __ -> null,
-            null);
+            null,
+            onThisSideClosedSink,
+            onThisSideClosedSink.asMono());
 
     String errorMsg = "error";
 
@@ -107,6 +111,7 @@ public class SetupRejectionTest {
     LeaksTrackingByteBufAllocator allocator =
         LeaksTrackingByteBufAllocator.instrument(ByteBufAllocator.DEFAULT);
     TestDuplexConnection conn = new TestDuplexConnection(allocator);
+    Sinks.Empty<Void> onThisSideClosedSink = Sinks.empty();
     RSocketRequester rSocket =
         new RSocketRequester(
             conn,
@@ -119,7 +124,9 @@ public class SetupRejectionTest {
             0,
             null,
             __ -> null,
-            null);
+            null,
+            onThisSideClosedSink,
+            onThisSideClosedSink.asMono());
 
     conn.addToReceivedBuffer(
         ErrorFrameCodec.encode(ByteBufAllocator.DEFAULT, 0, new RejectedSetupException("error")));

--- a/rsocket-examples/build.gradle
+++ b/rsocket-examples/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     implementation "io.micrometer:micrometer-core"
     implementation "io.micrometer:micrometer-tracing"
     implementation project(":rsocket-micrometer")
-    testImplementation 'org.awaitility:awaitility'
 
     runtimeOnly 'ch.qos.logback:logback-classic'
 
@@ -37,6 +36,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.awaitility:awaitility'
     testImplementation "io.micrometer:micrometer-test"
     testImplementation "io.micrometer:micrometer-tracing-integration-test"
 

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalClientTransport.java
@@ -79,10 +79,10 @@ public final class LocalClientTransport implements ClientTransport {
 
           Sinks.One<Object> inSink = Sinks.one();
           Sinks.One<Object> outSink = Sinks.one();
-          UnboundedProcessor in = new UnboundedProcessor(() -> inSink.tryEmitValue(inSink));
-          UnboundedProcessor out = new UnboundedProcessor(() -> outSink.tryEmitValue(outSink));
+          UnboundedProcessor in = new UnboundedProcessor(inSink::tryEmitEmpty);
+          UnboundedProcessor out = new UnboundedProcessor(outSink::tryEmitEmpty);
 
-          Mono<Void> onClose = inSink.asMono().zipWith(outSink.asMono()).then();
+          Mono<Void> onClose = inSink.asMono().and(outSink.asMono());
 
           server.apply(new LocalDuplexConnection(name, allocator, out, in, onClose)).subscribe();
 

--- a/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
+++ b/rsocket-transport-local/src/main/java/io/rsocket/transport/local/LocalDuplexConnection.java
@@ -36,7 +36,7 @@ final class LocalDuplexConnection implements DuplexConnection {
 
   private final LocalSocketAddress address;
   private final ByteBufAllocator allocator;
-  private final Flux<ByteBuf> in;
+  private final UnboundedProcessor in;
 
   private final Mono<Void> onClose;
 
@@ -54,7 +54,7 @@ final class LocalDuplexConnection implements DuplexConnection {
   LocalDuplexConnection(
       String name,
       ByteBufAllocator allocator,
-      Flux<ByteBuf> in,
+      UnboundedProcessor in,
       UnboundedProcessor out,
       Mono<Void> onClose) {
     this.address = new LocalSocketAddress(name);
@@ -109,6 +109,11 @@ final class LocalDuplexConnection implements DuplexConnection {
   @Override
   public SocketAddress remoteAddress() {
     return address;
+  }
+
+  @Override
+  public String toString() {
+    return "LocalDuplexConnection{" + "address=" + address + "hash=" + hashCode() + '}';
   }
 
   static class ByteBufReleaserOperator

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/TcpDuplexConnection.java
@@ -31,7 +31,7 @@ import reactor.netty.Connection;
 
 /** An implementation of {@link DuplexConnection} that connects via TCP. */
 public final class TcpDuplexConnection extends BaseDuplexConnection {
-
+  private final String side;
   private final Connection connection;
 
   /**
@@ -40,14 +40,19 @@ public final class TcpDuplexConnection extends BaseDuplexConnection {
    * @param connection the {@link Connection} for managing the server
    */
   public TcpDuplexConnection(Connection connection) {
-    this.connection = Objects.requireNonNull(connection, "connection must not be null");
+    this("unknown", connection);
+  }
 
-    connection
-        .outbound()
-        .send(sender.hide())
-        .then()
-        .doFinally(__ -> connection.dispose())
-        .subscribe();
+  /**
+   * Creates a new instance
+   *
+   * @param connection the {@link Connection} for managing the server
+   */
+  public TcpDuplexConnection(String side, Connection connection) {
+    this.connection = Objects.requireNonNull(connection, "connection must not be null");
+    this.side = side;
+
+    connection.outbound().send(sender).then().doFinally(__ -> connection.dispose()).subscribe();
   }
 
   @Override
@@ -84,5 +89,10 @@ public final class TcpDuplexConnection extends BaseDuplexConnection {
   @Override
   public void sendFrame(int streamId, ByteBuf frame) {
     super.sendFrame(streamId, FrameLengthCodec.encode(alloc(), frame.readableBytes(), frame));
+  }
+
+  @Override
+  public String toString() {
+    return "TcpDuplexConnection{" + "side='" + side + '\'' + ", connection=" + connection + '}';
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/WebsocketDuplexConnection.java
@@ -36,7 +36,7 @@ import reactor.netty.Connection;
  * stitched back on for frames received.
  */
 public final class WebsocketDuplexConnection extends BaseDuplexConnection {
-
+  private final String side;
   private final Connection connection;
 
   /**
@@ -45,11 +45,21 @@ public final class WebsocketDuplexConnection extends BaseDuplexConnection {
    * @param connection the {@link Connection} to for managing the server
    */
   public WebsocketDuplexConnection(Connection connection) {
+    this("unknown", connection);
+  }
+
+  /**
+   * Creates a new instance
+   *
+   * @param connection the {@link Connection} to for managing the server
+   */
+  public WebsocketDuplexConnection(String side, Connection connection) {
     this.connection = Objects.requireNonNull(connection, "connection must not be null");
+    this.side = side;
 
     connection
         .outbound()
-        .sendObject(sender.map(BinaryWebSocketFrame::new).hide())
+        .sendObject(sender.map(BinaryWebSocketFrame::new))
         .then()
         .doFinally(__ -> connection.dispose())
         .subscribe();
@@ -84,5 +94,16 @@ public final class WebsocketDuplexConnection extends BaseDuplexConnection {
   public void sendErrorAndClose(RSocketErrorException e) {
     final ByteBuf errorFrame = ErrorFrameCodec.encode(alloc(), 0, e);
     sender.tryEmitFinal(errorFrame);
+  }
+
+  @Override
+  public String toString() {
+    return "WebsocketDuplexConnection{"
+        + "side='"
+        + side
+        + '\''
+        + ", connection="
+        + connection
+        + '}';
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/TcpClientTransport.java
@@ -116,6 +116,6 @@ public final class TcpClientTransport implements ClientTransport {
     return client
         .doOnConnected(c -> c.addHandlerLast(new RSocketLengthCodec(maxFrameLength)))
         .connect()
-        .map(TcpDuplexConnection::new);
+        .map(connection -> new TcpDuplexConnection("client", connection));
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/client/WebsocketClientTransport.java
@@ -172,6 +172,6 @@ public final class WebsocketClientTransport implements ClientTransport {
         .websocket(specBuilder.build())
         .uri(path)
         .connect()
-        .map(WebsocketDuplexConnection::new);
+        .map(connection -> new WebsocketDuplexConnection("client", connection));
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/TcpServerTransport.java
@@ -114,7 +114,7 @@ public final class TcpServerTransport implements ServerTransport<CloseableChanne
             c -> {
               c.addHandlerLast(new RSocketLengthCodec(maxFrameLength));
               acceptor
-                  .apply(new TcpDuplexConnection(c))
+                  .apply(new TcpDuplexConnection("server", c))
                   .then(Mono.<Void>never())
                   .subscribe(c.disposeSubscriber());
             })

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketRouteTransport.java
@@ -80,6 +80,8 @@ public final class WebsocketRouteTransport
   public static BiFunction<WebsocketInbound, WebsocketOutbound, Publisher<Void>> newHandler(
       ConnectionAcceptor acceptor) {
     return (in, out) ->
-        acceptor.apply(new WebsocketDuplexConnection((Connection) in)).then(out.neverComplete());
+        acceptor
+            .apply(new WebsocketDuplexConnection("server", (Connection) in))
+            .then(out.neverComplete());
   }
 }

--- a/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/transport/netty/server/WebsocketServerTransport.java
@@ -117,7 +117,7 @@ public final class WebsocketServerTransport
               return response.sendWebsocket(
                   (in, out) ->
                       acceptor
-                          .apply(new WebsocketDuplexConnection((Connection) in))
+                          .apply(new WebsocketDuplexConnection("server", (Connection) in))
                           .then(out.neverComplete()),
                   specBuilder.build());
             })


### PR DESCRIPTION
this PR ensures that `RSocket#onClose` waits until all the underlying components are closed