### PR TITLE
support netty boringssl aarch_64 classifier

### DIFF
--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 def os_suffix = ""
-if (osdetector.classifier in ["linux-x86_64", "osx-x86_64", "windows-x86_64"]) {
+if (osdetector.classifier in ["linux-x86_64", "linux-aarch_64", "osx-x86_64", "osx-aarch_64", "windows-x86_64"]) {
     os_suffix = "::" + osdetector.classifier
 }
 


### PR DESCRIPTION
support netty boringssl aarch_64

### Motivation:

Netty boringssl is available on arm64 (aarch_64)

Let's use the proper classifier.

### Modifications:

update build.gradle

### Result:

Correct artifact is observed on MacOS arm64 laptop.

