### PR TITLE
Log data in KEEPALIVE frame

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/frame/FrameUtil.java
+++ b/rsocket-core/src/main/java/io/rsocket/frame/FrameUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.rsocket.frame;
 
 import io.netty.buffer.ByteBuf;
@@ -99,8 +114,9 @@ public class FrameUtil {
       case REQUEST_CHANNEL:
         data = RequestChannelFrameCodec.data(frame);
         break;
-        // Payload and synthetic types
+        // Payload, KeepAlive and synthetic types
       case PAYLOAD:
+      case KEEPALIVE:
       case NEXT:
       case NEXT_COMPLETE:
       case COMPLETE:


### PR DESCRIPTION
Ensure `FrameUtil` logs the data of KEEPALIVE frames if present.